### PR TITLE
 fix: visual consistency, accessibility improvements, and Link component

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -21,7 +21,6 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { Typography } from "@/components/ui/typography";
 import { getBadgeCategories, getBadgeCountByCategory } from "@/services/badges";
 import { AppLogo } from "./app-logo";
 import { ScrollArea } from "./ui/scroll-area";
@@ -129,7 +128,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
                   >
                     <a href={item.url}>
                       <item.icon />
-                      <Typography as="span">{item.name}</Typography>
+                      <span>{item.name}</span>
                     </a>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
@@ -152,7 +151,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
                       isActive={cat === activeCategory}
                     >
                       <a href={`/?category=${cat}`}>
-                        <Typography as="span">{cat}</Typography>
+                        <span>{cat}</span>
                       </a>
                     </SidebarMenuButton>
                     <SidebarMenuBadge>
@@ -169,7 +168,10 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           {nav.navFooter.map((item) => (
             <SidebarMenuItem key={item.name}>
-              <SidebarMenuButton asChild>
+              <SidebarMenuButton
+                asChild
+                isActive={pathname === item.url}
+              >
                 <a href={item.url}>
                   <item.icon />
                   <span>{item.name}</span>

--- a/src/components/badges/badge-card.tsx
+++ b/src/components/badges/badge-card.tsx
@@ -25,7 +25,7 @@ export const BadgeCard = memo(function BadgeCard({ badge }: { badge: Badge }) {
           open(badge);
         }
       }}
-      className="relative group bg-card cursor-pointer rounded-sm border border-transparent transition px-4  py-6  text-center flex flex-col hover:bg-primary/10 hover:border-primary/80 focus:outline-none focus:ring-2 focus:ring-primary/80 focus:ring-offset-2 focus:ring-offset-card data-[state=open]:bg-primary/10"
+      className="relative group bg-card cursor-pointer rounded-md border border-transparent transition p-4 pt-6 text-center flex flex-col hover:bg-primary/10 hover:border-primary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/80 focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-primary/10"
     >
       <img
         src={url}

--- a/src/components/badges/badge-favorite-button.tsx
+++ b/src/components/badges/badge-favorite-button.tsx
@@ -25,7 +25,7 @@ export function BadgeFavoriteButton({
       aria-label={active ? "Remove from favorites" : "Add to favorites"}
       className={cn(
         className,
-        active ? "text-destructive" : "text-muted-foreground hover:text-white",
+        active ? "text-primary" : "text-muted-foreground hover:text-foreground",
       )}
     >
       <HeartIcon className="size-4" fill={active ? "currentColor" : "none"} />

--- a/src/components/badges/badge-sidebar.tsx
+++ b/src/components/badges/badge-sidebar.tsx
@@ -98,7 +98,7 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
           </SheetHeader>
           <div className="px-6 space-y-8">
             <section>
-              <Typography as="h3" variant="accent" className="mb-1">
+              <Typography as="h3" variant="muted" className="mb-1">
                 Preview
               </Typography>
               <img
@@ -111,13 +111,13 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
               />
             </section>
             <section>
-              <Typography as="h3" variant="accent" className="mb-1">
+              <Typography as="h3" variant="muted" className="mb-1">
                 Markdown
               </Typography>
               <CodeBlock language="markdown" code={badge?.markdown ?? ""} />
             </section>
             <section>
-              <Typography as="h3" variant="accent" className="mb-1">
+              <Typography as="h3" variant="muted" className="mb-1">
                 Image URL
               </Typography>
               <CodeBlock
@@ -130,13 +130,13 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
               />
             </section>
             <section>
-              <Typography as="h3" variant="accent" className="mb-1">
+              <Typography as="h3" variant="muted" className="mb-1">
                 Related
               </Typography>
               <div className="grid grid-cols-2 gap-2">
                 {relatedBadges?.map((badge) => (
                   <a key={badge.id} href={`/badges/${badge?.id}`}>
-                    <div className=" bg-[#1e1e1e] rounded-sm border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary">
+                    <div className="bg-card rounded-md border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary">
                       <img
                         src={badge?.url}
                         alt={`${badge?.name} badge`}

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -1,0 +1,28 @@
+import type { ComponentProps } from "react";
+
+import { cn } from "@/lib/utils";
+
+type LinkProps = ComponentProps<"a"> & {
+  external?: boolean;
+};
+
+function Link({ className, external = false, children, ...props }: LinkProps) {
+  const externalProps = external
+    ? { target: "_blank" as const, rel: "noopener noreferrer" }
+    : {};
+
+  return (
+    <a
+      className={cn(
+        "text-primary underline underline-offset-4 transition-colors hover:text-primary/80",
+        className,
+      )}
+      {...externalProps}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+}
+
+export { Link };

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -424,7 +424,7 @@ function SidebarGroupLabel({
       data-slot="sidebar-group-label"
       data-sidebar="group-label"
       className={cn(
-        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+        "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-muted-foreground/60 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
         "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
@@ -493,7 +493,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm text-muted-foreground ring-sidebar-ring outline-hidden transition-[width,height,padding,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,19 +1,22 @@
 ---
-import { Typography } from "@/components/ui/typography";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { Link } from "@/components/ui/link";
 import Layout from "@/layouts/Layout.astro";
 ---
 
-<Layout title="Page not Found">
-  <section class="content-center justify-center">
-    <div>
-      <Typography as="h1" size="h1" className="mb-4">
-        Oops! <br /> 404 Error!
-      </Typography>
-      <Typography color="muted">
+<Layout title="Page not Found" noIndex>
+  <Empty>
+    <EmptyHeader>
+      <EmptyTitle>Oops! - 404 Not Found</EmptyTitle>
+      <EmptyDescription>
         The page you are trying to access does not exist, return to the
-        <a href="/">main page</a>
-        if you have missed it
-      </Typography>
-    </div>
-  </section>
+        <Link href="/">home page</Link> if you have lost your way
+      </EmptyDescription>
+    </EmptyHeader>
+  </Empty>
 </Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,4 +1,5 @@
 ---
+import { Link } from "@/components/ui/link";
 import { Typography } from "@/components/ui/typography";
 import Layout from "@/layouts/Layout.astro";
 ---
@@ -14,25 +15,19 @@ import Layout from "@/layouts/Layout.astro";
         in your profile or projects. You can search by name.
       </Typography>
       <Typography as="p">
-        All badges provided by this project were extracted from <a
+        All badges provided by this project were extracted from <Link
           href="https://github.com/Ileriayo/markdown-badges"
-          class="underline"
-          target="_blank"
-          >Ileriayo/markdown-badges GitHub repository
-        </a>
-        , which come from <a
-          href="https://shields.io/"
-          class="underline"
-          target="_blank">shields.io</a
+          external>Ileriayo/markdown-badges GitHub repository</Link
+        >, which come from <Link href="https://shields.io/" external
+          >shields.io</Link
         >.
       </Typography>
       <Typography>
-        Alternatively to this site you can visit: <a
+        Alternatively to this site you can visit: <Link
           href="https://ileriayo.github.io/markdown-badges/"
-          class="underline"
-          target="_blank">ileriayo.github.io/markdown-badges/</a
+          external>ileriayo.github.io/markdown-badges/</Link
         >, the official site of the repository where you can find all the badges
-        as well
+        as well.
       </Typography>
     </section>
 
@@ -42,10 +37,9 @@ import Layout from "@/layouts/Layout.astro";
       >
       <Typography>
         You can contribute to this project by adding new badges or improving the
-        code. You can find the repository on <a
+        code. You can find the repository on <Link
           href="https://github.com/GFrancV/markdown-badges"
-          class="underline"
-          target="_blank">GitHub</a
+          external>GitHub</Link
         >.
       </Typography>
     </section>

--- a/src/pages/badges/[...id].astro
+++ b/src/pages/badges/[...id].astro
@@ -27,7 +27,7 @@ const badgeSEO = getBadgeSEOData(badge);
     <section class="grid grid-cols-1 md:grid-cols-4 gap-6 border-b mb-6">
       <div class="cols-span-full md:col-span-1 flex items-center">
         <div
-          class="p-4 rounded-sm bg-[#1e1e1e] border border-transparent aspect-video md:aspect-square flex w-full"
+          class="p-4 rounded-md bg-card border border-transparent aspect-video md:aspect-square flex w-full"
         >
           <img
             src={badge.url}
@@ -72,7 +72,7 @@ const badgeSEO = getBadgeSEOData(badge);
           relatedBadges?.map((badge) => (
             <a
               href={`/badges/${badge?.id}`}
-              class="bg-[#1e1e1e] rounded-sm border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary"
+              class="bg-card rounded-md border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary"
             >
               <img
                 src={badge?.url}

--- a/src/pages/docs/api.astro
+++ b/src/pages/docs/api.astro
@@ -1,5 +1,6 @@
 ---
 import { CodeBlock } from "@/components/ui/code-block";
+import { Link } from "@/components/ui/link";
 import { Typography } from "@/components/ui/typography";
 import Layout from "@/layouts/Layout.astro";
 
@@ -271,11 +272,9 @@ const exampleResponse = `{
         Please do not use this API to build a product or service that replicates
         or directly competes with Markdown Badges as a standalone application.
         If you are unsure whether your use case qualifies, check the source
-        repository on <a
+        repository on <Link
           href="https://github.com/GFrancV/markdown-badges"
-          class="underline"
-          target="_blank"
-          rel="noopener">GitHub</a
+          external>GitHub</Link
         > or open an issue to discuss it.
       </Typography>
     </section>


### PR DESCRIPTION
## Overview

A focused pass over the UI to resolve visual inconsistencies, semantic color misuse, hardcoded design tokens, and accessibility issues found during a full audit of the application's visual identity.

### Sidebar hierarchy (sidebar.tsx, app-sidebar.tsx)

The sidebar previously rendered all items — active, inactive, and group
labels — at the same white color, making every element feel equally
important and creating visual noise.

- Added `text-muted-foreground` as the default text color for `SidebarMenuButton` so inactive items recede visually
- Added `color` to the button's `transition` list for a smooth color change on activation
- Changed `SidebarGroupLabel` from `text-sidebar-foreground/70` to `text-muted-foreground/60`, placing labels clearly below inactive items in the hierarchy (labels → inactive → active)
- Replaced `<Typography as="span">` wrappers inside nav and category items with plain `<span>` so the button's cascaded color is not overridden by `text-foreground`
- Removed the now-unused `Typography` import from `app-sidebar.tsx`
- Added `isActive={pathname === item.url}` to footer nav items so the "About" link correctly highlights when on `/about`

### Bug fixes

**404.astro** — `color="muted"` is not a prop on the `Typography` component (only `variant` exists). The prop was silently ignored, rendering the error description in full white instead of muted gray. The page was also refactored to use the `Empty` / `EmptyDescription` component pattern for consistency with other empty states in the app.

**badge-card.tsx** — Replaced `focus:ring-*` with `focus-visible:ring-*` across the card's focus styles. `focus:` triggers on mouse clicks too; `focus-visible:` restricts the ring to keyboard navigation only, which is the correct accessibility behavior. Also corrected `ring-offset-card` to `ring-offset-background` to match the actual stacking context.

### Semantic color fixes

**badge-favorite-button.tsx** — The active (saved) heart icon was styled with `text-destructive`, which is the error/danger orange-red color. Changed to `text-primary` (the app's rose/mauve accent), which is semantically correct for a "liked" state and visually consistent with the rest of the design system. Also replaced the hardcoded `hover:text-white` with `hover:text-foreground`.

**badge-sidebar.tsx** — Section labels ("Preview", "Markdown", "Image URL", "Related") used `variant="accent"`, which maps to
`text-accent-foreground` — identical to `text-foreground` in this theme. The labels were visually indistinguishable from regular content. Changed to `variant="muted"` so they read clearly as labels.

### Design token fixes

Replaced three instances of the hardcoded `bg-[#1e1e1e]` color used in badge preview containers and related-badge grids with `bg-card`. The hardcoded value was correct for the VS2015 highlight.js code block theme (and remains there), but badge UI containers should reference the design token so they stay in sync if the palette changes.

Standardised border-radius from `rounded-sm` to `rounded-md` on badge cards, preview containers, and related-badge grids to match every other interactive component in the system.

### Link component (src/components/ui/link.tsx)

Added a reusable `Link` component for inline text links. All inline `<a>` elements in content pages previously had either no styling or inconsistent inline classes.

```tsx
<Link href="/path">internal link</Link>
<Link href="https://..." external>opens in new tab</Link>
```

The `external` prop automatically adds `target="_blank"` and `rel="noopener noreferrer"`, removing boilerplate and preventing the common mistake of omitting the `rel` attribute. Applied across `about.astro`, `docs/api.astro`, and `404.astro`.

## Files changed

| File | Change |
|---|---|
| `src/components/ui/sidebar.tsx` | Inactive item color, group label color, color transition |
| `src/components/app-sidebar.tsx` | `span` for text nodes, `isActive` on footer, remove unused import |
| `src/components/badges/badge-card.tsx` | `focus-visible`, `rounded-md`, `ring-offset-background` |
| `src/components/badges/badge-favorite-button.tsx` | `text-primary` for active state, `text-foreground` on hover |
| `src/components/badges/badge-sidebar.tsx` | `variant="muted"` on labels, `bg-card`, `rounded-md` |
| `src/pages/badges/[...id].astro` | `bg-card`, `rounded-md` |
| `src/pages/404.astro` | Fix invalid prop, refactor to `Empty` pattern, use `Link` |
| `src/pages/about.astro` | Replace inline `<a>` styles with `Link` component |
| `src/pages/docs/api.astro` | Replace bare `<a>` with `Link` component |
| `src/components/ui/link.tsx` | **New** — reusable styled text link component |
