### PR TITLE
feat: refactor layout to sidebar-based app shell with active category navigation  

### DIFF
--- a/components.json
+++ b/components.json
@@ -19,5 +19,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "registries": {}
+  "registries": {
+    "@svgl": "https://svgl.app/r/{name}.json"
+  }
 }

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,0 +1,29 @@
+import { GithubIcon } from "lucide-react";
+
+import { AppLogo } from "./app-logo";
+import { Button } from "./ui/button";
+import { SidebarTrigger } from "./ui/sidebar";
+
+export function AppHeader() {
+  return (
+    <header className="flex justify-between items-center h-12 py-2 px-6 border-b sticky top-0 w-full z-1000 bg-background">
+      <div className="md:hidden flex items-center gap-2">
+        <SidebarTrigger />
+        <AppLogo />
+      </div>
+
+      <div className="flex items-center gap-2 ml-auto">
+        <Button asChild variant="outline" size="sm">
+          <a
+            href="https://github.com/GFrancV/markdown-badges"
+            target="_blank"
+            rel="noopener"
+          >
+            <GithubIcon className="w-6 " />
+            View Repo
+          </a>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/app-logo.tsx
+++ b/src/components/app-logo.tsx
@@ -1,0 +1,14 @@
+import { MarkdownDark } from "@/components/ui/svgs/markdownDark";
+import { Typography } from "@/components/ui/typography";
+import { cn } from "@/lib/utils";
+
+export function AppLogo({ className }: { className?: string }) {
+  return (
+    <div className={cn(className, "flex gap-2 items-center")}>
+      <MarkdownDark className="size-9! stroke-2" />
+      <Typography as="span" size="h4">
+        Markdown Badges
+      </Typography>
+    </div>
+  );
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+import { AppHeader } from "@/components/app-header";
+import { AppSidebar } from "@/components/app-sidebar";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+
+export function AppShell({
+  children,
+  pathname,
+  category,
+  defaultSidebarOpen,
+}: {
+  children: ReactNode;
+  pathname?: string;
+  category?: string;
+  defaultSidebarOpen?: boolean;
+}) {
+  return (
+    <SidebarProvider pathname={pathname} category={category} defaultOpen={defaultSidebarOpen}>
+      <AppSidebar />
+      <SidebarInset>
+        <AppHeader />
+        <div className="p-6">{children}</div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,4 +1,10 @@
-import { BoxIcon, HeartIcon, HomeIcon, InfoIcon } from "lucide-react";
+import {
+  BoxIcon,
+  CloudIcon,
+  HeartIcon,
+  HomeIcon,
+  InfoIcon,
+} from "lucide-react";
 import { type ComponentProps, useEffect, useRef, useState } from "react";
 
 import {
@@ -37,6 +43,11 @@ const nav = {
       url: "/generator",
       icon: BoxIcon,
     },
+    {
+      name: "API",
+      url: "/docs/api",
+      icon: CloudIcon,
+    },
   ],
   navFooter: [
     {
@@ -57,11 +68,15 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
 
   // Initialized from the server-validated SSR prop — no hydration mismatch.
   // Category is always valid here because Layout.astro filters invalid values before passing them down.
-  const [activeCategory, setActiveCategory] = useState<string | undefined>(ssrCategory);
+  const [activeCategory, setActiveCategory] = useState<string | undefined>(
+    ssrCategory,
+  );
 
   useEffect(() => {
     const syncCategoryFromUrl = () => {
-      const cat = new URLSearchParams(window.location.search).get("category") || undefined;
+      const cat =
+        new URLSearchParams(window.location.search).get("category") ||
+        undefined;
       setActiveCategory(cat);
     };
 
@@ -76,11 +91,15 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
     };
   }, []);
 
-  const isValidCategory = !!activeCategory && categories.includes(activeCategory);
+  const isValidCategory =
+    !!activeCategory && categories.includes(activeCategory);
 
   useEffect(() => {
     if (isValidCategory && activeCategoryRef.current) {
-      activeCategoryRef.current.scrollIntoView({ block: "nearest", behavior: "instant" });
+      activeCategoryRef.current.scrollIntoView({
+        block: "nearest",
+        behavior: "instant",
+      });
     }
   }, [activeCategory, isValidCategory]);
 
@@ -128,12 +147,17 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
                     key={cat}
                     ref={cat === activeCategory ? activeCategoryRef : undefined}
                   >
-                    <SidebarMenuButton asChild isActive={cat === activeCategory}>
+                    <SidebarMenuButton
+                      asChild
+                      isActive={cat === activeCategory}
+                    >
                       <a href={`/?category=${cat}`}>
                         <Typography as="span">{cat}</Typography>
                       </a>
                     </SidebarMenuButton>
-                    <SidebarMenuBadge>{badgeCountByCategory[cat]}</SidebarMenuBadge>
+                    <SidebarMenuBadge>
+                      {badgeCountByCategory[cat]}
+                    </SidebarMenuBadge>
                   </SidebarMenuItem>
                 ))}
               </SidebarMenu>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,0 +1,160 @@
+import { BoxIcon, HeartIcon, HomeIcon, InfoIcon } from "lucide-react";
+import { type ComponentProps, useEffect, useRef, useState } from "react";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import { Typography } from "@/components/ui/typography";
+import { getBadgeCategories, getBadgeCountByCategory } from "@/services/badges";
+import { AppLogo } from "./app-logo";
+import { ScrollArea } from "./ui/scroll-area";
+
+const nav = {
+  navMain: [
+    {
+      name: "Home",
+      url: "/",
+      icon: HomeIcon,
+    },
+    {
+      name: "Favorites",
+      url: "/favorites",
+      icon: HeartIcon,
+    },
+    {
+      name: "Generator",
+      url: "/generator",
+      icon: BoxIcon,
+    },
+  ],
+  navFooter: [
+    {
+      name: "About",
+      url: "/about",
+      icon: InfoIcon,
+    },
+  ],
+} as const;
+
+// Module-level constants: computed once at import time (server + client), never on re-render
+const categories = getBadgeCategories();
+const badgeCountByCategory = getBadgeCountByCategory();
+
+export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
+  const { pathname, category: ssrCategory } = useSidebar();
+  const activeCategoryRef = useRef<HTMLLIElement>(null);
+
+  // Initialized from the server-validated SSR prop — no hydration mismatch.
+  // Category is always valid here because Layout.astro filters invalid values before passing them down.
+  const [activeCategory, setActiveCategory] = useState<string | undefined>(ssrCategory);
+
+  useEffect(() => {
+    const syncCategoryFromUrl = () => {
+      const cat = new URLSearchParams(window.location.search).get("category") || undefined;
+      setActiveCategory(cat);
+    };
+
+    // popstate: browser back/forward navigation
+    window.addEventListener("popstate", syncCategoryFromUrl);
+    // locationchange: dispatched by search.tsx after every replaceState call
+    window.addEventListener("locationchange", syncCategoryFromUrl);
+
+    return () => {
+      window.removeEventListener("popstate", syncCategoryFromUrl);
+      window.removeEventListener("locationchange", syncCategoryFromUrl);
+    };
+  }, []);
+
+  const isValidCategory = !!activeCategory && categories.includes(activeCategory);
+
+  useEffect(() => {
+    if (isValidCategory && activeCategoryRef.current) {
+      activeCategoryRef.current.scrollIntoView({ block: "nearest", behavior: "instant" });
+    }
+  }, [activeCategory, isValidCategory]);
+
+  return (
+    <Sidebar {...props}>
+      <SidebarHeader className="border-b">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild>
+              <a href="/">
+                <AppLogo />
+              </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {nav.navMain.map((item) => (
+                <SidebarMenuItem key={item.name}>
+                  <SidebarMenuButton
+                    asChild
+                    isActive={!isValidCategory && pathname === item.url}
+                  >
+                    <a href={item.url}>
+                      <item.icon />
+                      <Typography as="span">{item.name}</Typography>
+                    </a>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+        <SidebarGroup className="flex flex-col flex-1 min-h-0">
+          <SidebarGroupLabel>Categories</SidebarGroupLabel>
+          <SidebarGroupContent className="flex-1 min-h-0">
+            <ScrollArea className="h-full">
+              <SidebarMenu>
+                {categories.map((cat) => (
+                  <SidebarMenuItem
+                    key={cat}
+                    ref={cat === activeCategory ? activeCategoryRef : undefined}
+                  >
+                    <SidebarMenuButton asChild isActive={cat === activeCategory}>
+                      <a href={`/?category=${cat}`}>
+                        <Typography as="span">{cat}</Typography>
+                      </a>
+                    </SidebarMenuButton>
+                    <SidebarMenuBadge>{badgeCountByCategory[cat]}</SidebarMenuBadge>
+                  </SidebarMenuItem>
+                ))}
+              </SidebarMenu>
+            </ScrollArea>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter>
+        <SidebarMenu>
+          {nav.navFooter.map((item) => (
+            <SidebarMenuItem key={item.name}>
+              <SidebarMenuButton asChild>
+                <a href={item.url}>
+                  <item.icon />
+                  <span>{item.name}</span>
+                </a>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}

--- a/src/components/badges/badge-card.tsx
+++ b/src/components/badges/badge-card.tsx
@@ -25,28 +25,33 @@ export const BadgeCard = memo(function BadgeCard({ badge }: { badge: Badge }) {
           open(badge);
         }
       }}
-      className="relative group bg-[#1e1e1e] cursor-pointer text-white rounded-sm border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary badget-element h-full"
+      className="relative group bg-card cursor-pointer rounded-sm border border-transparent transition px-4  py-6  text-center flex flex-col hover:bg-primary/10 hover:border-primary/80 focus:outline-none focus:ring-2 focus:ring-primary/80 focus:ring-offset-2 focus:ring-offset-card data-[state=open]:bg-primary/10"
     >
-      <Typography as="h3" size="h4" className="mt-1 mb-3">
-        {name}
-      </Typography>
       <img
         src={url}
         alt={`${name} badge`}
-        width="100"
-        height="28"
-        className="mt-auto h-7 w-auto mx-auto mb-4"
+        width="80"
+        height="20"
+        className="h-5 w-auto mx-auto mb-4"
         loading="lazy"
       />
-      <div className="mt-2">
-        <Button
-          variant="outline"
-          className="rounded-full group-hover:border-primary group-hover:text-primary"
-        >
+
+      <Typography as="p" className="mb-2">
+        {name}
+      </Typography>
+
+      <Button
+        asChild
+        variant="outline"
+        size="sm"
+        className="text-muted-foreground"
+      >
+        <a href={`/?category=${category}`} onClick={(e) => e.stopPropagation()}>
           {category}
-        </Button>
-      </div>
-      <div className="absolute top-1 right-1 transition duration-300 flex flex-col items-center gap-1">
+        </a>
+      </Button>
+
+      <div className="absolute top-0.5 right-0.5 transition duration-300 flex flex-col items-center gap-0.5">
         <CopyClipboardButton content={`![${name}](${url})`} />
         <BadgeFavoriteButton
           badge={badge}

--- a/src/components/badges/badge-favorites.tsx
+++ b/src/components/badges/badge-favorites.tsx
@@ -1,8 +1,21 @@
-import { ClipboardIcon, FolderHeartIcon, SearchIcon } from "lucide-react";
+import {
+  ClipboardIcon,
+  FolderHeartIcon,
+  SearchIcon,
+  TrashIcon,
+} from "lucide-react";
 
 import { BadgeCard } from "@/components/badges/badge-card";
 import { ClientProviders } from "@/components/client-providers";
 import { Button } from "@/components/ui/button";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
 import { Typography } from "@/components/ui/typography";
 import { useFavorites } from "@/context/favorites-context";
 
@@ -15,27 +28,29 @@ export function BadgeFavorites() {
 }
 
 function BadgeFavoritesContent() {
-  const { favorites, copyAll } = useFavorites();
+  const { favorites, copyAll, clearAll } = useFavorites();
 
   return favorites.length === 0 ? (
-    <div className="flex w-full max-w-sm flex-col items-center justify-center gap-2.5 text-center m-auto">
-      <div className="rounded-lg bg-muted text-foreground p-4">
-        <FolderHeartIcon width={32} height={32} className="size-8" />
-      </div>
-      <Typography as="h2" size="h3">
-        No Favorites Yet
-      </Typography>
-      <Typography variant="muted">
-        Start adding badges to your favorites by clicking the heart icon on any
-        badge.
-      </Typography>
-      <Button asChild>
-        <a href="/">
-          <SearchIcon className="size-4" />
-          Browse Badges
-        </a>
-      </Button>
-    </div>
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <FolderHeartIcon />
+        </EmptyMedia>
+        <EmptyTitle>No Favorites Yet</EmptyTitle>
+        <EmptyDescription>
+          Start adding badges to your favorites by clicking the heart icon on
+          any badge.
+        </EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent className="flex-row justify-center gap-2">
+        <Button asChild>
+          <a href="/">
+            <SearchIcon className="size-4" />
+            Browse Badges
+          </a>
+        </Button>
+      </EmptyContent>
+    </Empty>
   ) : (
     <>
       <header className="flex justify-between items-center mb-8">
@@ -50,13 +65,19 @@ function BadgeFavoritesContent() {
             </Typography>
           </div>
         </div>
-        <Button variant="outline" onClick={copyAll}>
-          <ClipboardIcon />
-          Copy All
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button onClick={copyAll}>
+            <ClipboardIcon />
+            Copy All
+          </Button>
+          <Button variant="secondary" onClick={clearAll}>
+            <TrashIcon />
+            Clear All
+          </Button>
+        </div>
       </header>
       <section>
-        <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
+        <div className="grid lg:grid-cols-5 md:grid-cols-3 grid-cols-2 gap-4">
           {favorites.map((badge) => (
             <BadgeCard key={badge.id} badge={badge} />
           ))}

--- a/src/components/badges/badges-list.tsx
+++ b/src/components/badges/badges-list.tsx
@@ -4,7 +4,7 @@ import { ClientProviders } from "@/components/client-providers";
 export function BadgesList({ badges }: { badges: Badge[] }) {
   return (
     <ClientProviders>
-      <div className="grid md:grid-cols-4 grid-cols-2 gap-4">
+      <div className="grid xl:grid-cols-6 lg:grid-cols-5 md:grid-cols-3 grid-cols-2 gap-4">
         {badges.map((badge) => (
           <BadgeCard key={badge.id} badge={badge} />
         ))}

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -2,6 +2,7 @@ import {
   ChevronDownIcon,
   ChevronsDownIcon,
   CommandIcon,
+  ExternalLinkIcon,
   SearchIcon,
   ShieldOffIcon,
   XIcon,
@@ -22,13 +23,20 @@ import {
   ComboboxValue,
 } from "@/components/ui/combobox";
 import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
 import { Kbd } from "@/components/ui/kbd";
-import { Typography } from "@/components/ui/typography";
 import { filterBadges, getBadgeCategories, getBadges } from "@/services/badges";
 
 type SearchProps = {
@@ -49,7 +57,7 @@ export function Search({
   const [categoryQuery, setCategoryQuery] = useState<string | null>(
     initialCategory,
   );
-  const [resultsAmount, setResultsAmount] = useState(20);
+  const [resultsAmount, setResultsAmount] = useState(30);
   const [isReady, setIsReady] = useState(false);
 
   const [debouncedQuery] = useDebounce(query, 450);
@@ -78,10 +86,13 @@ export function Search({
     else url.searchParams.delete("category");
 
     window.history.replaceState({}, "", url);
-    setResultsAmount(20);
+    window.dispatchEvent(new Event("locationchange"));
+    setResultsAmount(30);
   }, [debouncedQuery, categoryQuery, isReady]);
 
   useEffect(() => {
+    if (!categories.includes(initialCategory || "")) setCategoryQuery(null);
+
     setIsReady(true);
   }, []);
 
@@ -101,7 +112,7 @@ export function Search({
   }, []);
 
   const handleLoadMoreResults = () => {
-    setResultsAmount((prev) => prev + 20);
+    setResultsAmount((prev) => prev + 30);
   };
 
   const handleClearQuery = () => {
@@ -110,12 +121,13 @@ export function Search({
 
   return (
     <>
-      <div className="flex md:flex-row flex-col gap-2 mb-10">
+      <div className="flex md:flex-row flex-col gap-2 mb-4">
         <InputGroup>
           <InputGroupInput
             ref={searchInput}
             type="text"
             name="query"
+            autoComplete="off"
             value={query ?? undefined}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={`Search in ${badges.length} badges`}
@@ -149,7 +161,7 @@ export function Search({
         >
           <ComboboxTrigger
             render={
-              <Button variant="outline" className="w-54 justify-between">
+              <Button variant="outline" className="w-50 justify-between">
                 <ComboboxValue placeholder="All Categories" />
                 <ChevronDownIcon className="size-4 opacity-50" />
               </Button>
@@ -189,28 +201,30 @@ export function Search({
       )}
 
       {filteredBadges.length === 0 && query && query.length > 0 && (
-        <div className="font-semibold text-center mt-12">
-          <ShieldOffIcon className="text-gray-500 mx-auto mb-4" size={48} />
-          <Typography size="h4">No badges found</Typography>
-          <Typography size="h4" variant="muted">
-            {query}
-          </Typography>
-
-          <div className="flex justify-center items-center gap-4 mt-4 text-neutral-300">
-            <Button>
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <ShieldOffIcon />
+            </EmptyMedia>
+            <EmptyTitle>No badges found</EmptyTitle>
+            <EmptyDescription>No badges found for "{query}"</EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent className="flex-row justify-center gap-2">
+            <Button asChild>
               <a
                 href="https://github.com/gfrancv/markdown-badges/issues/new?labels=request&title=%5BRequest%5D%3A"
                 target="_blank"
                 rel="noopener noreferrer"
               >
+                <ExternalLinkIcon />
                 Request Badge
               </a>
             </Button>
             <Button variant="secondary" onClick={handleClearQuery}>
               Clear search
             </Button>
-          </div>
-        </div>
+          </EmptyContent>
+        </Empty>
       )}
     </>
   );

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { ScrollArea as ScrollAreaPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,0 +1,745 @@
+"use client";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+import { Slot } from "radix-ui";
+import * as React from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+import { Badge } from "./badge";
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state";
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = "16rem";
+const SIDEBAR_WIDTH_MOBILE = "18rem";
+const SIDEBAR_WIDTH_ICON = "3rem";
+const SIDEBAR_KEYBOARD_SHORTCUT = "b";
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed";
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+  pathname?: string;
+  category?: string;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.");
+  }
+
+  return context;
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  pathname,
+  category,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  pathname?: string;
+  category?: string;
+}) {
+  const isMobile = useIsMobile();
+  const [openMobile, setOpenMobile] = React.useState(false);
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen);
+  const open = openProp ?? _open;
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value;
+      if (setOpenProp) {
+        setOpenProp(openState);
+      } else {
+        _setOpen(openState);
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+    },
+    [setOpenProp, open],
+  );
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
+  }, [isMobile, setOpen, setOpenMobile]);
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault();
+        toggleSidebar();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggleSidebar]);
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed";
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      pathname,
+      category,
+    }),
+    [
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+      pathname,
+      category,
+    ],
+  );
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <TooltipProvider delayDuration={0}>
+        <div
+          data-slot="sidebar-wrapper"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH,
+              "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+              ...style,
+            } as React.CSSProperties
+          }
+          className={cn(
+            "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+            className,
+          )}
+          {...props}
+        >
+          {children}
+        </div>
+      </TooltipProvider>
+    </SidebarContext.Provider>
+  );
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right";
+  variant?: "sidebar" | "floating" | "inset";
+  collapsible?: "offcanvas" | "icon" | "none";
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)",
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          side === "left"
+            ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
+            : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className,
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow-sm"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon"
+      className={cn("size-7", className)}
+      onClick={(event) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background",
+        "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupLabel({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "div";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-label"
+      data-sidebar="group-label"
+      className={cn(
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupAction({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-group-action"
+      data-sidebar="group-action"
+      className={cn(
+        "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+function SidebarMenuButton({
+  asChild = false,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  isActive?: boolean;
+  tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+} & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const Comp = asChild ? Slot.Root : "button";
+  const { isMobile, state } = useSidebar();
+
+  const button = (
+    <Comp
+      data-slot="sidebar-menu-button"
+      data-sidebar="menu-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    };
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  );
+}
+
+function SidebarMenuAction({
+  className,
+  asChild = false,
+  showOnHover = false,
+  ...props
+}: React.ComponentProps<"button"> & {
+  asChild?: boolean;
+  showOnHover?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "button";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-action"
+      data-sidebar="menu-action"
+      className={cn(
+        "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform peer-hover/menu-button:text-sidebar-accent-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        // Increases the hit area of the button on mobile.
+        "after:absolute after:-inset-2 md:after:hidden",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        showOnHover &&
+          "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground data-[state=open]:opacity-100 md:opacity-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <Badge
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      variant="outline"
+      className={cn(
+        "pointer-events-none absolute right-1 select-none tabular-nums z-100",
+        "peer-data-[size=sm]/menu-button:top-1",
+        "peer-data-[size=default]/menu-button:top-1.5",
+        "peer-data-[size=lg]/menu-button:top-2.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean;
+}) {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  }, []);
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  );
+}
+
+function SidebarMenuSubButton({
+  asChild = false,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean;
+  size?: "sm" | "md";
+  isActive?: boolean;
+}) {
+  const Comp = asChild ? Slot.Root : "a";
+
+  return (
+    <Comp
+      data-slot="sidebar-menu-sub-button"
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+        "data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground",
+        size === "sm" && "text-xs",
+        size === "md" && "text-sm",
+        "group-data-[collapsible=icon]:hidden",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/components/ui/svgs/markdownDark.tsx
+++ b/src/components/ui/svgs/markdownDark.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from "react";
+
+const MarkdownDark = (props: SVGProps<SVGSVGElement>) => (
+  <svg {...props} viewBox="0 0 208 128" xmlSpace="preserve">
+    <path
+      fill="none"
+      stroke="#FFF"
+      strokeWidth="10"
+      d="M15 5h178a10 10 0 0 1 10 10v98a10 10 0 0 1-10 10H15a10 10 0 0 1-10-10V15A10 10 0 0 1 15 5z"
+    />
+    <path
+      fill="#FFF"
+      d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39H30zm125 0-30-33h20V30h20v35h20l-30 33z"
+    />
+  </svg>
+);
+
+export { MarkdownDark };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,55 @@
+import * as React from "react"
+import { Tooltip as TooltipPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5 text-xs text-balance text-background fade-in-0 zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -19,6 +19,7 @@ const typographyVariants = cva("", {
       h2: "text-3xl font-semibold tracking-tight",
       h3: "text-2xl font-semibold tracking-tight",
       h4: "text-xl font-semibold tracking-tight",
+      lg: "text-lg leading-6 font-semibold",
       sm: "text-sm leading-none font-medium",
     },
   },

--- a/src/context/favorites-context.tsx
+++ b/src/context/favorites-context.tsx
@@ -15,6 +15,7 @@ type FavoritesContextType = {
   isFavorite: (id: string) => boolean;
   toggle: (badge: Badge | null) => void;
   copyAll: () => void;
+  clearAll: () => void;
 };
 
 const FavoritesContext = createContext<FavoritesContextType | null>(null);
@@ -64,9 +65,13 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
     copy(markdown);
   }, [favorites, copy]);
 
+  const clearAll = useCallback(() => {
+    setFavorites([]);
+  }, []);
+
   const value = useMemo(
-    () => ({ favorites, isFavorite, toggle, copyAll }),
-    [favorites, isFavorite, toggle, copyAll],
+    () => ({ favorites, isFavorite, toggle, copyAll, clearAll }),
+    [favorites, isFavorite, toggle, copyAll, clearAll],
   );
 
   return (

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,12 +3,10 @@ import "@/styles/global.css";
 
 import SpeedInsights from "@vercel/speed-insights/astro";
 
-import NavMenu from "@/components/NavMenu.astro";
+import { AppShell } from "@/components/app-shell";
 import SEO from "@/components/SEO.astro";
 import { Toaster } from "@/components/ui/sonner";
-import { Typography } from "@/components/ui/typography";
-import GithubIcon from "@/icons/github.astro";
-import MarkdownIcon from "@/icons/markdown.astro";
+import { getBadgeCategories } from "@/services/badges";
 
 interface Props {
   title: string;
@@ -30,7 +28,16 @@ const {
   jsonLd,
 } = Astro.props;
 
-const year = new Date().getFullYear();
+const pathname = new URL(Astro.request.url).pathname;
+
+const rawCategory = Astro.url.searchParams.get("category");
+const category =
+  rawCategory && getBadgeCategories().includes(rawCategory)
+    ? rawCategory
+    : undefined;
+
+const defaultSidebarOpen =
+  Astro.cookies.get("sidebar_state")?.value !== "false";
 ---
 
 <!doctype html>
@@ -47,95 +54,15 @@ const year = new Date().getFullYear();
     />
     <SpeedInsights />
   </head>
-  <body
-    class="bg-[#121212] bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-size-[14px_24px] flex flex-col min-h-screen"
-  >
-    <header>
-      <nav class="fixed w-full z-20 top-0 left-0 backdrop-blur-lg">
-        <div
-          class="max-w-5xl flex flex-wrap items-center md:justify-between justify-center md:gap-0 gap-4 mx-auto p-4"
-        >
-          <a href="/" class="flex items-center space-x-3">
-            <MarkdownIcon class="stroke-[#f1f1ef]" />
-            <Typography
-              as="span"
-              size="h3"
-              color="white"
-              className="self-center whitespace-nowrap"
-            >
-              Markdown Badges
-            </Typography>
-          </a>
-          <NavMenu />
-          <div>
-            <a
-              href="https://github.com/GFrancV/markdown-badges"
-              class="gap-2 md:flex items-center hidden text-white focus:ring-4 focus:outline-hidden font-medium rounded-lg text-sm px-4 py-2 text-center focus:ring-fuchsia-300"
-              target="_blank"
-              rel="noopener"
-            >
-              <GithubIcon class="w-6 fill-white" />
-              View Repo
-            </a>
-          </div>
-        </div>
-      </nav>
-    </header>
-    <main class="grow w-full max-w-5xl mx-auto pt-36 pb-12 px-6">
+  <body>
+    <AppShell
+      client:load
+      pathname={pathname}
+      category={category}
+      defaultSidebarOpen={defaultSidebarOpen}
+    >
       <slot />
-    </main>
-    <footer class="p-4 flex align-middle justify-center">
-      <Typography color="muted" className="text-center">
-        Created with ❤️ by
-        <a
-          href="https://gfrancv.vercel.app"
-          class="hover:underline"
-          target="_blank"
-          rel="noopener"
-        >
-          GFrancV
-        </a>
-        <br />
-        ©GFrancV - {year}
-      </Typography>
-    </footer>
-    <style is:global>
-      @supports selector(::-webkit-scrollbar) {
-        @media (hover: hover) {
-          ::-webkit-scrollbar {
-            width: 10px;
-            height: 10px;
-            border-radius: 10px;
-          }
-
-          ::-webkit-scrollbar-thumb {
-            border-radius: 10px;
-            background-color: #666;
-            border: 2px solid transparent;
-            background-clip: content-box;
-          }
-
-          ::-webkit-scrollbar-thumb:active {
-            background-color: #666;
-          }
-
-          ::-webkit-scrollbar-track {
-            background: #1e1e1e;
-          }
-
-          ::-webkit-scrollbar-corner {
-            background: #1e1e1e;
-          }
-        }
-      }
-
-      @supports not selector(::-webkit-scrollbar) {
-        * {
-          scrollbar-color: #1e1e1e transparent;
-          scrollbar-width: thin;
-        }
-      }
-    </style>
+    </AppShell>
     <Toaster client:load />
   </body>
 </html>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,48 +4,50 @@ import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="About - Markdown Badges">
-  <section class="mb-8">
-    <Typography as="h1" size="h1" className="mb-4">
-      About this Project</Typography
-    >
-    <Typography>
-      This project is a simple tool to search and copy markdown badgets to use
-      in your profile or projects. You can search by name.
-    </Typography>
-    <Typography as="p">
-      All badges provided by this project were extracted from <a
-        href="https://github.com/Ileriayo/markdown-badges"
-        class="underline"
-        target="_blank"
-        >Ileriayo/markdown-badges GitHub repository
-      </a>
-      , which come from <a
-        href="https://shields.io/"
-        class="underline"
-        target="_blank">shields.io</a
-      >.
-    </Typography>
-    <Typography>
-      Alternatively to this site you can visit: <a
-        href="https://ileriayo.github.io/markdown-badges/"
-        class="underline"
-        target="_blank">ileriayo.github.io/markdown-badges/</a
-      >, the official site of the repository where you can find all the badges
-      as well
-    </Typography>
-  </section>
+  <div class="mx-auto max-w-4xl">
+    <section class="mb-8">
+      <Typography as="h1" size="h1" className="mb-4">
+        About this Project</Typography
+      >
+      <Typography>
+        This project is a simple tool to search and copy markdown badgets to use
+        in your profile or projects. You can search by name.
+      </Typography>
+      <Typography as="p">
+        All badges provided by this project were extracted from <a
+          href="https://github.com/Ileriayo/markdown-badges"
+          class="underline"
+          target="_blank"
+          >Ileriayo/markdown-badges GitHub repository
+        </a>
+        , which come from <a
+          href="https://shields.io/"
+          class="underline"
+          target="_blank">shields.io</a
+        >.
+      </Typography>
+      <Typography>
+        Alternatively to this site you can visit: <a
+          href="https://ileriayo.github.io/markdown-badges/"
+          class="underline"
+          target="_blank">ileriayo.github.io/markdown-badges/</a
+        >, the official site of the repository where you can find all the badges
+        as well
+      </Typography>
+    </section>
 
-  <section class="mb-8">
-    <Typography as="h2" size="h2" className="mb-4">
-      How to contribute</Typography
-    >
-    <Typography>
-      You can contribute to this project by adding new badges or improving the
-      code. You can find the repository on <a
-        href="https://github.com/GFrancV/markdown-badges"
-        class="underline"
-        target="_blank">GitHub</a
-      >.
-    </Typography>
-  </section>
+    <section class="mb-8">
+      <Typography as="h2" size="h2" className="mb-4">
+        How to contribute</Typography
+      >
+      <Typography>
+        You can contribute to this project by adding new badges or improving the
+        code. You can find the repository on <a
+          href="https://github.com/GFrancV/markdown-badges"
+          class="underline"
+          target="_blank">GitHub</a
+        >.
+      </Typography>
+    </section>
+  </div>
 </Layout>

--- a/src/pages/badges/[...id].astro
+++ b/src/pages/badges/[...id].astro
@@ -23,63 +23,69 @@ const badgeSEO = getBadgeSEOData(badge);
 ---
 
 <Layout {...badgeSEO}>
-  <div class="grid grid-cols-1 md:grid-cols-4 gap-6 border-b pb-6 mb-6">
-    <div class="cols-span-full md:col-span-1 flex items-center">
-      <div
-        class="p-4 rounded-sm bg-[#1e1e1e] border border-transparent aspect-video md:aspect-square flex w-full"
-      >
-        <img
-          src={badge.url}
-          alt={`${badge.name} badge`}
-          width={104}
-          height={32}
-          class="h-8 w-auto m-auto"
-        />
+  <div class="max-w-4xl mx-auto space-y-6">
+    <section class="grid grid-cols-1 md:grid-cols-4 gap-6 border-b mb-6">
+      <div class="cols-span-full md:col-span-1 flex items-center">
+        <div
+          class="p-4 rounded-sm bg-[#1e1e1e] border border-transparent aspect-video md:aspect-square flex w-full"
+        >
+          <img
+            src={badge.url}
+            alt={`${badge.name} badge`}
+            width={100}
+            height={32}
+            class="h-8 w-auto m-auto"
+          />
+        </div>
       </div>
-    </div>
-    <div class="cols-span-full md:col-span-3">
-      <header class="border-b pb-4 mb-4">
-        <Typography as="h1" size="h1" className="mb-2">
-          {badge.name} Badge
-        </Typography>
-        <Typography variant="muted">
-          {badge.category}
-        </Typography>
-      </header>
-      <section class="mb-4">
-        <Typography as="h2" size="h4" className="mb-2"> Markdown </Typography>
-        <CodeBlock client:load language="markdown" code={badge.markdown} />
-      </section>
-      <section class="mb-4">
-        <Typography as="h2" size="h4" className="mb-2"> Html Image </Typography>
-        <CodeBlock
-          client:load
-          language="html"
-          code={`<img src="${badge.url}" alt="${badge.name} badge">`}
-        />
-      </section>
-    </div>
-  </div>
-  <div>
-    <Typography as="h2" size="h3" className="mb-4"> Related Badges </Typography>
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-      {
-        relatedBadges?.map((badge) => (
-          <a
-            href={`/badges/${badge?.id}`}
-            class="bg-[#1e1e1e] rounded-sm border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary"
-          >
-            <img
-              src={badge?.url}
-              alt={`${badge?.name} badge`}
-              width={100}
-              height={28}
-              class="h-7 w-auto mx-auto"
-              loading="lazy"
-            />
-          </a>
-        ))
-      }
-    </div>
+      <div class="cols-span-full md:col-span-3">
+        <header class="border-b pb-4 mb-4">
+          <Typography as="h1" size="h1" className="mb-2">
+            {badge.name} Badge
+          </Typography>
+          <Typography variant="muted">
+            {badge.category}
+          </Typography>
+        </header>
+        <section class="mb-4">
+          <Typography as="h2" size="h4" className="mb-2"> Markdown </Typography>
+          <CodeBlock client:load language="markdown" code={badge.markdown} />
+        </section>
+        <section class="mb-4">
+          <Typography as="h2" size="h4" className="mb-2">
+            Html Image
+          </Typography>
+          <CodeBlock
+            client:load
+            language="html"
+            code={`<img src="${badge.url}" alt="${badge.name} badge">`}
+          />
+        </section>
+      </div>
+    </section>
+    <section>
+      <Typography as="h2" size="h3" className="mb-4">
+        Related Badges
+      </Typography>
+      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {
+          relatedBadges?.map((badge) => (
+            <a
+              href={`/badges/${badge?.id}`}
+              class="bg-[#1e1e1e] rounded-sm border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary"
+            >
+              <img
+                src={badge?.url}
+                alt={`${badge?.name} badge`}
+                width={100}
+                height={28}
+                class="h-7 w-auto mx-auto"
+                loading="lazy"
+              />
+            </a>
+          ))
+        }
+      </div>
+    </section>
   </div>
 </Layout>

--- a/src/pages/docs/api.astro
+++ b/src/pages/docs/api.astro
@@ -27,252 +27,257 @@ const exampleResponse = `{
   description="Public read-only API reference for Markdown Badges. Browse endpoints, query parameters, and response schemas."
   keywords="markdown badges api, badges api, shields.io api, readme badges api"
 >
-  <section class="mb-10">
-    <Typography as="h1" size="h1" className="mb-4">API Reference</Typography>
-    <Typography>
-      Markdown Badges provides a public, read-only HTTP API that returns badge
-      data as JSON. No authentication or API key is required. It is designed for
-      lightweight integrations such as IDE plugins, browser extensions, CLI
-      tools, and similar developer utilities.
-    </Typography>
-  </section>
-
-  <section class="mb-10">
-    <Typography as="h2" size="h2" className="mb-4">Base URL</Typography>
-    <CodeBlock code={BASE_URL} language="json" client:load />
-  </section>
-
-  <section class="mb-12">
-    <Typography as="h2" size="h2" className="mb-6">Endpoints</Typography>
+  <div class="mx-auto max-w-4xl">
+    <section class="mb-10">
+      <Typography as="h1" size="h1" className="mb-4">API Reference</Typography>
+      <Typography>
+        Markdown Badges provides a public, read-only HTTP API that returns badge
+        data as JSON. No authentication or API key is required. It is designed
+        for lightweight integrations such as IDE plugins, browser extensions,
+        CLI tools, and similar developer utilities.
+      </Typography>
+    </section>
 
     <section class="mb-10">
-      <div class="flex items-center gap-3 mb-3">
-        <span
-          class="text-xs font-bold px-2 py-1 rounded bg-fuchsia-500/20 text-fuchsia-300 border border-fuchsia-500/30 font-mono"
-        >
-          GET
-        </span>
-        <Typography as="h3" size="h3">/api/badges</Typography>
-      </div>
-      <Typography className="mb-6">
-        Returns a list of badges. Results can be narrowed with a fuzzy search
-        query and capped with a limit. When no parameters are provided, the
-        first 20 badges are returned.
-      </Typography>
-
-      <Typography as="h4" size="h4" className="mb-3"
-        >Query Parameters</Typography
-      >
-      <div class="overflow-x-auto rounded-lg border border-white/10 mb-8">
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="border-b border-white/10 bg-white/5 text-left">
-              <th class="px-4 py-3 font-semibold text-white">Parameter</th>
-              <th class="px-4 py-3 font-semibold text-white">Type</th>
-              <th class="px-4 py-3 font-semibold text-white">Required</th>
-              <th class="px-4 py-3 font-semibold text-white">Default</th>
-              <th class="px-4 py-3 font-semibold text-white">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">search</td>
-              <td class="px-4 py-3 text-muted-foreground">string</td>
-              <td class="px-4 py-3 text-muted-foreground">No</td>
-              <td class="px-4 py-3 font-mono text-muted-foreground">—</td>
-              <td class="px-4 py-3 text-muted-foreground">
-                Fuzzy search against badge names. Must be at least 1 character
-                when provided.
-              </td>
-            </tr>
-            <tr>
-              <td class="px-4 py-3 font-mono text-fuchsia-300">limit</td>
-              <td class="px-4 py-3 text-muted-foreground">integer</td>
-              <td class="px-4 py-3 text-muted-foreground">No</td>
-              <td class="px-4 py-3 font-mono text-muted-foreground">20</td>
-              <td class="px-4 py-3 text-muted-foreground">
-                Maximum number of badges to return. Accepted range: 1–200.
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <Typography as="h4" size="h4" className="mb-3">Response Schema</Typography
-      >
-      <div class="overflow-x-auto rounded-lg border border-white/10 mb-8">
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="border-b border-white/10 bg-white/5 text-left">
-              <th class="px-4 py-3 font-semibold text-white">Field</th>
-              <th class="px-4 py-3 font-semibold text-white">Type</th>
-              <th class="px-4 py-3 font-semibold text-white">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">total</td>
-              <td class="px-4 py-3 text-muted-foreground">integer</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Total badges matching the current filters, before slicing.</td
-              >
-            </tr>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">limit</td>
-              <td class="px-4 py-3 text-muted-foreground">integer</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >The effective limit applied to this response.</td
-              >
-            </tr>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">count</td>
-              <td class="px-4 py-3 text-muted-foreground">integer</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Number of items in <span class="font-mono text-fuchsia-300"
-                  >data</span
-                > (may be less than <span class="font-mono text-fuchsia-300"
-                  >limit</span
-                > when results are exhausted).</td
-              >
-            </tr>
-            <tr>
-              <td class="px-4 py-3 font-mono text-fuchsia-300">data</td>
-              <td class="px-4 py-3 text-muted-foreground">Badge[]</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Array of badge objects.</td
-              >
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <Typography as="h4" size="h4" className="mb-3">Badge Object</Typography>
-      <div class="overflow-x-auto rounded-lg border border-white/10 mb-8">
-        <table class="w-full text-sm">
-          <thead>
-            <tr class="border-b border-white/10 bg-white/5 text-left">
-              <th class="px-4 py-3 font-semibold text-white">Field</th>
-              <th class="px-4 py-3 font-semibold text-white">Type</th>
-              <th class="px-4 py-3 font-semibold text-white">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">id</td>
-              <td class="px-4 py-3 text-muted-foreground">string</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Unique identifier for the badge.</td
-              >
-            </tr>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">name</td>
-              <td class="px-4 py-3 text-muted-foreground">string</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Human-readable name of the technology or service.</td
-              >
-            </tr>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">url</td>
-              <td class="px-4 py-3 text-muted-foreground">string (URL)</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Official website of the technology.</td
-              >
-            </tr>
-            <tr class="border-b border-white/10">
-              <td class="px-4 py-3 font-mono text-fuchsia-300">markdown</td>
-              <td class="px-4 py-3 text-muted-foreground">string</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Ready-to-use Markdown snippet to embed the badge.</td
-              >
-            </tr>
-            <tr>
-              <td class="px-4 py-3 font-mono text-fuchsia-300">category</td>
-              <td class="px-4 py-3 text-muted-foreground">string</td>
-              <td class="px-4 py-3 text-muted-foreground"
-                >Category the badge belongs to (e.g. <span
-                  class="font-mono text-fuchsia-300">Frameworks</span
-                >, <span class="font-mono text-fuchsia-300">Languages</span
-                >).</td
-              >
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <Typography as="h4" size="h4" className="mb-3">Example Request</Typography
-      >
-      <CodeBlock
-        code="GET https://markdown-badges.vercel.app/api/badges?search=react&limit=5"
-        language="json"
-        client:load
-      />
-
-      <Typography as="h4" size="h4" className="mb-3 mt-6"
-        >Example Response</Typography
-      >
-      <CodeBlock code={exampleResponse} language="json" client:load />
+      <Typography as="h2" size="h2" className="mb-4">Base URL</Typography>
+      <CodeBlock code={BASE_URL} language="json" client:load />
     </section>
-  </section>
 
-  <section class="mb-10">
-    <Typography as="h2" size="h2" className="mb-4">Limitations</Typography>
-    <ul class="flex flex-col gap-3">
-      <li class="flex gap-3">
-        <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
-        <Typography>
-          <strong class="text-white">Rate limit:</strong> 60 requests per minute per
-          IP address. Exceeding this returns a <span
-            class="font-mono text-fuchsia-300">429 Too Many Requests</span
-          > response with a <span class="font-mono text-fuchsia-300"
-            >Retry-After</span
-          > header indicating when to retry.
-        </Typography>
-      </li>
-      <li class="flex gap-3">
-        <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
-        <Typography>
-          <strong class="text-white">Static dataset:</strong> The badge catalogue
-          is curated and updated manually. The API reflects the current dataset at
-          deploy time, not a live data source.
-        </Typography>
-      </li>
-      <li class="flex gap-3">
-        <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
-        <Typography>
-          <strong class="text-white">Maximum response size:</strong> A single request
-          returns at most 200 badges (<span class="font-mono text-fuchsia-300"
-            >limit=200</span
-          >). Pagination is not supported beyond this cap.
-        </Typography>
-      </li>
-      <li class="flex gap-3">
-        <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
-        <Typography>
-          <strong class="text-white">Read-only:</strong> The API exposes no write
-          operations. Badge data cannot be created, updated, or deleted via the API.
-        </Typography>
-      </li>
-    </ul>
-  </section>
+    <section class="mb-12">
+      <Typography as="h2" size="h2" className="mb-6">Endpoints</Typography>
 
-  <section class="mb-8">
-    <Typography as="h2" size="h2" className="mb-4">Acceptable Use</Typography>
-    <Typography className="mb-4">
-      This API is intended for use in <strong class="text-white"
-        >developer tools, IDE plugins, browser extensions, CLI utilities, and
-        similar integrations</strong
-      > that help developers find and insert badges into their projects.
-    </Typography>
-    <Typography>
-      Please do not use this API to build a product or service that replicates
-      or directly competes with Markdown Badges as a standalone application. If
-      you are unsure whether your use case qualifies, check the source
-      repository on <a
-        href="https://github.com/GFrancV/markdown-badges"
-        class="underline"
-        target="_blank"
-        rel="noopener">GitHub</a
-      > or open an issue to discuss it.
-    </Typography>
-  </section>
+      <section class="mb-10">
+        <div class="flex items-center gap-3 mb-3">
+          <span
+            class="text-xs font-bold px-2 py-1 rounded bg-fuchsia-500/20 text-fuchsia-300 border border-fuchsia-500/30 font-mono"
+          >
+            GET
+          </span>
+          <Typography as="h3" size="h3">/api/badges</Typography>
+        </div>
+        <Typography className="mb-6">
+          Returns a list of badges. Results can be narrowed with a fuzzy search
+          query and capped with a limit. When no parameters are provided, the
+          first 20 badges are returned.
+        </Typography>
+
+        <Typography as="h4" size="h4" className="mb-3"
+          >Query Parameters</Typography
+        >
+        <div class="overflow-x-auto rounded-lg border border-white/10 mb-8">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-white/10 bg-white/5 text-left">
+                <th class="px-4 py-3 font-semibold text-white">Parameter</th>
+                <th class="px-4 py-3 font-semibold text-white">Type</th>
+                <th class="px-4 py-3 font-semibold text-white">Required</th>
+                <th class="px-4 py-3 font-semibold text-white">Default</th>
+                <th class="px-4 py-3 font-semibold text-white">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">search</td>
+                <td class="px-4 py-3 text-muted-foreground">string</td>
+                <td class="px-4 py-3 text-muted-foreground">No</td>
+                <td class="px-4 py-3 font-mono text-muted-foreground">—</td>
+                <td class="px-4 py-3 text-muted-foreground">
+                  Fuzzy search against badge names. Must be at least 1 character
+                  when provided.
+                </td>
+              </tr>
+              <tr>
+                <td class="px-4 py-3 font-mono text-fuchsia-300">limit</td>
+                <td class="px-4 py-3 text-muted-foreground">integer</td>
+                <td class="px-4 py-3 text-muted-foreground">No</td>
+                <td class="px-4 py-3 font-mono text-muted-foreground">20</td>
+                <td class="px-4 py-3 text-muted-foreground">
+                  Maximum number of badges to return. Accepted range: 1–200.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <Typography as="h4" size="h4" className="mb-3"
+          >Response Schema</Typography
+        >
+        <div class="overflow-x-auto rounded-lg border border-white/10 mb-8">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-white/10 bg-white/5 text-left">
+                <th class="px-4 py-3 font-semibold text-white">Field</th>
+                <th class="px-4 py-3 font-semibold text-white">Type</th>
+                <th class="px-4 py-3 font-semibold text-white">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">total</td>
+                <td class="px-4 py-3 text-muted-foreground">integer</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Total badges matching the current filters, before slicing.</td
+                >
+              </tr>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">limit</td>
+                <td class="px-4 py-3 text-muted-foreground">integer</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >The effective limit applied to this response.</td
+                >
+              </tr>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">count</td>
+                <td class="px-4 py-3 text-muted-foreground">integer</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Number of items in <span class="font-mono text-fuchsia-300"
+                    >data</span
+                  > (may be less than <span class="font-mono text-fuchsia-300"
+                    >limit</span
+                  > when results are exhausted).</td
+                >
+              </tr>
+              <tr>
+                <td class="px-4 py-3 font-mono text-fuchsia-300">data</td>
+                <td class="px-4 py-3 text-muted-foreground">Badge[]</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Array of badge objects.</td
+                >
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <Typography as="h4" size="h4" className="mb-3">Badge Object</Typography>
+        <div class="overflow-x-auto rounded-lg border border-white/10 mb-8">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="border-b border-white/10 bg-white/5 text-left">
+                <th class="px-4 py-3 font-semibold text-white">Field</th>
+                <th class="px-4 py-3 font-semibold text-white">Type</th>
+                <th class="px-4 py-3 font-semibold text-white">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">id</td>
+                <td class="px-4 py-3 text-muted-foreground">string</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Unique identifier for the badge.</td
+                >
+              </tr>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">name</td>
+                <td class="px-4 py-3 text-muted-foreground">string</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Human-readable name of the technology or service.</td
+                >
+              </tr>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">url</td>
+                <td class="px-4 py-3 text-muted-foreground">string (URL)</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Official website of the technology.</td
+                >
+              </tr>
+              <tr class="border-b border-white/10">
+                <td class="px-4 py-3 font-mono text-fuchsia-300">markdown</td>
+                <td class="px-4 py-3 text-muted-foreground">string</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Ready-to-use Markdown snippet to embed the badge.</td
+                >
+              </tr>
+              <tr>
+                <td class="px-4 py-3 font-mono text-fuchsia-300">category</td>
+                <td class="px-4 py-3 text-muted-foreground">string</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >Category the badge belongs to (e.g. <span
+                    class="font-mono text-fuchsia-300">Frameworks</span
+                  >, <span class="font-mono text-fuchsia-300">Languages</span
+                  >).</td
+                >
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <Typography as="h4" size="h4" className="mb-3"
+          >Example Request</Typography
+        >
+        <CodeBlock
+          code="GET https://markdown-badges.vercel.app/api/badges?search=react&limit=5"
+          language="json"
+          client:load
+        />
+
+        <Typography as="h4" size="h4" className="mb-3 mt-6"
+          >Example Response</Typography
+        >
+        <CodeBlock code={exampleResponse} language="json" client:load />
+      </section>
+    </section>
+
+    <section class="mb-10">
+      <Typography as="h2" size="h2" className="mb-4">Limitations</Typography>
+      <ul class="flex flex-col gap-3">
+        <li class="flex gap-3">
+          <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
+          <Typography>
+            <strong class="text-white">Rate limit:</strong> 60 requests per minute
+            per IP address. Exceeding this returns a <span
+              class="font-mono text-fuchsia-300">429 Too Many Requests</span
+            > response with a <span class="font-mono text-fuchsia-300"
+              >Retry-After</span
+            > header indicating when to retry.
+          </Typography>
+        </li>
+        <li class="flex gap-3">
+          <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
+          <Typography>
+            <strong class="text-white">Static dataset:</strong> The badge catalogue
+            is curated and updated manually. The API reflects the current dataset
+            at deploy time, not a live data source.
+          </Typography>
+        </li>
+        <li class="flex gap-3">
+          <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
+          <Typography>
+            <strong class="text-white">Maximum response size:</strong> A single request
+            returns at most 200 badges (<span class="font-mono text-fuchsia-300"
+              >limit=200</span
+            >). Pagination is not supported beyond this cap.
+          </Typography>
+        </li>
+        <li class="flex gap-3">
+          <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
+          <Typography>
+            <strong class="text-white">Read-only:</strong> The API exposes no write
+            operations. Badge data cannot be created, updated, or deleted via the
+            API.
+          </Typography>
+        </li>
+      </ul>
+    </section>
+
+    <section class="mb-8">
+      <Typography as="h2" size="h2" className="mb-4">Acceptable Use</Typography>
+      <Typography className="mb-4">
+        This API is intended for use in <strong class="text-white"
+          >developer tools, IDE plugins, browser extensions, CLI utilities, and
+          similar integrations</strong
+        > that help developers find and insert badges into their projects.
+      </Typography>
+      <Typography>
+        Please do not use this API to build a product or service that replicates
+        or directly competes with Markdown Badges as a standalone application.
+        If you are unsure whether your use case qualifies, check the source
+        repository on <a
+          href="https://github.com/GFrancV/markdown-badges"
+          class="underline"
+          target="_blank"
+          rel="noopener">GitHub</a
+        > or open an issue to discuss it.
+      </Typography>
+    </section>
+  </div>
 </Layout>

--- a/src/pages/favorites.astro
+++ b/src/pages/favorites.astro
@@ -4,5 +4,7 @@ import Layout from "@/layouts/Layout.astro";
 ---
 
 <Layout title="Favorites - Markdown Badges" noIndex>
-  <BadgeFavorites client:load />
+  <div class="mx-auto max-w-4xl">
+    <BadgeFavorites client:load />
+  </div>
 </Layout>

--- a/src/pages/generator.astro
+++ b/src/pages/generator.astro
@@ -8,10 +8,10 @@ import Layout from "@/layouts/Layout.astro";
   title="Generator - Markdown Badges"
   description="Create stunning Markdown Badges for your README.md files effortlessly with our online generator. Perfect for developers, and open-source contributors, our tool helps you showcase your skills, tools, and project highlights with stylish badges."
 >
-  <section>
+  <div class="mx-auto max-w-4xl">
     <Typography as="h1" size="h1" className="mb-8">
       Badges generator
     </Typography>
     <BadgeGenerator client:load />
-  </section>
+  </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
 import { Search } from "@/components/search";
-import { Typography } from "@/components/ui/typography";
-import MarkdownIcon from "@/icons/markdown.astro";
 import Layout from "@/layouts/Layout.astro";
 
 const query = Astro.url.searchParams.get("query") || null;
@@ -9,22 +7,5 @@ const category = Astro.url.searchParams.get("category") || null;
 ---
 
 <Layout title="Markdown Badges">
-  <section>
-    <header class="mb-8">
-      <Typography
-        as="h1"
-        size="h1"
-        className="flex items-center justify-center gap-2"
-      >
-        <MarkdownIcon class="w-16 h-16 stroke-white" />
-        Markdown Badges
-      </Typography>
-      <Typography variant="muted" className="text-center">
-        Awesome site to copy markdown badges for your readmes and other markdown
-        files.
-      </Typography>
-    </header>
-
-    <Search client:load initialQuery={query} initialCategory={category} />
-  </section>
+  <Search client:load initialQuery={query} initialCategory={category} />
 </Layout>

--- a/src/services/badges.ts
+++ b/src/services/badges.ts
@@ -36,6 +36,16 @@ export function getBadgeCategories(): string[] {
   return [...new Set(getBadges().map((badge) => badge.category))];
 }
 
+export function getBadgeCountByCategory(): Record<string, number> {
+  return getBadges().reduce(
+    (acc, badge) => {
+      acc[badge.category] = (acc[badge.category] || 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
+}
+
 export function getRelatedBadges(badge: Badge, maxBadges: number = 4): Badge[] {
   return getBadges()
     .filter((b) => b.category === badge.category && b.id !== badge.id)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -46,7 +46,7 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.1822 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
@@ -56,7 +56,7 @@
   --primary-foreground: oklch(0.145 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
+  --muted: oklch(0.35 0 0);
   --muted-foreground: oklch(0.708 0 0);
   --accent: oklch(0.269 0 0);
   --accent-foreground: oklch(0.985 0 0);
@@ -70,14 +70,14 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
+  --sidebar: oklch(0.1822 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: oklch(0.74 0.11 342);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar-ring: oklch(0.74 0.11 342 / 40%);
 }
 
 @layer base {
@@ -90,5 +90,41 @@
   button:not(:disabled),
   [role="button"]:not(:disabled) {
     cursor: pointer;
+  }
+}
+
+@supports selector(::-webkit-scrollbar) {
+  @media (hover: hover) {
+    ::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+      border-radius: 10px;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      border-radius: 10px;
+      background-color: #666;
+      border: 2px solid transparent;
+      background-clip: content-box;
+    }
+
+    ::-webkit-scrollbar-thumb:active {
+      background-color: #666;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: #1e1e1e;
+    }
+
+    ::-webkit-scrollbar-corner {
+      background: #1e1e1e;
+    }
+  }
+}
+
+@supports not selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-color: #1e1e1e transparent;
+    scrollbar-width: thin;
   }
 }


### PR DESCRIPTION
## Overview

Complete layout overhaul replacing the old top navbar with a modern sidebar-based app shell built on shadcn/ui. This PR introduces persistent navigation, active category highlighting, per-category badge counts, and improves the SSR/client balance across the application.

## What's new

### New sidebar layout (`AppShell`)

The old fixed top navbar and footer have been replaced by a full sidebar layout composed of three new components:

- **`AppLogo`** — logo with link to home
- **`AppHeader`** — top bar with sidebar toggle trigger
- **`AppShell`** — root layout wrapper that composes `AppSidebar` + `AppHeader` + page content inside a `SidebarProvider`
 
The sidebar has three sections: a header with the logo, a content area with navigation links and categories, and a footer with the About link. The sidebar is collapsible (offcanvas on desktop, Sheet drawer on mobile) and persists its open/closed state via cookie.

### Active category highlighting

When a `?category=X` query param is present in the URL, the sidebar:
- Deselects the Home nav item
- Highlights the matching category item
- Auto-scrolls the categories list to bring that item into view
 
This works both on full page loads (link click from sidebar) and on client-side URL updates (selecting a category from the search combobox), keeping the sidebar always in sync with the current filter.

### Badge count per category (`SidebarMenuBadge`)

Each category item in the sidebar now shows the total number of badges it contains using the `SidebarMenuBadge` component. The counts are derived from `getBadgeCountByCategory()`, a new service function computed once at module import time — no per-render overhead.

### SSR + client sync architecture

The layout leverages Astro's SSR for correctness and React for interactivity:

- **Category validation on the server** — `Layout.astro` validates the `?category=`param against `getBadgeCategories()` before passing it down. Invalid values never reach the client, eliminating client-side cleanup effects.
- **Sidebar state from cookie on the server** — `Layout.astro` reads the  `sidebar_state` cookie and passes `defaultOpen` to `SidebarProvider`, so the HTML is rendered with the correct open/closed state and avoids any layout shift (FOUC) on page refresh.
- **Client-side URL sync** — `search.tsx` dispatches a `locationchange` custom event after every `replaceState` call. `AppSidebar` listens to both `locationchange` and `popstate` to keep `activeCategory` state in sync without full page reloads.

## Other changes

### Search component

- Replaced the plain "no results" div with the new `Empty` component for a consistent empty state UI
- Increased pagination batch size from 20 to 30 items
- Added `autoComplete="off"` to the search input
- Fixed invalid initial category not being cleared on mount

### Badge components

- Improved responsive grid: `2 → 3 → 5 → 6` columns across breakpoints
- General improvements to `BadgeCard` and `BadgeFavorites` components
 
### Favorites context

- Added `clearAll()` action to `FavoritesContext`

### Styles

- Sidebar CSS variables tuned (background, primary, ring colors)
- Scrollbar styles moved from inline `<style is:global>` in the layout to  `global.css`
 
### New shadcn/ui primitives

`Badge`, `Empty`, `ScrollArea`, `Skeleton`, `Tooltip`, `Sidebar` (full compound component), and `use-mobile` hook.

## Commits

- `chore(ui)` — add shadcn primitives and use-mobile hook
- `feat(layout)` — replace old navbar with sidebar-based app shell
- `refactor(pages)` — adapt all pages to new sidebar layout
- `refactor(badges)` — improve badge components and responsive grid
- `feat(favorites)` — add clearAll action to favorites context
- `refactor(search)` — improve empty state, pagination size, and dispatch locationchange
- `feat(sidebar)` — highlight active category, show badge count, and sync URL client-side