### PR TITLE
Fix SSG warning in build

### DIFF
--- a/src/components/NavMenu.astro
+++ b/src/components/NavMenu.astro
@@ -1,7 +1,7 @@
 ---
 import MenuItem from "./MenuItem.astro";
 
-const pathname = new URL(Astro.request.url).pathname;
+const pathname = Astro.url.pathname;
 const currentPath = pathname.slice(1);
 ---
 

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -8,15 +8,13 @@ export function AppShell({
   children,
   pathname,
   category,
-  defaultSidebarOpen,
 }: {
   children: ReactNode;
   pathname?: string;
   category?: string;
-  defaultSidebarOpen?: boolean;
 }) {
   return (
-    <SidebarProvider pathname={pathname} category={category} defaultOpen={defaultSidebarOpen}>
+    <SidebarProvider pathname={pathname} category={category}>
       <AppSidebar />
       <SidebarInset>
         <AppHeader />

--- a/src/data/badges.json
+++ b/src/data/badges.json
@@ -3437,8 +3437,8 @@
     "category": "Operating System"
   },
   {
-    "id": "pop!\\_os",
-    "name": "Pop!\\_OS",
+    "id": "pop-os",
+    "name": "Pop!_OS",
     "url": "https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white",
     "markdown": "![Pop!\\_OS](https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white)",
     "category": "Operating System"

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -28,16 +28,13 @@ const {
   jsonLd,
 } = Astro.props;
 
-const pathname = new URL(Astro.request.url).pathname;
+const pathname = Astro.url.pathname;
 
 const rawCategory = Astro.url.searchParams.get("category");
 const category =
   rawCategory && getBadgeCategories().includes(rawCategory)
     ? rawCategory
     : undefined;
-
-const defaultSidebarOpen =
-  Astro.cookies.get("sidebar_state")?.value !== "false";
 ---
 
 <!doctype html>
@@ -55,12 +52,7 @@ const defaultSidebarOpen =
     <SpeedInsights />
   </head>
   <body>
-    <AppShell
-      client:load
-      pathname={pathname}
-      category={category}
-      defaultSidebarOpen={defaultSidebarOpen}
-    >
+    <AppShell client:load pathname={pathname} category={category}>
       <slot />
     </AppShell>
     <Toaster client:load />


### PR DESCRIPTION
## Overview 

This pull request removes the functionality that read the client's cookie to determine whether the sidebar was open or not has been removed, as this caused an issue with Astro SSG. Additionally, the badge data was edited to fix an ID issue that prevented the URL from generating correctly.

## Changes

### Remove  read client cookie

-  Removed reading of the `sidebar_state` cookie from `Layout.astro`
- Removed the prop used to pass sidebar state to `app-shell.tsx`

**Reason:** 
Accessing client-specific data (cookies) during build time is not compatible with Astro SSG, leading to warnings and incorrect behavior.

**Impact:** 
This has no impact, since there is no button on the desktop to collapse or expand the sidebar, so the default behavior (open) is sufficient in these cases; and on mobile, it doesn't make sense to keep the sidebar open between pages.

### Fix Pop! OS badge ID
- Updated `badges.json` to correct the `pop-os` ID
- Fixes incorrect URL generation and 404 errors