### PR TITLE
feat: Add CSS badge to Languages category in badges.json

### DIFF
--- a/src/data/badges.json
+++ b/src/data/badges.json
@@ -2723,6 +2723,13 @@
     "category": "Languages"
   },
   {
+    "id": "css",
+    "name": "CSS",
+    "url": "https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white",
+    "markdown": "![CSS3](https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white)",
+    "category": "Languages"
+  },
+  {
     "id": "css3",
     "name": "CSS3",
     "url": "https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white",


### PR DESCRIPTION
This pull request adds a new badge for CSS to the `badges.json` file, enhancing the available options for representing programming languages.

* **Enhancements to badge options:**
  - Added a new entry for the CSS badge, including its `id`, `name`, `url`, `markdown`, and `category` fields.