### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/badge-generator.tsx
+++ b/src/components/badge-generator.tsx
@@ -63,8 +63,7 @@ export function BadgeGenerator() {
   );
 
   const imgCode = useMemo(
-    () =>
-      `<img src="${escapeHtmlAttr(badgeUrl)}" alt="${escapeHtmlAttr(`${badgeName} badge`)}">`,
+    () => `<img src="${badgeUrl}" alt="${escapeHtmlAttr(`${badgeName} badge`)}">`,
     [badgeName, badgeUrl],
   );
 

--- a/src/components/badge-generator.tsx
+++ b/src/components/badge-generator.tsx
@@ -17,6 +17,21 @@ import { Input } from "@/components/ui/input";
 import { getIcons } from "@/services/simple-icons";
 import { CodeBlock } from "./ui/code-block";
 
+const COLOR_HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+function sanitizeColorHex(value: string, fallback: string): string {
+  return COLOR_HEX_PATTERN.test(value) ? value : fallback;
+}
+
+function escapeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 export function BadgeGenerator() {
   const [badgeName, setBadgeName] = useState("GitHub");
   const [logoColor, setLogoColor] = useState("#ffffff");
@@ -47,7 +62,13 @@ export function BadgeGenerator() {
   }, []);
 
   const badgeUrl = useMemo(() => {
-    return `https://img.shields.io/badge/${badgeName}-1000?style=for-the-badge&logo=${logo}&logoColor=${logoColor.slice(1)}&labelColor=${leftColor.slice(1)}&color=${rightColor.slice(1)}`;
+    const safeBadgeName = encodeURIComponent(badgeName);
+    const safeLogo = encodeURIComponent(logo ?? "");
+    const safeLogoColor = sanitizeColorHex(logoColor, "#ffffff").slice(1);
+    const safeLeftColor = sanitizeColorHex(leftColor, "#000000").slice(1);
+    const safeRightColor = sanitizeColorHex(rightColor, "#000000").slice(1);
+
+    return `https://img.shields.io/badge/${safeBadgeName}-1000?style=for-the-badge&logo=${safeLogo}&logoColor=${safeLogoColor}&labelColor=${safeLeftColor}&color=${safeRightColor}`;
   }, [badgeName, logo, logoColor, leftColor, rightColor]);
 
   const markdownCode = useMemo(
@@ -56,7 +77,8 @@ export function BadgeGenerator() {
   );
 
   const imgCode = useMemo(
-    () => `<img src="${badgeUrl}" alt="${badgeName} badge">`,
+    () =>
+      `<img src="${escapeHtmlAttr(badgeUrl)}" alt="${escapeHtmlAttr(`${badgeName} badge`)}">`,
     [badgeName, badgeUrl],
   );
 

--- a/src/components/badge-generator.tsx
+++ b/src/components/badge-generator.tsx
@@ -14,23 +14,9 @@ import {
 } from "@/components/ui/combobox";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
+import { escapeHtmlAttr, sanitizeColorHex } from "@/lib/sanitize";
 import { getIcons } from "@/services/simple-icons";
 import { CodeBlock } from "./ui/code-block";
-
-const COLOR_HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
-
-function sanitizeColorHex(value: string, fallback: string): string {
-  return COLOR_HEX_PATTERN.test(value) ? value : fallback;
-}
-
-function escapeHtmlAttr(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;");
-}
 
 export function BadgeGenerator() {
   const [badgeName, setBadgeName] = useState("GitHub");

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,14 @@
+const COLOR_HEX_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export function sanitizeColorHex(value: string, fallback: string): string {
+  return COLOR_HEX_PATTERN.test(value) ? value : fallback;
+}
+
+export function escapeHtmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}


### PR DESCRIPTION
Potential fix for [https://github.com/GFrancV/markdown-badges/security/code-scanning/1](https://github.com/GFrancV/markdown-badges/security/code-scanning/1)

Best fix: normalize and encode all user-derived URL components before building `badgeUrl`, and escape HTML attribute context when generating `imgCode`.

Concretely in `src/components/badge-generator.tsx`:
- Add small helper functions:
  - `sanitizeColorHex` to only allow `#RRGGBB` (fallback safe default).
  - `escapeHtmlAttr` to encode `& < > " '` for HTML attribute contexts.
- Build `badgeUrl` using `encodeURIComponent` for `badgeName` and `logo`, and sanitized hex values (without `#`) for colors.
- Build `imgCode` using escaped attribute values (`escapeHtmlAttr`) so the generated HTML snippet is safe even if interpreted as HTML.
- Keep existing behavior/functionality (badge preview + markdown/html code generation) unchanged from a user perspective.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
