### PR TITLE
refactor: add the `aria-label` attribute to buttons that don't have it

### DIFF
--- a/src/components/copy-clipboard-button.tsx
+++ b/src/components/copy-clipboard-button.tsx
@@ -27,6 +27,7 @@ export function CopyClipboardButton({
         className,
         isCopied ? "text-primary" : "text-muted-foreground",
       )}
+      aria-label="Copy to clipboard"
     >
       {isCopied ? <ClipboardCheckIcon /> : <ClipboardIcon />}
     </Button>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -161,7 +161,11 @@ export function Search({
         >
           <ComboboxTrigger
             render={
-              <Button variant="outline" className="w-50 justify-between">
+              <Button
+                variant="outline"
+                className="w-50 justify-between"
+                aria-label="Select category"
+              >
                 <ComboboxValue placeholder="All Categories" />
                 <ChevronDownIcon className="size-4 opacity-50" />
               </Button>


### PR DESCRIPTION
Add the `aria-label` attribute to buttons that don't have it