### PR TITLE
 feat: badge generation pipeline, URL-safe IDs, and weekly auto-update workflow

### DIFF
--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,0 +1,148 @@
+name: Weekly Badges Update
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual triggering from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-badges:
+    name: Sync badges from upstream README
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # ── Step 1: Backup current badges.json ───────────────────────────────────
+      - name: Backup data/badges.json
+        id: backup
+        run: |
+          if [ ! -f data/badges.json ]; then
+            echo "::warning::data/badges.json not found — starting from an empty baseline"
+            echo "[]" > data/badges.json
+          fi
+          cp data/badges.json data/badges.old.json
+          OLD_COUNT=$(node -p "require('./data/badges.old.json').length")
+          echo "old_count=$OLD_COUNT" >> $GITHUB_OUTPUT
+          echo "Backed up $OLD_COUNT badges to data/badges.old.json"
+
+      # ── Step 2: Generate new badges ──────────────────────────────────────────
+      - name: Generate new badges from upstream README
+        run: pnpm badges:generate
+
+      # ── Step 3: Run tests ────────────────────────────────────────────────────
+      - name: Run test suite on generated badges.json
+        run: pnpm test
+
+      # ── Step 4: Compare SHA-256 hashes ───────────────────────────────────────
+      - name: Compare file hashes
+        id: diff
+        run: |
+          HASH_NEW=$(sha256sum data/badges.json     | awk '{print $1}')
+          HASH_OLD=$(sha256sum data/badges.old.json | awk '{print $1}')
+          NEW_COUNT=$(node -p "require('./data/badges.json').length")
+          OLD_COUNT=${{ steps.backup.outputs.old_count }}
+          DELTA=$((NEW_COUNT - OLD_COUNT))
+          DELTA_DISPLAY=$([ "$DELTA" -ge 0 ] && echo "+$DELTA" || echo "$DELTA")
+
+          echo "new_count=$NEW_COUNT"       >> $GITHUB_OUTPUT
+          echo "delta=$DELTA_DISPLAY"       >> $GITHUB_OUTPUT
+
+          echo "Old hash : $HASH_OLD"
+          echo "New hash : $HASH_NEW"
+          echo "Badges   : $OLD_COUNT → $NEW_COUNT ($DELTA_DISPLAY)"
+
+          if [ "$HASH_NEW" = "$HASH_OLD" ]; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "::notice::No content changes detected — badges.json is already up to date."
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "::notice::Content changed: $OLD_COUNT → $NEW_COUNT badges ($DELTA_DISPLAY)"
+          fi
+
+      # ── Step 5: Clean up backup (always, even on failure) ────────────────────
+      - name: Remove backup file
+        if: always()
+        run: rm -f data/badges.old.json
+
+      # ── Step 6: Write job summary ─────────────────────────────────────────────
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
+            cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## ✅ Badges updated — PR will be created
+
+          | | Count |
+          |---|---|
+          | Before | ${{ steps.backup.outputs.old_count }} |
+          | After  | ${{ steps.diff.outputs.new_count }} |
+          | Delta  | ${{ steps.diff.outputs.delta }} |
+          EOF
+          elif [ "${{ steps.diff.outputs.changed }}" = "false" ]; then
+            cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## ⏭️ No changes — badges.json is already up to date
+
+          Badge count: ${{ steps.diff.outputs.new_count }}
+          EOF
+          else
+            cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+          ## ❌ Workflow failed
+
+          The workflow stopped before reaching the hash comparison step.
+          Check the step logs above for details.
+          EOF
+          fi
+
+      # ── Step 7: Create Pull Request ───────────────────────────────────────────
+      - name: Create Pull Request
+        if: steps.diff.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: data/badges.json
+          commit-message: |
+            chore(badges): weekly sync from upstream
+
+            ${{ steps.backup.outputs.old_count }} → ${{ steps.diff.outputs.new_count }} badges (${{ steps.diff.outputs.delta }})
+          title: "chore(badges): weekly sync (${{ steps.diff.outputs.delta }} badges)"
+          body: |
+            ## Weekly Badges Sync
+
+            Automated update pulled from the upstream [Ileriayo/markdown-badges](https://github.com/Ileriayo/markdown-badges) README.
+
+            | | Count |
+            |---|---|
+            | Before | ${{ steps.backup.outputs.old_count }} |
+            | After  | ${{ steps.diff.outputs.new_count }} |
+            | Delta  | **${{ steps.diff.outputs.delta }}** |
+
+            ### Verification passed
+            - ✅ `node scripts/generate-badges.js` completed without errors
+            - ✅ All tests passed (`pnpm test`)
+            - ✅ SHA-256 of `data/badges.json` differs from the previous version
+
+            ---
+            *Generated by the [weekly-update-badges](../../actions/workflows/update-badges.yml) workflow*
+          branch: chore/weekly-badges-update
+          base: main
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ pnpm-debug.log*
 .idea/
 
 .vercel
+
+# badge generation artifacts
+data/badges.old.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Key libraries: `fuzzyjs` (badge search), `sonner` (toasts), `next-themes` (dark/
 
 ### Data Flow
 
-1. **Source of truth**: `src/data/badges.json` — static JSON with ~600+ badge definitions (`{ id, name, url, markdown, category }`).
+1. **Source of truth**: `data/badges.json` — static JSON with ~600+ badge definitions (`{ id, name, url, markdown, category }`).
 2. **Service layer**: `src/services/badges.ts` — all badge filtering/retrieval logic using fuzzy search (fuzzyjs). This is where search, category filtering, and related-badge lookups live.
 3. **Icons**: `src/services/icons.ts` — fetches simple-icons metadata dynamically from GitHub at runtime (used in the generator).
 4. **Pages**: Astro pages in `src/pages/` define routes. Badge detail pages (`/badges/[id]`) are statically pre-rendered at build time from the JSON.
@@ -47,4 +47,4 @@ Key libraries: `fuzzyjs` (badge search), `sonner` (toasts), `next-themes` (dark/
 
 ### Adding Badges
 
-New badges are added to `src/data/badges.json`. See `CONTRIBUTING.md` for the exact schema and guidelines.
+New badges are added to `data/badges.json`. See `CONTRIBUTING.md` for the exact schema and guidelines.

--- a/data/badges.json
+++ b/data/badges.json
@@ -14,6 +14,13 @@
     "category": "Artificial Intelligence"
   },
   {
+    "id": "claude",
+    "name": "Claude",
+    "url": "https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white",
+    "markdown": "![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
     "id": "dependabot",
     "name": "Dependabot",
     "url": "https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot&logoColor=white",
@@ -23,15 +30,15 @@
   {
     "id": "github-copilot",
     "name": "GitHub Copilot",
-    "url": "https://img.shields.io/badge/GitHub_Copilot-8957E5?style=for-the-badge&logo=github-copilot&logoColor=white",
-    "markdown": "![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-8957E5?style=for-the-badge&logo=github-copilot&logoColor=white)",
+    "url": "https://img.shields.io/badge/github_copilot-8957E5?style=for-the-badge&logo=github-copilot&logoColor=white",
+    "markdown": "![GitHub Copilot](https://img.shields.io/badge/github_copilot-8957E5?style=for-the-badge&logo=github-copilot&logoColor=white)",
     "category": "Artificial Intelligence"
   },
   {
-    "id": "google-assistant",
-    "name": "Google Assistant",
-    "url": "https://img.shields.io/badge/google%20assistant-4285F4?style=for-the-badge&logo=google%20assistant&logoColor=white",
-    "markdown": "![Google Assistant](https://img.shields.io/badge/google%20assistant-4285F4?style=for-the-badge&logo=google%20assistant&logoColor=white)",
+    "id": "google-deepmind",
+    "name": "Google Deepmind",
+    "url": "https://img.shields.io/badge/deepmind-%234285F4.svg?style=for-the-badge&logo=deepmind&logoColor=white",
+    "markdown": "![Google Deepmind](https://img.shields.io/badge/deepmind-%234285F4.svg?style=for-the-badge&logo=deepmind&logoColor=white)",
     "category": "Artificial Intelligence"
   },
   {
@@ -42,11 +49,102 @@
     "category": "Artificial Intelligence"
   },
   {
+    "id": "huggingface",
+    "name": "HuggingFace",
+    "url": "https://img.shields.io/badge/huggingface-%23FFD21E.svg?style=for-the-badge&logo=huggingface&logoColor=white",
+    "markdown": "![HuggingFace](https://img.shields.io/badge/huggingface-%23FFD21E.svg?style=for-the-badge&logo=huggingface&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "langchain",
+    "name": "LangChain",
+    "url": "https://img.shields.io/badge/langchain-%231C3C3C.svg?style=for-the-badge&logo=langchain&logoColor=white",
+    "markdown": "![LangChain](https://img.shields.io/badge/langchain-%231C3C3C.svg?style=for-the-badge&logo=langchain&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "langflow",
+    "name": "Langflow",
+    "url": "https://img.shields.io/badge/langflow-%230066CC.svg?style=for-the-badge&logo=langflow&logoColor=white",
+    "markdown": "![Langflow](https://img.shields.io/badge/langflow-%230066CC.svg?style=for-the-badge&logo=langflow&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "langgraph",
+    "name": "LangGraph",
+    "url": "https://img.shields.io/badge/langgraph-%231C3C3C.svg?style=for-the-badge&logo=langgraph&logoColor=white",
+    "markdown": "![LangGraph](https://img.shields.io/badge/langgraph-%231C3C3C.svg?style=for-the-badge&logo=langgraph&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "minimax",
+    "name": "Minimax",
+    "url": "https://img.shields.io/badge/minimax-B4393C?style=for-the-badge&logo=minimax&logoColor=white",
+    "markdown": "![Minimax](https://img.shields.io/badge/minimax-B4393C?style=for-the-badge&logo=minimax&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "mistralai",
+    "name": "MistralAI",
+    "url": "https://img.shields.io/badge/mistralai-FA520F?style=for-the-badge&logo=mistralai&logoColor=white",
+    "markdown": "![MistralAI](https://img.shields.io/badge/mistralai-FA520F?style=for-the-badge&logo=mistralai&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "n8n",
+    "name": "n8n",
+    "url": "https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white",
+    "markdown": "![n8n](https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "ollama",
+    "name": "Ollama",
+    "url": "https://img.shields.io/badge/ollama-%23000000.svg?style=for-the-badge&logo=ollama&logoColor=white",
+    "markdown": "![Ollama](https://img.shields.io/badge/ollama-%23000000.svg?style=for-the-badge&logo=ollama&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
     "id": "perplexity",
     "name": "Perplexity",
     "url": "https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F",
     "markdown": "![Perplexity](https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F)",
     "category": "Artificial Intelligence"
+  },
+  {
+    "id": "yolo",
+    "name": "YOLO",
+    "url": "https://img.shields.io/badge/YOLO-111F68?style=for-the-badge&logo=yolo&logoColor=white",
+    "markdown": "![YOLO](https://img.shields.io/badge/YOLO-111F68?style=for-the-badge&logo=yolo&logoColor=white)",
+    "category": "Artificial Intelligence"
+  },
+  {
+    "id": "bitcoin",
+    "name": "Bitcoin",
+    "url": "https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white",
+    "markdown": "![Bitcoin](https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white)",
+    "category": "Blockchain"
+  },
+  {
+    "id": "blockchain.com",
+    "name": "Blockchain.com",
+    "url": "https://img.shields.io/badge/blockchain.com-%232F3134?style=for-the-badge&logo=blockchaindotcom&logoColor=white",
+    "markdown": "![Blockchaindotcom](https://img.shields.io/badge/blockchain.com-%232F3134?style=for-the-badge&logo=blockchaindotcom&logoColor=white)",
+    "category": "Blockchain"
+  },
+  {
+    "id": "cardano",
+    "name": "Cardano",
+    "url": "https://img.shields.io/badge/cardano-%230133AD.svg?style=for-the-badge&logo=cardano&logoColor=white",
+    "markdown": "![Cardano](https://img.shields.io/badge/cardano-%230133AD.svg?style=for-the-badge&logo=cardano&logoColor=white)",
+    "category": "Blockchain"
+  },
+  {
+    "id": "ethers",
+    "name": "Ethers",
+    "url": "https://img.shields.io/badge/ethers-%232535A0.svg?style=for-the-badge&logo=ethers&logoColor=white",
+    "markdown": "![Ethers](https://img.shields.io/badge/ethers-%232535A0.svg?style=for-the-badge&logo=ethers&logoColor=white)",
+    "category": "Blockchain"
   },
   {
     "id": "hyperledger",
@@ -56,10 +154,38 @@
     "category": "Blockchain"
   },
   {
+    "id": "ipfs",
+    "name": "IPFS",
+    "url": "https://img.shields.io/badge/IPFS-%2365C2CB.svg?style=for-the-badge&logo=IPFS&logoColor=white",
+    "markdown": "![IPFS](https://img.shields.io/badge/IPFS-%2365C2CB.svg?style=for-the-badge&logo=IPFS&logoColor=white)",
+    "category": "Blockchain"
+  },
+  {
+    "id": "opensea",
+    "name": "OpenSea",
+    "url": "https://img.shields.io/badge/OpenSea-%232081E2.svg?style=for-the-badge&logo=opensea&logoColor=white",
+    "markdown": "![OpenSea](https://img.shields.io/badge/OpenSea-%232081E2.svg?style=for-the-badge&logo=opensea&logoColor=white)",
+    "category": "Blockchain"
+  },
+  {
+    "id": "solana",
+    "name": "Solana",
+    "url": "https://img.shields.io/badge/solana-%239945FF.svg?style=for-the-badge&logo=solana&logoColor=white",
+    "markdown": "![Solana](https://img.shields.io/badge/solana-%239945FF.svg?style=for-the-badge&logo=solana&logoColor=white)",
+    "category": "Blockchain"
+  },
+  {
     "id": "blogger",
     "name": "Blogger",
     "url": "https://img.shields.io/badge/Blogger-FF5722?style=for-the-badge&logo=blogger&logoColor=white",
     "markdown": "![Blogger](https://img.shields.io/badge/Blogger-FF5722?style=for-the-badge&logo=blogger&logoColor=white)",
+    "category": "Blog"
+  },
+  {
+    "id": "daily.dev",
+    "name": "daily.dev",
+    "url": "https://img.shields.io/badge/daily.dev-CE3DF3?style=for-the-badge&logo=daily.dev&logoColor=white",
+    "markdown": "![daily.dev](https://img.shields.io/badge/daily.dev-CE3DF3?style=for-the-badge&logo=daily.dev&logoColor=white)",
     "category": "Blog"
   },
   {
@@ -119,10 +245,31 @@
     "category": "Blog"
   },
   {
+    "id": "zola",
+    "name": "Zola",
+    "url": "https://img.shields.io/badge/Zola-black?style=for-the-badge&logo=zola&logoColor=white",
+    "markdown": "![Zola](https://img.shields.io/badge/Zola-black?style=for-the-badge&logo=zola&logoColor=white)",
+    "category": "Blog"
+  },
+  {
+    "id": "arc",
+    "name": "Arc",
+    "url": "https://img.shields.io/badge/Arc-000000?style=for-the-badge&logo=arc&logoColor=white",
+    "markdown": "![Arc](https://img.shields.io/badge/Arc-000000?style=for-the-badge&logo=arc&logoColor=white)",
+    "category": "Browsers"
+  },
+  {
     "id": "brave",
     "name": "Brave",
     "url": "https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white",
     "markdown": "![Brave](https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white)",
+    "category": "Browsers"
+  },
+  {
+    "id": "duckduckgo",
+    "name": "DuckDuckGo",
+    "url": "https://img.shields.io/badge/duckduckgo-de5833?style=for-the-badge&logo=duckduckgo&logoColor=white",
+    "markdown": "![DuckDuckGo](https://img.shields.io/badge/duckduckgo-de5833?style=for-the-badge&logo=duckduckgo&logoColor=white)",
     "category": "Browsers"
   },
   {
@@ -135,8 +282,8 @@
   {
     "id": "firefox",
     "name": "Firefox",
-    "url": "https://img.shields.io/badge/Firefox-FF7139?style=for-the-badge&logo=Firefox&logoColor=white",
-    "markdown": "![Firefox](https://img.shields.io/badge/Firefox-FF7139?style=for-the-badge&logo=Firefox&logoColor=white)",
+    "url": "https://img.shields.io/badge/Firefox-FF7139?style=for-the-badge&logo=Firefox-Browser&logoColor=white",
+    "markdown": "![Firefox](https://img.shields.io/badge/Firefox-FF7139?style=for-the-badge&logo=Firefox-Browser&logoColor=white)",
     "category": "Browsers"
   },
   {
@@ -149,8 +296,8 @@
   {
     "id": "icecat",
     "name": "IceCat",
-    "url": "https://img.shields.io/badge/icecat-263A85?style=for-the-badge&logo=gnuicecat&logoColor=white",
-    "markdown": "![IceCat](https://img.shields.io/badge/icecat-263A85?style=for-the-badge&logo=gnuicecat&logoColor=white)",
+    "url": "https://img.shields.io/badge/gnuicecat-263A85?style=for-the-badge&logo=gnuicecat&logoColor=white",
+    "markdown": "![IceCat](https://img.shields.io/badge/gnuicecat-263A85?style=for-the-badge&logo=gnuicecat&logoColor=white)",
     "category": "Browsers"
   },
   {
@@ -189,24 +336,108 @@
     "category": "Browsers"
   },
   {
-    "id": "arc",
-    "name": "Arc",
-    "url": "https://img.shields.io/badge/Arc-000000?style=for-the-badge&logo=arc&logoColor=white",
-    "markdown": "![Arc](https://img.shields.io/badge/Arc-000000?style=for-the-badge&logo=arc&logoColor=white)",
+    "id": "zen",
+    "name": "Zen",
+    "url": "https://img.shields.io/badge/Zen-%23F76F53.svg?style=for-the-badge&logo=zenbrowser&logoColor=white",
+    "markdown": "![Zen](https://img.shields.io/badge/Zen-%23F76F53.svg?style=for-the-badge&logo=zenbrowser&logoColor=white)",
     "category": "Browsers"
   },
   {
-    "id": "circleci",
-    "name": "CircleCI",
-    "url": "https://img.shields.io/badge/circleci-%23161616.svg?style=for-the-badge&logo=circleci&logoColor=white",
-    "markdown": "![CircleCI](https://img.shields.io/badge/circleci-%23161616.svg?style=for-the-badge&logo=circleci&logoColor=white)",
-    "category": "CI"
+    "id": "altium-designer",
+    "name": "Altium Designer",
+    "url": "https://img.shields.io/badge/altium_designer-%23A5915F.svg?style=for-the-badge&logo=altiumdesigner&logoColor=white",
+    "markdown": "![Altium Designer](https://img.shields.io/badge/altium_designer-%23A5915F.svg?style=for-the-badge&logo=altiumdesigner&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "archicad",
+    "name": "Archicad",
+    "url": "https://img.shields.io/badge/archicad-%232D50A5.svg?style=for-the-badge&logo=archicad&logoColor=white",
+    "markdown": "![Archicad](https://img.shields.io/badge/archicad-%232D50A5.svg?style=for-the-badge&logo=archicad&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "autocad",
+    "name": "AutoCAD",
+    "url": "https://img.shields.io/badge/autocad-%23E51050.svg?style=for-the-badge&logo=autocad&logoColor=white",
+    "markdown": "![AutoCAD](https://img.shields.io/badge/autocad-%23E51050.svg?style=for-the-badge&logo=autocad&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "autodesk",
+    "name": "AutoDesk",
+    "url": "https://img.shields.io/badge/autodesk-%23000000.svg?style=for-the-badge&logo=autodesk&logoColor=white",
+    "markdown": "![AutoDesk](https://img.shields.io/badge/autodesk-%23000000.svg?style=for-the-badge&logo=autodesk&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "autodesk-revit",
+    "name": "Autodesk Revit",
+    "url": "https://img.shields.io/badge/Autodesk_Revit-%23186BFF.svg?style=for-the-badge&logo=autodeskrevit&logoColor=white",
+    "markdown": "![Autodesk Revit](https://img.shields.io/badge/Autodesk_Revit-%23186BFF.svg?style=for-the-badge&logo=autodeskrevit&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "freecad",
+    "name": "FreeCAD",
+    "url": "https://img.shields.io/badge/freecad-%23418FDE.svg?style=for-the-badge&logo=freecad&logoColor=white",
+    "markdown": "![FreeCAD](https://img.shields.io/badge/freecad-%23418FDE.svg?style=for-the-badge&logo=freecad&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "kicad",
+    "name": "KiCad",
+    "url": "https://img.shields.io/badge/kicad-%23314CB0.svg?style=for-the-badge&logo=kicad&logoColor=white",
+    "markdown": "![KiCad](https://img.shields.io/badge/kicad-%23314CB0.svg?style=for-the-badge&logo=kicad&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "microstation",
+    "name": "Microstation",
+    "url": "https://img.shields.io/badge/microstation-%2362BB47.svg?style=for-the-badge&logo=microstation&logoColor=white",
+    "markdown": "![Microstation](https://img.shields.io/badge/microstation-%2362BB47.svg?style=for-the-badge&logo=microstation&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "openscad",
+    "name": "OpenSCAD",
+    "url": "https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto",
+    "markdown": "![OpenSCAD](https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto)",
+    "category": "CAD"
+  },
+  {
+    "id": "rhinoceros",
+    "name": "Rhinoceros",
+    "url": "https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white",
+    "markdown": "![Rhinoceros](https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "sketchup",
+    "name": "SketchUp",
+    "url": "https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white",
+    "markdown": "![SketchUp](https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white)",
+    "category": "CAD"
+  },
+  {
+    "id": "tinkercad",
+    "name": "Tinkercad",
+    "url": "https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white",
+    "markdown": "![Tinkercad](https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white)",
+    "category": "CAD"
   },
   {
     "id": "chipperci",
     "name": "ChipperCI",
     "url": "https://img.shields.io/badge/chipperci-1e394e.svg?style=for-the-badge&logo=chipperci&logoColor=white",
     "markdown": "![ChipperCI](https://img.shields.io/badge/chipperci-1e394e.svg?style=for-the-badge&logo=chipperci&logoColor=white)",
+    "category": "CI"
+  },
+  {
+    "id": "circleci",
+    "name": "CircleCI",
+    "url": "https://img.shields.io/badge/circle%20ci-%23161616.svg?style=for-the-badge&logo=circleci&logoColor=white",
+    "markdown": "![CircleCI](https://img.shields.io/badge/circle%20ci-%23161616.svg?style=for-the-badge&logo=circleci&logoColor=white)",
     "category": "CI"
   },
   {
@@ -217,10 +448,10 @@
     "category": "CI"
   },
   {
-    "id": "gitlab-ci",
-    "name": "GitLab CI",
-    "url": "https://img.shields.io/badge/gitlab%20CI-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white",
-    "markdown": "![GitLab CI](https://img.shields.io/badge/gitlab%20CI-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white)",
+    "id": "fastlane",
+    "name": "Fastlane",
+    "url": "https://img.shields.io/badge/fastlane-%2382bd4e.svg?style=for-the-badge&logo=fastlane&logoColor=black",
+    "markdown": "![Fastlane](https://img.shields.io/badge/fastlane-%2382bd4e.svg?style=for-the-badge&logo=fastlane&logoColor=black)",
     "category": "CI"
   },
   {
@@ -228,6 +459,13 @@
     "name": "GitHub Actions",
     "url": "https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white",
     "markdown": "![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white)",
+    "category": "CI"
+  },
+  {
+    "id": "gitlab-ci",
+    "name": "GitLab CI",
+    "url": "https://img.shields.io/badge/gitlab%20ci-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white",
+    "markdown": "![GitLab CI](https://img.shields.io/badge/gitlab%20ci-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white)",
     "category": "CI"
   },
   {
@@ -259,6 +497,20 @@
     "category": "Cloud Storage"
   },
   {
+    "id": "backblaze",
+    "name": "Backblaze",
+    "url": "https://img.shields.io/badge/Backblaze-%23E21E29.svg?style=for-the-badge&logo=Backblaze&logoColor=white",
+    "markdown": "![Backblaze](https://img.shields.io/badge/Backblaze-%23E21E29.svg?style=for-the-badge&logo=Backblaze&logoColor=white)",
+    "category": "Cloud Storage"
+  },
+  {
+    "id": "box",
+    "name": "Box",
+    "url": "https://img.shields.io/badge/box-%230061D5.svg?style=for-the-badge&logo=box&logoColor=white",
+    "markdown": "![Box](https://img.shields.io/badge/box-%230061D5.svg?style=for-the-badge&logo=box&logoColor=white)",
+    "category": "Cloud Storage"
+  },
+  {
     "id": "dropbox",
     "name": "Dropbox",
     "url": "https://img.shields.io/badge/Dropbox-%233B4D98.svg?style=for-the-badge&logo=Dropbox&logoColor=white",
@@ -270,6 +522,13 @@
     "name": "Google Drive",
     "url": "https://img.shields.io/badge/Google%20Drive-4285F4?style=for-the-badge&logo=googledrive&logoColor=white",
     "markdown": "![Google Drive](https://img.shields.io/badge/Google%20Drive-4285F4?style=for-the-badge&logo=googledrive&logoColor=white)",
+    "category": "Cloud Storage"
+  },
+  {
+    "id": "icloud",
+    "name": "iCloud",
+    "url": "https://img.shields.io/badge/icloud-%233693F3.svg?style=for-the-badge&logo=icloud&logoColor=white",
+    "markdown": "![iCloud](https://img.shields.io/badge/icloud-%233693F3.svg?style=for-the-badge&logo=icloud&logoColor=white)",
     "category": "Cloud Storage"
   },
   {
@@ -315,10 +574,17 @@
     "category": "Cryptocurrency"
   },
   {
-    "id": "bitcoin",
+    "id": "binance",
+    "name": "Binance",
+    "url": "https://img.shields.io/badge/Binance-FCD535?style=for-the-badge&logo=binance&logoColor=white",
+    "markdown": "![Binance](https://img.shields.io/badge/Binance-FCD535?style=for-the-badge&logo=binance&logoColor=white)",
+    "category": "Cryptocurrency"
+  },
+  {
+    "id": "bitcoin-cryptocurrency",
     "name": "Bitcoin",
-    "url": "https://img.shields.io/badge/bitcoin-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white",
-    "markdown": "![Bitcoin](https://img.shields.io/badge/bitcoin-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white)",
+    "url": "https://img.shields.io/badge/Bitcoin-000?style=for-the-badge&logo=bitcoin&logoColor=white",
+    "markdown": "![Bitcoin](https://img.shields.io/badge/Bitcoin-000?style=for-the-badge&logo=bitcoin&logoColor=white)",
     "category": "Cryptocurrency"
   },
   {
@@ -336,13 +602,6 @@
     "category": "Cryptocurrency"
   },
   {
-    "id": "binance",
-    "name": "Binance",
-    "url": "https://img.shields.io/badge/Binance-FCD535?style=for-the-badge&logo=binance&logoColor=white",
-    "markdown": "![Binance](https://img.shields.io/badge/Binance-FCD535?style=for-the-badge&logo=binance&logoColor=white)",
-    "category": "Cryptocurrency"
-  },
-  {
     "id": "chainlink",
     "name": "Chainlink",
     "url": "https://img.shields.io/badge/Chainlink-375BD2?style=for-the-badge&logo=Chainlink&logoColor=white",
@@ -350,17 +609,17 @@
     "category": "Cryptocurrency"
   },
   {
-    "id": "dogecoin",
-    "name": "Dogecoin",
-    "url": "https://img.shields.io/badge/dogecoin-B59A30?style=for-the-badge&logo=dogecoin&logoColor=white",
-    "markdown": "![Dogecoin](https://img.shields.io/badge/dogecoin-B59A30?style=for-the-badge&logo=dogecoin&logoColor=white)",
-    "category": "Cryptocurrency"
-  },
-  {
     "id": "dash",
     "name": "Dash",
     "url": "https://img.shields.io/badge/dash-008DE4?style=for-the-badge&logo=dash&logoColor=white",
     "markdown": "![Dash](https://img.shields.io/badge/dash-008DE4?style=for-the-badge&logo=dash&logoColor=white)",
+    "category": "Cryptocurrency"
+  },
+  {
+    "id": "dogecoin",
+    "name": "Dogecoin",
+    "url": "https://img.shields.io/badge/dogecoin-B59A30?style=for-the-badge&logo=dogecoin&logoColor=white",
+    "markdown": "![Dogecoin](https://img.shields.io/badge/dogecoin-B59A30?style=for-the-badge&logo=dogecoin&logoColor=white)",
     "category": "Cryptocurrency"
   },
   {
@@ -396,6 +655,13 @@
     "name": "Polkadot",
     "url": "https://img.shields.io/badge/polkadot-E6007A?style=for-the-badge&logo=polkadot&logoColor=white",
     "markdown": "![Polkadot](https://img.shields.io/badge/polkadot-E6007A?style=for-the-badge&logo=polkadot&logoColor=white)",
+    "category": "Cryptocurrency"
+  },
+  {
+    "id": "rarible",
+    "name": "Rarible",
+    "url": "https://img.shields.io/badge/rarible-%23FEDA03.svg?style=for-the-badge&logo=rarible&logoColor=black",
+    "markdown": "![Rarible](https://img.shields.io/badge/rarible-%23FEDA03.svg?style=for-the-badge&logo=rarible&logoColor=black)",
     "category": "Cryptocurrency"
   },
   {
@@ -455,6 +721,13 @@
     "category": "Databases"
   },
   {
+    "id": "clickhouse",
+    "name": "ClickHouse",
+    "url": "https://img.shields.io/badge/ClickHouse-FFCC01?style=for-the-badge&logo=clickhouse&logoColor=white",
+    "markdown": "![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC01?style=for-the-badge&logo=clickhouse&logoColor=white)",
+    "category": "Databases"
+  },
+  {
     "id": "cockroach-labs",
     "name": "Cockroach Labs",
     "url": "https://img.shields.io/badge/Cockroach%20Labs-6933FF?style=for-the-badge&logo=Cockroach%20Labs&logoColor=white",
@@ -466,6 +739,20 @@
     "name": "Couchbase",
     "url": "https://img.shields.io/badge/Couchbase-EA2328?style=for-the-badge&logo=couchbase&logoColor=white",
     "markdown": "![Couchbase](https://img.shields.io/badge/Couchbase-EA2328?style=for-the-badge&logo=couchbase&logoColor=white)",
+    "category": "Databases"
+  },
+  {
+    "id": "cratedb",
+    "name": "CrateDB",
+    "url": "https://img.shields.io/badge/CrateDB-009DC7?style=for-the-badge&logo=CrateDB&logoColor=white",
+    "markdown": "![CrateDB](https://img.shields.io/badge/CrateDB-009DC7?style=for-the-badge&logo=CrateDB&logoColor=white)",
+    "category": "Databases"
+  },
+  {
+    "id": "duckdb",
+    "name": "DuckDB",
+    "url": "https://img.shields.io/badge/duckdb-%23FFF000.svg?style=for-the-badge&logo=duckdb&logoColor=black",
+    "markdown": "![Duckdb](https://img.shields.io/badge/duckdb-%23FFF000.svg?style=for-the-badge&logo=duckdb&logoColor=black)",
     "category": "Databases"
   },
   {
@@ -490,13 +777,6 @@
     "category": "Databases"
   },
   {
-    "id": "musicbrainz",
-    "name": "MusicBrainz",
-    "url": "https://img.shields.io/badge/Musicbrainz-EB743B?style=for-the-badge&logo=musicbrainz&logoColor=BA478F",
-    "markdown": "![MusicBrainz](https://img.shields.io/badge/Musicbrainz-EB743B?style=for-the-badge&logo=musicbrainz&logoColor=BA478F)",
-    "category": "Databases"
-  },
-  {
     "id": "microsoft-sql-server",
     "name": "Microsoft SQL Server",
     "url": "https://img.shields.io/badge/Microsoft%20SQL%20Server-CC2927?style=for-the-badge&logo=microsoft%20sql%20server&logoColor=white",
@@ -508,6 +788,13 @@
     "name": "MongoDB",
     "url": "https://img.shields.io/badge/MongoDB-%234ea94b.svg?style=for-the-badge&logo=mongodb&logoColor=white",
     "markdown": "![MongoDB](https://img.shields.io/badge/MongoDB-%234ea94b.svg?style=for-the-badge&logo=mongodb&logoColor=white)",
+    "category": "Databases"
+  },
+  {
+    "id": "musicbrainz",
+    "name": "MusicBrainz",
+    "url": "https://img.shields.io/badge/Musicbrainz-EB743B?style=for-the-badge&logo=musicbrainz&logoColor=BA478F",
+    "markdown": "![MusicBrainz](https://img.shields.io/badge/Musicbrainz-EB743B?style=for-the-badge&logo=musicbrainz&logoColor=BA478F)",
     "category": "Databases"
   },
   {
@@ -529,6 +816,13 @@
     "name": "PlanetScale",
     "url": "https://img.shields.io/badge/planetscale-%23000000.svg?style=for-the-badge&logo=planetscale&logoColor=white",
     "markdown": "![PlanetScale](https://img.shields.io/badge/planetscale-%23000000.svg?style=for-the-badge&logo=planetscale&logoColor=white)",
+    "category": "Databases"
+  },
+  {
+    "id": "pocketbase",
+    "name": "PocketBase",
+    "url": "https://img.shields.io/badge/pocketbase-%23b8dbe4.svg?style=for-the-badge&logo=Pocketbase&logoColor=black",
+    "markdown": "![PocketBase](https://img.shields.io/badge/pocketbase-%23b8dbe4.svg?style=for-the-badge&logo=Pocketbase&logoColor=black)",
     "category": "Databases"
   },
   {
@@ -646,8 +940,8 @@
   {
     "id": "adobe-indesign",
     "name": "Adobe InDesign",
-    "url": "https://img.shields.io/badge/Adobe%20InDesign-49021F?style=for-the-badge&logo=adobeindesign&logoColor=FF3366",
-    "markdown": "![Adobe InDesign](https://img.shields.io/badge/Adobe%20InDesign-49021F?style=for-the-badge&logo=adobeindesign&logoColor=FF3366)",
+    "url": "https://img.shields.io/badge/Adobe%20InDesign-49021F?style=for-the-badge&logo=adobeindesign&logoColor=white",
+    "markdown": "![Adobe InDesign](https://img.shields.io/badge/Adobe%20InDesign-49021F?style=for-the-badge&logo=adobeindesign&logoColor=white)",
     "category": "Design"
   },
   {
@@ -686,13 +980,6 @@
     "category": "Design"
   },
   {
-    "id": "aseprite",
-    "name": "Aseprite",
-    "url": "https://img.shields.io/badge/Aseprite-FFFFFF?style=for-the-badge&logo=Aseprite&logoColor=#7D929E",
-    "markdown": "![Aseprite](https://img.shields.io/badge/Aseprite-FFFFFF?style=for-the-badge&logo=Aseprite&logoColor=#7D929E)",
-    "category": "Design"
-  },
-  {
     "id": "affinity-designer",
     "name": "Affinity Designer",
     "url": "https://img.shields.io/badge/affinity%20desginer-%231B72BE.svg?style=for-the-badge&logo=affinity-designer&logoColor=white",
@@ -704,6 +991,13 @@
     "name": "Affinity Photo",
     "url": "https://img.shields.io/badge/affinityphoto-%237E4DD2.svg?style=for-the-badge&logo=affinity-photo&logoColor=white",
     "markdown": "![Affinity Photo](https://img.shields.io/badge/affinityphoto-%237E4DD2.svg?style=for-the-badge&logo=affinity-photo&logoColor=white)",
+    "category": "Design"
+  },
+  {
+    "id": "aseprite",
+    "name": "Aseprite",
+    "url": "https://img.shields.io/badge/Aseprite-FFFFFF?style=for-the-badge&logo=Aseprite&logoColor=#7D929E",
+    "markdown": "![Aseprite](https://img.shields.io/badge/Aseprite-FFFFFF?style=for-the-badge&logo=Aseprite&logoColor=#7D929E)",
     "category": "Design"
   },
   {
@@ -721,10 +1015,24 @@
     "category": "Design"
   },
   {
+    "id": "clip-studio-paint",
+    "name": "Clip Studio Paint",
+    "url": "https://img.shields.io/badge/ClipStudioPaint-%23CFD3D3.svg?style=for-the-badge&logo=ClipStudioPaint&logoColor=white",
+    "markdown": "![Clip Studio Paint](https://img.shields.io/badge/ClipStudioPaint-%23CFD3D3.svg?style=for-the-badge&logo=ClipStudioPaint&logoColor=white)",
+    "category": "Design"
+  },
+  {
+    "id": "davinci-resolve",
+    "name": "DaVinci Resolve",
+    "url": "https://img.shields.io/badge/davinci_resolve-%23233A51.svg?style=for-the-badge&logo=davinciresolve&logoColor=white",
+    "markdown": "![DaVinci Resolve](https://img.shields.io/badge/davinci_resolve-%23233A51.svg?style=for-the-badge&logo=davinciresolve&logoColor=white)",
+    "category": "Design"
+  },
+  {
     "id": "drawio",
     "name": "Drawio",
-    "url": "https://img.shields.io/badge/-drawio-%23F08705?style=for-the-badge&logo=diagrams.net&logoColor=white",
-    "markdown": "![Drawio](https://img.shields.io/badge/-drawio-%23F08705?style=for-the-badge&logo=diagrams.net&logoColor=white)",
+    "url": "https://img.shields.io/badge/drawio-%23F08705?style=for-the-badge&logo=diagrams.net&logoColor=white",
+    "markdown": "![Drawio](https://img.shields.io/badge/drawio-%23F08705?style=for-the-badge&logo=diagrams.net&logoColor=white)",
     "category": "Design"
   },
   {
@@ -752,7 +1060,7 @@
     "id": "gimp",
     "name": "Gimp",
     "url": "https://img.shields.io/badge/Gimp-657D8B?style=for-the-badge&logo=gimp&logoColor=FFFFFF",
-    "markdown": "![Gimp](https://img.shields.io/badge/Gimp-657D8B?style=for-the-badge&logo=gimp&logoColor=FFFFFF)",
+    "markdown": "![Gimp Gnu Image Manipulation Program](https://img.shields.io/badge/Gimp-657D8B?style=for-the-badge&logo=gimp&logoColor=FFFFFF)",
     "category": "Design"
   },
   {
@@ -778,7 +1086,7 @@
   },
   {
     "id": "penpot",
-    "name": "penpot",
+    "name": "Penpot",
     "url": "https://img.shields.io/badge/penpot-%23FFFFFF.svg?style=for-the-badge&logo=penpot&logoColor=black",
     "markdown": "![Penpot](https://img.shields.io/badge/penpot-%23FFFFFF.svg?style=for-the-badge&logo=penpot&logoColor=black)",
     "category": "Design"
@@ -791,10 +1099,24 @@
     "category": "Design"
   },
   {
+    "id": "rhinoceros-design",
+    "name": "Rhinoceros",
+    "url": "https://img.shields.io/badge/Rhinoceros-801010?style=for-the-badge&logo=rhinoceros&logoColor=white",
+    "markdown": "![Rhinoceros](https://img.shields.io/badge/Rhinoceros-801010?style=for-the-badge&logo=rhinoceros&logoColor=white)",
+    "category": "Design"
+  },
+  {
     "id": "sketch",
     "name": "Sketch",
     "url": "https://img.shields.io/badge/Sketch-FFB387?style=for-the-badge&logo=sketch&logoColor=black",
     "markdown": "![Sketch](https://img.shields.io/badge/Sketch-FFB387?style=for-the-badge&logo=sketch&logoColor=black)",
+    "category": "Design"
+  },
+  {
+    "id": "sketch-up",
+    "name": "Sketch Up",
+    "url": "https://img.shields.io/badge/SketchUp-005F9E?style=for-the-badge&logo=sketchup&logoColor=white",
+    "markdown": "![Sketch Up](https://img.shields.io/badge/SketchUp-005F9E?style=for-the-badge&logo=sketchup&logoColor=white)",
     "category": "Design"
   },
   {
@@ -803,6 +1125,13 @@
     "url": "https://img.shields.io/badge/-Storybook-FF4785?style=for-the-badge&logo=storybook&logoColor=white",
     "markdown": "![Storybook](https://img.shields.io/badge/-Storybook-FF4785?style=for-the-badge&logo=storybook&logoColor=white)",
     "category": "Design"
+  },
+  {
+    "id": "backstage",
+    "name": "Backstage",
+    "url": "https://img.shields.io/badge/Backstage-%237A3CF8.svg?style=for-the-badge&logo=backstage&logoColor=white",
+    "markdown": "![Backstage](https://img.shields.io/badge/Backstage-%237A3CF8.svg?style=for-the-badge&logo=backstage&logoColor=white)",
+    "category": "Forums"
   },
   {
     "id": "codechef",
@@ -819,6 +1148,20 @@
     "category": "Forums"
   },
   {
+    "id": "codepen",
+    "name": "CodePen",
+    "url": "https://img.shields.io/badge/Codepen-000000?style=for-the-badge&logo=codepen&logoColor=white",
+    "markdown": "![CodePen](https://img.shields.io/badge/Codepen-000000?style=for-the-badge&logo=codepen&logoColor=white)",
+    "category": "Forums"
+  },
+  {
+    "id": "frontend-mentor",
+    "name": "Frontend Mentor",
+    "url": "https://img.shields.io/badge/Frontend_Mentor-%233F54A3.svg?style=for-the-badge&logo=frontendmentor&logoColor=white",
+    "markdown": "![Frontend Mentor](https://img.shields.io/badge/Frontend_Mentor-%233F54A3.svg?style=for-the-badge&logo=frontendmentor&logoColor=white)",
+    "category": "Forums"
+  },
+  {
     "id": "hackerearth",
     "name": "Hackerearth",
     "url": "https://img.shields.io/badge/HackerEarth-%232C3454.svg?&style=for-the-badge&logo=HackerEarth&logoColor=Blue",
@@ -826,10 +1169,10 @@
     "category": "Forums"
   },
   {
-    "id": "leetcode",
-    "name": "LeetCode",
-    "url": "https://img.shields.io/badge/Leetcode-000000?style=for-the-badge&logo=LeetCode&logoColor=#d16c06",
-    "markdown": "![LeetCode](https://img.shields.io/badge/Leetcode-000000?style=for-the-badge&logo=LeetCode&logoColor=#d16c06)",
+    "id": "hackerrank",
+    "name": "Hackerrank",
+    "url": "https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white",
+    "markdown": "![Hackerrank](https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white)",
     "category": "Forums"
   },
   {
@@ -837,6 +1180,13 @@
     "name": "Kaggle",
     "url": "https://img.shields.io/badge/Kaggle-035a7d?style=for-the-badge&logo=kaggle&logoColor=white",
     "markdown": "![Kaggle](https://img.shields.io/badge/Kaggle-035a7d?style=for-the-badge&logo=kaggle&logoColor=white)",
+    "category": "Forums"
+  },
+  {
+    "id": "leetcode",
+    "name": "LeetCode",
+    "url": "https://img.shields.io/badge/LeetCode-000000?style=for-the-badge&logo=LeetCode&logoColor=#d16c06",
+    "markdown": "![LeetCode](https://img.shields.io/badge/LeetCode-000000?style=for-the-badge&logo=LeetCode&logoColor=#d16c06)",
     "category": "Forums"
   },
   {
@@ -851,6 +1201,13 @@
     "name": "Quora",
     "url": "https://img.shields.io/badge/Quora-%23B92B27.svg?style=for-the-badge&logo=Quora&logoColor=white",
     "markdown": "![Quora](https://img.shields.io/badge/Quora-%23B92B27.svg?style=for-the-badge&logo=Quora&logoColor=white)",
+    "category": "Forums"
+  },
+  {
+    "id": "reddit",
+    "name": "Reddit",
+    "url": "https://img.shields.io/badge/Reddit-%23FF4500.svg?style=for-the-badge&logo=Reddit&logoColor=white",
+    "markdown": "![Reddit](https://img.shields.io/badge/Reddit-%23FF4500.svg?style=for-the-badge&logo=Reddit&logoColor=white)",
     "category": "Forums"
   },
   {
@@ -889,6 +1246,34 @@
     "category": "Documentation Platforms"
   },
   {
+    "id": "coda",
+    "name": "Coda",
+    "url": "https://img.shields.io/badge/coda-%23F46A54.svg?style=for-the-badge&logo=coda&logoColor=white",
+    "markdown": "![Coda](https://img.shields.io/badge/coda-%23F46A54.svg?style=for-the-badge&logo=coda&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "confluence",
+    "name": "Confluence",
+    "url": "https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white",
+    "markdown": "![Confluence](https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "docsify",
+    "name": "Docsify",
+    "url": "https://img.shields.io/badge/docsify-%232ECE53.svg?style=for-the-badge&logo=docsify&logoColor=white",
+    "markdown": "![Docsify](https://img.shields.io/badge/docsify-%232ECE53.svg?style=for-the-badge&logo=docsify&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "docusaurus",
+    "name": "Docusaurus",
+    "url": "https://img.shields.io/badge/docusaurus-%233ECC5F.svg?style=for-the-badge&logo=docusaurus&logoColor=white",
+    "markdown": "![Docusaurus](https://img.shields.io/badge/docusaurus-%233ECC5F.svg?style=for-the-badge&logo=docusaurus&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
     "id": "gitbook",
     "name": "GitBook",
     "url": "https://img.shields.io/badge/GitBook-%23000000.svg?style=for-the-badge&logo=gitbook&logoColor=white",
@@ -896,17 +1281,31 @@
     "category": "Documentation Platforms"
   },
   {
-    "id": "readthedocs-",
-    "name": "ReadTheDocs ",
-    "url": "https://img.shields.io/badge/Readthedocs-%23000000.svg?style=for-the-badge&logo=readthedocs&logoColor=white",
-    "markdown": "![ReadTheDocs](https://img.shields.io/badge/Readthedocs-%23000000.svg?style=for-the-badge&logo=readthedocs&logoColor=white)",
+    "id": "quip",
+    "name": "Quip",
+    "url": "https://img.shields.io/badge/quip-%23F27557.svg?style=for-the-badge&logo=quip&logoColor=white",
+    "markdown": "![Quip](https://img.shields.io/badge/quip-%23F27557.svg?style=for-the-badge&logo=quip&logoColor=white)",
     "category": "Documentation Platforms"
   },
   {
-    "id": "wikipedia",
-    "name": "Wikipedia",
-    "url": "https://img.shields.io/badge/Wikipedia-%23000000.svg?style=for-the-badge&logo=wikipedia&logoColor=white",
-    "markdown": "![Wikipedia](https://img.shields.io/badge/Wikipedia-%23000000.svg?style=for-the-badge&logo=wikipedia&logoColor=white)",
+    "id": "read-the-docs",
+    "name": "Read the Docs",
+    "url": "https://img.shields.io/badge/Read%20the%20Docs-%23000000?style=for-the-badge&logo=readthedocs&logoColor=white",
+    "markdown": "![Read the Docs](https://img.shields.io/badge/Read%20the%20Docs-%23000000?style=for-the-badge&logo=readthedocs&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "swagger",
+    "name": "Swagger",
+    "url": "https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white",
+    "markdown": "![Swagger](https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "tiddlywiki",
+    "name": "TiddlyWiki",
+    "url": "https://img.shields.io/badge/tiddlywiki-%23111111.svg?style=for-the-badge&logo=tiddlywiki&logoColor=white",
+    "markdown": "![TiddlyWiki](https://img.shields.io/badge/tiddlywiki-%23111111.svg?style=for-the-badge&logo=tiddlywiki&logoColor=white)",
     "category": "Documentation Platforms"
   },
   {
@@ -917,6 +1316,27 @@
     "category": "Documentation Platforms"
   },
   {
+    "id": "wikipedia",
+    "name": "Wikipedia",
+    "url": "https://img.shields.io/badge/Wikipedia-%23000000.svg?style=for-the-badge&logo=wikipedia&logoColor=white",
+    "markdown": "![Wikipedia](https://img.shields.io/badge/Wikipedia-%23000000.svg?style=for-the-badge&logo=wikipedia&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "zettlr",
+    "name": "Zettlr",
+    "url": "https://img.shields.io/badge/zettlr-%231CB27E.svg?style=for-the-badge&logo=zettlr&logoColor=white",
+    "markdown": "![Zettlr](https://img.shields.io/badge/zettlr-%231CB27E.svg?style=for-the-badge&logo=zettlr&logoColor=white)",
+    "category": "Documentation Platforms"
+  },
+  {
+    "id": "42",
+    "name": "42",
+    "url": "https://img.shields.io/badge/-42-black?style=for-the-badge&logo=42&logoColor=white",
+    "markdown": "![42](https://img.shields.io/badge/-42-black?style=for-the-badge&logo=42&logoColor=white)",
+    "category": "Education"
+  },
+  {
     "id": "codecademy",
     "name": "Codecademy",
     "url": "https://img.shields.io/badge/Codecademy-FFF0E5?style=for-the-badge&logo=codecademy&logoColor=1F243A",
@@ -924,17 +1344,17 @@
     "category": "Education"
   },
   {
+    "id": "codewars",
+    "name": "Codewars",
+    "url": "https://img.shields.io/badge/Codewars-B1361E?style=for-the-badge&logo=codewars&logoColor=grey",
+    "markdown": "![Codewars](https://img.shields.io/badge/Codewars-B1361E?style=for-the-badge&logo=codewars&logoColor=grey)",
+    "category": "Education"
+  },
+  {
     "id": "codingninjas",
     "name": "Codingninjas",
     "url": "https://img.shields.io/badge/coding%20ninjas-DD6620?style=for-the-badge&logo=codingninjas&logoColor=white",
     "markdown": "![codingninjas](https://img.shields.io/badge/coding%20ninjas-DD6620?style=for-the-badge&logo=codingninjas&logoColor=white)",
-    "category": "Education"
-  },
-  {
-    "id": "codewars",
-    "name": "Codewars",
-    "url": "https://img.shields.io/badge/Codewars-B1361E?style=for-the-badge&logo=codewars&logoColor=black",
-    "markdown": "![Codewars](https://img.shields.io/badge/Codewars-B1361E?style=for-the-badge&logo=codewars&logoColor=black)",
     "category": "Education"
   },
   {
@@ -975,8 +1395,8 @@
   {
     "id": "freecodecamp",
     "name": "FreeCodeCamp",
-    "url": "https://img.shields.io/badge/Freecodecamp-%23123.svg?style=for-the-badge&logo=freecodecamp&logoColor=green",
-    "markdown": "![FreeCodeCamp](https://img.shields.io/badge/Freecodecamp-%23123.svg?style=for-the-badge&logo=freecodecamp&logoColor=green)",
+    "url": "https://img.shields.io/badge/Freecodecamp-%23123.svg?&style=for-the-badge&logo=freecodecamp&logoColor=green",
+    "markdown": "![FreeCodeCamp](https://img.shields.io/badge/Freecodecamp-%23123.svg?&style=for-the-badge&logo=freecodecamp&logoColor=green)",
     "category": "Education"
   },
   {
@@ -990,7 +1410,7 @@
     "id": "geeksforgeeks",
     "name": "GeeksforGeeks",
     "url": "https://img.shields.io/badge/GeeksforGeeks-gray?style=for-the-badge&logo=geeksforgeeks&logoColor=35914c",
-    "markdown": "![GeeksforGeeks](https://img.shields.io/badge/GeeksforGeeks-gray?style=for-the-badge&logo=geeksforgeeks&logoColor=35914c)",
+    "markdown": "![GeeksForGeeks](https://img.shields.io/badge/GeeksforGeeks-gray?style=for-the-badge&logo=geeksforgeeks&logoColor=35914c)",
     "category": "Education"
   },
   {
@@ -1022,10 +1442,10 @@
     "category": "Education"
   },
   {
-    "id": "moodle",
-    "name": "Moodle",
-    "url": "https://img.shields.io/badge/Moodle-1000?style=for-the-badge&logo=Moodle&logoColor=ffffff&labelColor=f98012&color=f98012",
-    "markdown": "![Moodle](https://img.shields.io/badge/Moodle-1000?style=for-the-badge&logo=Moodle&logoColor=ffffff&labelColor=f98012&color=f98012)",
+    "id": "o'reilly",
+    "name": "O'Reilly",
+    "url": "https://img.shields.io/badge/O'Reilly-%23D30000.svg?style=for-the-badge&logo=o%27reilly&logoColor=F1F1F1",
+    "markdown": "![O'Reilly](https://img.shields.io/badge/O'Reilly-%23D30000.svg?style=for-the-badge&logo=o%27reilly&logoColor=F1F1F1)",
     "category": "Education"
   },
   {
@@ -1050,6 +1470,20 @@
     "category": "Education"
   },
   {
+    "id": "sololearn",
+    "name": "Sololearn",
+    "url": "https://img.shields.io/badge/Sololearn-149EF2?style=for-the-badge&logo=sololearn&logoColor=white",
+    "markdown": "![Sololearn](https://img.shields.io/badge/Sololearn-149EF2?style=for-the-badge&logo=sololearn&logoColor=white)",
+    "category": "Education"
+  },
+  {
+    "id": "the-odin-project",
+    "name": "The Odin Project",
+    "url": "https://img.shields.io/badge/the_odin_project-%23A9792B.svg?style=for-the-badge&logo=theodinproject&logoColor=white",
+    "markdown": "![The Odin Project](https://img.shields.io/badge/the_odin_project-%23A9792B.svg?style=for-the-badge&logo=theodinproject&logoColor=white)",
+    "category": "Education"
+  },
+  {
     "id": "udacity",
     "name": "Udacity",
     "url": "https://img.shields.io/badge/Udacity-grey?style=for-the-badge&logo=udacity&logoColor=15B8E6",
@@ -1061,6 +1495,13 @@
     "name": "Udemy",
     "url": "https://img.shields.io/badge/Udemy-A435F0?style=for-the-badge&logo=Udemy&logoColor=white",
     "markdown": "![Udemy](https://img.shields.io/badge/Udemy-A435F0?style=for-the-badge&logo=Udemy&logoColor=white)",
+    "category": "Education"
+  },
+  {
+    "id": "w3-schools",
+    "name": "W3 Schools",
+    "url": "https://img.shields.io/badge/W3%20Schools-04AA6D?style=for-the-badge&logo=w3schools&logoColor=white",
+    "markdown": "![W3 Schools](https://img.shields.io/badge/W3%20Schools-04AA6D?style=for-the-badge&logo=w3schools&logoColor=white)",
     "category": "Education"
   },
   {
@@ -1148,10 +1589,17 @@
     "category": "Funding"
   },
   {
+    "id": "stripe",
+    "name": "Stripe",
+    "url": "https://img.shields.io/badge/Stripe-5469d4?style=for-the-badge&logo=stripe&logoColor=ffffff",
+    "markdown": "![Stripe](https://img.shields.io/badge/Stripe-5469d4?style=for-the-badge&logo=stripe&logoColor=ffffff)",
+    "category": "Funding"
+  },
+  {
     "id": "wise",
     "name": "Wise",
-    "url": "https://img.shields.io/badge/wise-394e79?style=for-the-badge&logo=wise&logoColor=00B9FF",
-    "markdown": "![Wise](https://img.shields.io/badge/wise-394e79?style=for-the-badge&logo=wise&logoColor=00B9FF)",
+    "url": "https://img.shields.io/badge/Wise-394e79?style=for-the-badge&logo=wise&logoColor=00B9FF",
+    "markdown": "![Wise](https://img.shields.io/badge/Wise-394e79?style=for-the-badge&logo=wise&logoColor=00B9FF)",
     "category": "Funding"
   },
   {
@@ -1169,10 +1617,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "aiohttp",
-    "name": "Aiohttp",
-    "url": "https://img.shields.io/badge/aiohttp-%232C5bb4.svg?style=for-the-badge&logo=aiohttp&logoColor=white",
-    "markdown": "[Aiohttp](https://img.shields.io/badge/aiohttp-%232C5bb4.svg?style=for-the-badge&logo=aiohttp&logoColor=white)",
+    "id": "ajv",
+    "name": "Ajv",
+    "url": "https://img.shields.io/badge/ajv-%23C21325.svg?style=for-the-badge&logo=ajv&logoColor=white",
+    "markdown": "![Ajv](https://img.shields.io/badge/ajv-%23C21325.svg?style=for-the-badge&logo=ajv&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1183,10 +1631,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "amd-hip",
-    "name": "AMD HIP",
-    "url": "https://img.shields.io/badge/HIP-%23000000.svg?style=for-the-badge&logo=amd&logoColor=white&logoSize=auto",
-    "markdown": "![AMD HIP](https://img.shields.io/badge/HIP-%23000000.svg?style=for-the-badge&logo=amd&logoColor=white&logoSize=auto)",
+    "id": "amd",
+    "name": "AMD",
+    "url": "https://img.shields.io/badge/amd-%23ED1C24.svg?style=for-the-badge&logo=amd&logoColor=white",
+    "markdown": "![AMD](https://img.shields.io/badge/amd-%23ED1C24.svg?style=for-the-badge&logo=amd&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1197,38 +1645,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "angular",
-    "name": "Angular",
-    "url": "https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white",
-    "markdown": "![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
     "id": "angular.js",
     "name": "Angular.js",
     "url": "https://img.shields.io/badge/angular.js-%23E23237.svg?style=for-the-badge&logo=angularjs&logoColor=white",
     "markdown": "![Angular.js](https://img.shields.io/badge/angular.js-%23E23237.svg?style=for-the-badge&logo=angularjs&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "ant-design",
-    "name": "Ant Design",
-    "url": "https://img.shields.io/badge/-AntDesign-%230170FE?style=for-the-badge&logo=ant-design&logoColor=white",
-    "markdown": "![Ant-Design](https://img.shields.io/badge/-AntDesign-%230170FE?style=for-the-badge&logo=ant-design&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "apache-spark",
-    "name": "Apache Spark",
-    "url": "https://img.shields.io/badge/Apache%20Spark-FDEE21?style=for-the-badge&logo=apachespark&logoColor=black",
-    "markdown": "![Apache Spark](https://img.shields.io/badge/Apache%20Spark-FDEE21?style=for-the-badge&logo=apachespark&logoColor=black)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "apache-kafka",
-    "name": "Apache Kafka",
-    "url": "https://img.shields.io/badge/Apache%20Kafka-000?style=for-the-badge&logo=apachekafka",
-    "markdown": "![Apache Kafka](https://img.shields.io/badge/Apache%20Kafka-000?style=for-the-badge&logo=apachekafka)",
     "category": "Frameworks"
   },
   {
@@ -1246,6 +1666,20 @@
     "category": "Frameworks"
   },
   {
+    "id": "apache-kafka",
+    "name": "Apache Kafka",
+    "url": "https://img.shields.io/badge/Apache%20Kafka-000?style=for-the-badge&logo=apachekafka",
+    "markdown": "![Apache Kafka](https://img.shields.io/badge/Apache%20Kafka-000?style=for-the-badge&logo=apachekafka)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "apache-spark",
+    "name": "Apache Spark",
+    "url": "https://img.shields.io/badge/Apache%20Spark-FDEE21?style=flat-square&logo=apachespark&logoColor=black",
+    "markdown": "![Apache Spark](https://img.shields.io/badge/Apache%20Spark-FDEE21?style=flat-square&logo=apachespark&logoColor=black)",
+    "category": "Frameworks"
+  },
+  {
     "id": "apollo-graphql",
     "name": "Apollo GraphQL",
     "url": "https://img.shields.io/badge/-ApolloGraphQL-311C87?style=for-the-badge&logo=apollo-graphql",
@@ -1253,10 +1687,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "astro",
-    "name": "Astro",
-    "url": "https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white",
-    "markdown": "![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)",
+    "id": "arm",
+    "name": "Arm",
+    "url": "https://img.shields.io/badge/arm-%230091BD.svg?style=for-the-badge&logo=arm&logoColor=white",
+    "markdown": "![Arm](https://img.shields.io/badge/arm-%230091BD.svg?style=for-the-badge&logo=arm&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1267,6 +1701,20 @@
     "category": "Frameworks"
   },
   {
+    "id": "biome",
+    "name": "Biome",
+    "url": "https://img.shields.io/badge/biome-%2360A5FA.svg?style=for-the-badge&logo=biome&logoColor=white",
+    "markdown": "![Biome](https://img.shields.io/badge/biome-%2360A5FA.svg?style=for-the-badge&logo=biome&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "black",
+    "name": "Black",
+    "url": "https://img.shields.io/badge/black-%23000000.svg?style=for-the-badge&logo=black&logoColor=white",
+    "markdown": "![Black](https://img.shields.io/badge/black-%23000000.svg?style=for-the-badge&logo=black&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
     "id": "blazor",
     "name": "Blazor",
     "url": "https://img.shields.io/badge/blazor-%235C2D91.svg?style=for-the-badge&logo=blazor&logoColor=white",
@@ -1274,31 +1722,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "bootstrap",
-    "name": "Bootstrap",
-    "url": "https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white",
-    "markdown": "![Bootstrap](https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
     "id": "buefy",
     "name": "Buefy",
     "url": "https://img.shields.io/badge/Buefy-7957D5?style=for-the-badge&logo=buefy&logoColor=48289E",
     "markdown": "![Buefy](https://img.shields.io/badge/Buefy-7957D5?style=for-the-badge&logo=buefy&logoColor=48289E)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "bulma",
-    "name": "Bulma",
-    "url": "https://img.shields.io/badge/bulma-00D0B1?style=for-the-badge&logo=bulma&logoColor=white",
-    "markdown": "![Bulma](https://img.shields.io/badge/bulma-00D0B1?style=for-the-badge&logo=bulma&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "bun",
-    "name": "Bun",
-    "url": "https://img.shields.io/badge/Bun-%23000000.svg?style=for-the-badge&logo=bun&logoColor=white",
-    "markdown": "![Bun](https://img.shields.io/badge/Bun-%23000000.svg?style=for-the-badge&logo=bun&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1323,13 +1750,6 @@
     "category": "Frameworks"
   },
   {
-    "id": "clerk",
-    "name": "Clerk",
-    "url": "https://img.shields.io/badge/Clerk-6C47FF?style=for-the-badge&logo=clerk&logoColor=white",
-    "markdown": "![Clerk](https://img.shields.io/badge/Clerk-6C47FF?style=for-the-badge&logo=clerk&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
     "id": "code-igniter",
     "name": "Code Igniter",
     "url": "https://img.shields.io/badge/CodeIgniter-%23EF4223.svg?style=for-the-badge&logo=codeIgniter&logoColor=white",
@@ -1337,10 +1757,38 @@
     "category": "Frameworks"
   },
   {
+    "id": "composer",
+    "name": "Composer",
+    "url": "https://img.shields.io/badge/composer-%23885630.svg?style=for-the-badge&logo=composer&logoColor=white",
+    "markdown": "![Composer](https://img.shields.io/badge/composer-%23885630.svg?style=for-the-badge&logo=composer&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "conan",
+    "name": "Conan",
+    "url": "https://img.shields.io/badge/conan-%236699CB.svg?style=for-the-badge&logo=conan&logoColor=white",
+    "markdown": "![Conan](https://img.shields.io/badge/conan-%236699CB.svg?style=for-the-badge&logo=conan&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
     "id": "context-api",
     "name": "Context API",
     "url": "https://img.shields.io/badge/Context--Api-000000?style=for-the-badge&logo=react",
     "markdown": "![Context-API](https://img.shields.io/badge/Context--Api-000000?style=for-the-badge&logo=react)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "cuda",
+    "name": "CUDA",
+    "url": "https://img.shields.io/badge/cuda-000000.svg?style=for-the-badge&logo=nVIDIA&logoColor=green",
+    "markdown": "![nVIDIA](https://img.shields.io/badge/cuda-000000.svg?style=for-the-badge&logo=nVIDIA&logoColor=green)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "d3.js",
+    "name": "D3.js",
+    "url": "https://img.shields.io/badge/D3.JS-%23000000?style=for-the-badge&logo=D3&logoColor=#ff823e",
+    "markdown": "![D3.js](https://img.shields.io/badge/D3.JS-%23000000?style=for-the-badge&logo=D3&logoColor=#ff823e)",
     "category": "Frameworks"
   },
   {
@@ -1365,13 +1813,6 @@
     "category": "Frameworks"
   },
   {
-    "id": "django",
-    "name": "Django",
-    "url": "https://img.shields.io/badge/django-%23092E20.svg?style=for-the-badge&logo=django&logoColor=white",
-    "markdown": "![Django](https://img.shields.io/badge/django-%23092E20.svg?style=for-the-badge&logo=django&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
     "id": "djangorest",
     "name": "DjangoREST",
     "url": "https://img.shields.io/badge/DJANGO-REST-ff1709?style=for-the-badge&logo=django&logoColor=white&color=ff1709&labelColor=gray",
@@ -1383,6 +1824,20 @@
     "name": "Drupal",
     "url": "https://img.shields.io/badge/drupal-%230678BE.svg?style=for-the-badge&logo=drupal&logoColor=white",
     "markdown": "![Drupal](https://img.shields.io/badge/drupal-%230678BE.svg?style=for-the-badge&logo=drupal&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "ejs",
+    "name": "EJS",
+    "url": "https://img.shields.io/badge/ejs-%23B4CA65.svg?style=for-the-badge&logo=ejs&logoColor=black",
+    "markdown": "![EJS](https://img.shields.io/badge/ejs-%23B4CA65.svg?style=for-the-badge&logo=ejs&logoColor=black)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "elasticsearch",
+    "name": "Elasticsearch",
+    "url": "https://img.shields.io/badge/elasticsearch-%230377CC.svg?style=for-the-badge&logo=elasticsearch&logoColor=white",
+    "markdown": "![Elasticsearch](https://img.shields.io/badge/elasticsearch-%230377CC.svg?style=for-the-badge&logo=elasticsearch&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1400,27 +1855,6 @@
     "category": "Frameworks"
   },
   {
-    "id": "expo",
-    "name": "Expo",
-    "url": "https://img.shields.io/badge/expo-1C1E24?style=for-the-badge&logo=expo&logoColor=#D04A37",
-    "markdown": "![Expo](https://img.shields.io/badge/expo-1C1E24?style=for-the-badge&logo=expo&logoColor=#D04A37)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "express.js",
-    "name": "Express.js",
-    "url": "https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB",
-    "markdown": "![Express.js](https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "fastapi",
-    "name": "FastAPI",
-    "url": "https://img.shields.io/badge/FastAPI-005571?style=for-the-badge&logo=fastapi",
-    "markdown": "![FastAPI](https://img.shields.io/badge/FastAPI-005571?style=for-the-badge&logo=fastapi)",
-    "category": "Frameworks"
-  },
-  {
     "id": "fastify",
     "name": "Fastify",
     "url": "https://img.shields.io/badge/fastify-%23000000.svg?style=for-the-badge&logo=fastify&logoColor=white",
@@ -1430,22 +1864,29 @@
   {
     "id": "filament",
     "name": "Filament",
-    "url": "https://img.shields.io/badge/Filament-FFAA00?style=for-the-badge&logoColor=%23000000",
-    "markdown": "![Filament](https://img.shields.io/badge/Filament-FFAA00?style=for-the-badge&logoColor=%23000000)",
+    "url": "https://img.shields.io/badge/filament-%23FDAE4B.svg?style=for-the-badge&logo=filament&logoColor=black&logoSize=auto",
+    "markdown": "![Filament](https://img.shields.io/badge/filament-%23FDAE4B.svg?style=for-the-badge&logo=filament&logoColor=black&logoSize=auto)",
     "category": "Frameworks"
   },
   {
-    "id": "flask",
-    "name": "Flask",
-    "url": "https://img.shields.io/badge/flask-%23000.svg?style=for-the-badge&logo=flask&logoColor=white",
-    "markdown": "![Flask](https://img.shields.io/badge/flask-%23000.svg?style=for-the-badge&logo=flask&logoColor=white)",
+    "id": "flatpak",
+    "name": "Flatpak",
+    "url": "https://img.shields.io/badge/flatpak-%234A90D9.svg?style=for-the-badge&logo=flatpak&logoColor=white",
+    "markdown": "![Flatpak](https://img.shields.io/badge/flatpak-%234A90D9.svg?style=for-the-badge&logo=flatpak&logoColor=white)",
     "category": "Frameworks"
   },
   {
-    "id": "flutter",
-    "name": "Flutter",
-    "url": "https://img.shields.io/badge/Flutter-%2302569B.svg?style=for-the-badge&logo=Flutter&logoColor=white",
-    "markdown": "![Flutter](https://img.shields.io/badge/Flutter-%2302569B.svg?style=for-the-badge&logo=Flutter&logoColor=white)",
+    "id": "font-awesome",
+    "name": "Font Awesome",
+    "url": "https://img.shields.io/badge/Font_Awesome-%23538DD7.svg?style=for-the-badge&logo=fontawesome&logoColor=white",
+    "markdown": "![Font Awesome](https://img.shields.io/badge/Font_Awesome-%23538DD7.svg?style=for-the-badge&logo=fontawesome&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "framework7",
+    "name": "Framework7",
+    "url": "https://img.shields.io/badge/framework7-%23EE350F.svg?style=for-the-badge&logo=framework7&logoColor=white",
+    "markdown": "![Framework7](https://img.shields.io/badge/framework7-%23EE350F.svg?style=for-the-badge&logo=framework7&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1465,29 +1906,57 @@
   {
     "id": "green-sock",
     "name": "Green Sock",
-    "url": "https://img.shields.io/badge/green%20sock-88CE02?style=for-the-badge&logo=greensock&logoColor=white",
-    "markdown": "![Green Sock](https://img.shields.io/badge/green%20sock-88CE02?style=for-the-badge&logo=greensock&logoColor=white)",
+    "url": "https://img.shields.io/badge/green%20sock-88CE02?style=for-the-badge&logo=greensock&logoColor=black",
+    "markdown": "![Green Sock](https://img.shields.io/badge/green%20sock-88CE02?style=for-the-badge&logo=greensock&logoColor=black)",
     "category": "Frameworks"
   },
   {
-    "id": "gulp",
-    "name": "Gulp",
-    "url": "https://img.shields.io/badge/GULP-%23CF4647.svg?style=for-the-badge&logo=gulp&logoColor=white",
-    "markdown": "![Gulp](https://img.shields.io/badge/GULP-%23CF4647.svg?style=for-the-badge&logo=gulp&logoColor=white)",
+    "id": "gsap",
+    "name": "GSAP",
+    "url": "https://img.shields.io/badge/GSAP-%2388CE02.svg?style=for-the-badge&logo=greensock&logoColor=black",
+    "markdown": "![GSAP](https://img.shields.io/badge/GSAP-%2388CE02.svg?style=for-the-badge&logo=greensock&logoColor=black)",
     "category": "Frameworks"
   },
   {
-    "id": "insomnia",
-    "name": "Insomnia",
-    "url": "https://img.shields.io/badge/Insomnia-black?style=for-the-badge&logo=insomnia&logoColor=5849BE",
-    "markdown": "![Insomnia](https://img.shields.io/badge/Insomnia-black?style=for-the-badge&logo=insomnia&logoColor=5849BE)",
+    "id": "gutenberg",
+    "name": "Gutenberg",
+    "url": "https://img.shields.io/badge/gutenberg-%23077CB2.svg?style=for-the-badge&logo=gutenberg&logoColor=white",
+    "markdown": "![Gutenberg](https://img.shields.io/badge/gutenberg-%23077CB2.svg?style=for-the-badge&logo=gutenberg&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "handlebars",
+    "name": "Handlebars",
+    "url": "https://img.shields.io/badge/Handlebars-%23000000?style=for-the-badge&logo=Handlebars.js&logoColor=white",
+    "markdown": "![Handlebars](https://img.shields.io/badge/Handlebars-%23000000?style=for-the-badge&logo=Handlebars.js&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "helm",
+    "name": "Helm",
+    "url": "https://img.shields.io/badge/helm-%230F1689.svg?style=for-the-badge&logo=helm&logoColor=white",
+    "markdown": "![Helm](https://img.shields.io/badge/helm-%230F1689.svg?style=for-the-badge&logo=helm&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "homebrew",
+    "name": "Homebrew",
+    "url": "https://img.shields.io/badge/homebrew-%23FBB040.svg?style=for-the-badge&logo=homebrew&logoColor=black",
+    "markdown": "![Homebrew](https://img.shields.io/badge/homebrew-%23FBB040.svg?style=for-the-badge&logo=homebrew&logoColor=black)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "hono",
+    "name": "Hono",
+    "url": "https://img.shields.io/badge/hono-%23E36002.svg?style=for-the-badge&logo=hono&logoColor=white",
+    "markdown": "![Hono](https://img.shields.io/badge/hono-%23E36002.svg?style=for-the-badge&logo=hono&logoColor=white)",
     "category": "Frameworks"
   },
   {
     "id": "htmx",
     "name": "htmx",
-    "url": "https://img.shields.io/badge/htmx-3366CC.svg?style=for-the-badge&logo=htmx&logoColor=white",
-    "markdown": "![HTMX](https://img.shields.io/badge/htmx-3366CC.svg?style=for-the-badge&logo=htmx&logoColor=white)",
+    "url": "https://img.shields.io/badge/htmx-%233366CC.svg?style=for-the-badge&logo=htmx&logoColor=white",
+    "markdown": "![htmx](https://img.shields.io/badge/htmx-%233366CC.svg?style=for-the-badge&logo=htmx&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1498,10 +1967,24 @@
     "category": "Frameworks"
   },
   {
-    "id": "ionic",
-    "name": "Ionic",
-    "url": "https://img.shields.io/badge/Ionic-%233880FF.svg?style=for-the-badge&logo=Ionic&logoColor=white",
-    "markdown": "![Ionic](https://img.shields.io/badge/Ionic-%233880FF.svg?style=for-the-badge&logo=Ionic&logoColor=white)",
+    "id": "insomnia",
+    "name": "Insomnia",
+    "url": "https://img.shields.io/badge/Insomnia-black?style=for-the-badge&logo=insomnia&logoColor=5849BE",
+    "markdown": "![Insomnia](https://img.shields.io/badge/Insomnia-black?style=for-the-badge&logo=insomnia&logoColor=5849BE)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "jamstack",
+    "name": "Jamstack",
+    "url": "https://img.shields.io/badge/jamstack-%23F0047F.svg?style=for-the-badge&logo=jamstack&logoColor=white",
+    "markdown": "![Jamstack](https://img.shields.io/badge/jamstack-%23F0047F.svg?style=for-the-badge&logo=jamstack&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "jasmine",
+    "name": "Jasmine",
+    "url": "https://img.shields.io/badge/jasmine-%238A4182.svg?style=for-the-badge&logo=jasmine&logoColor=white",
+    "markdown": "![Jasmine](https://img.shields.io/badge/jasmine-%238A4182.svg?style=for-the-badge&logo=jasmine&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1533,6 +2016,13 @@
     "category": "Frameworks"
   },
   {
+    "id": "junit5",
+    "name": "JUnit5",
+    "url": "https://img.shields.io/badge/JUnit5-f5f5f5?style=for-the-badge&logo=junit5&logoColor=dc524a",
+    "markdown": "![JUnit5](https://img.shields.io/badge/JUnit5-f5f5f5?style=for-the-badge&logo=junit5&logoColor=dc524a)",
+    "category": "Frameworks"
+  },
+  {
     "id": "jwt/json-web-token",
     "name": "JWT/JSON Web Token",
     "url": "https://img.shields.io/badge/JWT-black?style=for-the-badge&logo=JSON%20web%20tokens",
@@ -1540,10 +2030,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "laravel",
-    "name": "Laravel",
-    "url": "https://img.shields.io/badge/laravel-%23FF2D20.svg?style=for-the-badge&logo=laravel&logoColor=white",
-    "markdown": "![Laravel](https://img.shields.io/badge/laravel-%23FF2D20.svg?style=for-the-badge&logo=laravel&logoColor=white)",
+    "id": "ktor",
+    "name": "Ktor",
+    "url": "https://img.shields.io/badge/Ktor-%23087CFA.svg?style=for-the-badge&logo=Ktor&logoColor=white",
+    "markdown": "![Ktor](https://img.shields.io/badge/Ktor-%23087CFA.svg?style=for-the-badge&logo=Ktor&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1554,31 +2044,24 @@
     "category": "Frameworks"
   },
   {
+    "id": "lit",
+    "name": "Lit",
+    "url": "https://img.shields.io/badge/lit-%23324FFF.svg?style=for-the-badge&logo=lit&logoColor=white",
+    "markdown": "![Lit](https://img.shields.io/badge/lit-%23324FFF.svg?style=for-the-badge&logo=lit&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "livewire",
+    "name": "Livewire",
+    "url": "https://img.shields.io/badge/livewire-%234e56a6.svg?style=for-the-badge&logo=livewire&logoColor=white",
+    "markdown": "![Livewire](https://img.shields.io/badge/livewire-%234e56a6.svg?style=for-the-badge&logo=livewire&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
     "id": "maven",
     "name": "Maven",
     "url": "https://img.shields.io/badge/apachemaven-C71A36.svg?style=for-the-badge&logo=apachemaven&logoColor=white",
     "markdown": "![Maven](https://img.shields.io/badge/apachemaven-C71A36.svg?style=for-the-badge&logo=apachemaven&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "mui",
-    "name": "MUI",
-    "url": "https://img.shields.io/badge/MUI-%230081CB.svg?style=for-the-badge&logo=mui&logoColor=white",
-    "markdown": "![MUI](https://img.shields.io/badge/MUI-%230081CB.svg?style=for-the-badge&logo=mui&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "meteor-js",
-    "name": "Meteor JS",
-    "url": "https://img.shields.io/badge/meteorjs-%23d74c4c.svg?style=for-the-badge&logo=meteor&logoColor=white",
-    "markdown": "![Metero JS](https://img.shields.io/badge/meteorjs-%23d74c4c.svg?style=for-the-badge&logo=meteor&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "mantine",
-    "name": "Mantine",
-    "url": "https://img.shields.io/badge/Mantine-ffffff?style=for-the-badge&logo=Mantine&logoColor=339af0",
-    "markdown": "![Mantine](https://img.shields.io/badge/Mantine-ffffff?style=for-the-badge&logo=Mantine&logoColor=339af0)",
     "category": "Frameworks"
   },
   {
@@ -1589,52 +2072,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "mediapipe",
-    "name": "Mediapipe",
-    "url": "https://img.shields.io/badge/mediapipe-0097A7.svg?style=for-the-badge&logo=mediapipe&logoColor=white",
-    "markdown": "![MaxCompute](https://img.shields.io/badge/mediapipe-0097A7.svg?style=for-the-badge&logo=mediapipe&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
     "id": "nativescript",
     "name": "NativeScript",
     "url": "https://img.shields.io/badge/NativeScript-%2365ADF1?style=for-the-badge&logo=nativescript&logoColor=white",
     "markdown": "![NativeScript](https://img.shields.io/badge/NativeScript-%2365ADF1?style=for-the-badge&logo=nativescript&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "npm",
-    "name": "NPM",
-    "url": "https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white",
-    "markdown": "![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "nestjs",
-    "name": "NestJS",
-    "url": "https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white",
-    "markdown": "![NestJS](https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "next-js",
-    "name": "Next JS",
-    "url": "https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white",
-    "markdown": "![Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "node.js",
-    "name": "Node.js",
-    "url": "https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white",
-    "markdown": "![NodeJS](https://img.shields.io/badge/node.js-6DA55F?style=for-the-badge&logo=node.js&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "nodemon",
-    "name": "Nodemon",
-    "url": "https://img.shields.io/badge/NODEMON-%23323330.svg?style=for-the-badge&logo=nodemon&logoColor=%BBDEAD",
-    "markdown": "![Nodemon](https://img.shields.io/badge/NODEMON-%23323330.svg?style=for-the-badge&logo=nodemon&logoColor=%BBDEAD)",
     "category": "Frameworks"
   },
   {
@@ -1645,24 +2086,24 @@
     "category": "Frameworks"
   },
   {
-    "id": "nuxt-js",
-    "name": "Nuxt JS",
-    "url": "https://img.shields.io/badge/Nuxt-002E3B?style=for-the-badge&logo=nuxt.js&logoColor=#00DC82",
-    "markdown": "![Nuxt JS](https://img.shields.io/badge/Nuxt-002E3B?style=for-the-badge&logo=nuxt.js&logoColor=#00DC82)",
+    "id": "nodemon",
+    "name": "Nodemon",
+    "url": "https://img.shields.io/badge/NODEMON-%23323330.svg?style=for-the-badge&logo=nodemon&logoColor=%BBDEAD",
+    "markdown": "![Nodemon](https://img.shields.io/badge/NODEMON-%23323330.svg?style=for-the-badge&logo=nodemon&logoColor=%BBDEAD)",
     "category": "Frameworks"
   },
   {
-    "id": "nx",
-    "name": "Nx",
-    "url": "https://img.shields.io/badge/nx-143055?style=for-the-badge&logo=nx&logoColor=white",
-    "markdown": "![Nx](https://img.shields.io/badge/nx-143055?style=for-the-badge&logo=nx&logoColor=white)",
+    "id": "npm",
+    "name": "NPM",
+    "url": "https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white",
+    "markdown": "![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white)",
     "category": "Frameworks"
   },
   {
-    "id": "opencv",
-    "name": "OpenCV",
-    "url": "https://img.shields.io/badge/opencv-%23white.svg?style=for-the-badge&logo=opencv&logoColor=white",
-    "markdown": "![OpenCV](https://img.shields.io/badge/opencv-%23white.svg?style=for-the-badge&logo=opencv&logoColor=white)",
+    "id": "nuget",
+    "name": "NuGet",
+    "url": "https://img.shields.io/badge/nuget-%23004880.svg?style=for-the-badge&logo=nuget&logoColor=white",
+    "markdown": "![NuGet](https://img.shields.io/badge/nuget-%23004880.svg?style=for-the-badge&logo=nuget&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1683,7 +2124,14 @@
     "id": "p5js",
     "name": "P5js",
     "url": "https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF",
-    "markdown": "![P5js](https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF)",
+    "markdown": "![p5js](https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "pantheon",
+    "name": "Pantheon",
+    "url": "https://img.shields.io/badge/pantheon-%23FFDC28.svg?style=for-the-badge&logo=pantheon&logoColor=black",
+    "markdown": "![Pantheon](https://img.shields.io/badge/pantheon-%23FFDC28.svg?style=for-the-badge&logo=pantheon&logoColor=black)",
     "category": "Frameworks"
   },
   {
@@ -1691,6 +2139,34 @@
     "name": "Phoenix Framework",
     "url": "https://img.shields.io/badge/phoenixframework-%23FD4F00.svg?style=for-the-badge&logo=phoenixframework&logoColor=black",
     "markdown": "![Phoenix Framework](https://img.shields.io/badge/phoenixframework-%23FD4F00.svg?style=for-the-badge&logo=phoenixframework&logoColor=black)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "photon",
+    "name": "Photon",
+    "url": "https://img.shields.io/badge/photon-%23004480.svg?style=for-the-badge&logo=photon&logoColor=white",
+    "markdown": "![Photon](https://img.shields.io/badge/photon-%23004480.svg?style=for-the-badge&logo=photon&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "pipx",
+    "name": "pipx",
+    "url": "https://img.shields.io/badge/pipx-%232CFFAA.svg?style=for-the-badge&logo=pipx&logoColor=black",
+    "markdown": "![pipx](https://img.shields.io/badge/pipx-%232CFFAA.svg?style=for-the-badge&logo=pipx&logoColor=black)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "pkgsrc",
+    "name": "pkgsrc",
+    "url": "https://img.shields.io/badge/pkgsrc-%23FF6600.svg?style=for-the-badge&logo=pkgsrc&logoColor=white",
+    "markdown": "![pkgsrc](https://img.shields.io/badge/pkgsrc-%23FF6600.svg?style=for-the-badge&logo=pkgsrc&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "platformio",
+    "name": "PlatformIO",
+    "url": "https://img.shields.io/badge/platformio-%23000.svg?style=for-the-badge&logo=platformio&logoColor=F5822A",
+    "markdown": "![PlatformIO](https://img.shields.io/badge/platformio-%23000.svg?style=for-the-badge&logo=platformio&logoColor=F5822A)",
     "category": "Frameworks"
   },
   {
@@ -1715,10 +2191,31 @@
     "category": "Frameworks"
   },
   {
+    "id": "postcss",
+    "name": "PostCSS",
+    "url": "https://img.shields.io/badge/PostCSS-%23DD3A0A.svg?style=for-the-badge&logo=postcss&logoColor=white",
+    "markdown": "![PostCSS](https://img.shields.io/badge/PostCSS-%23DD3A0A.svg?style=for-the-badge&logo=postcss&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
     "id": "prefect",
     "name": "Prefect",
     "url": "https://img.shields.io/badge/Prefect-%23ffffff.svg?style=for-the-badge&logo=prefect&logoColor=white",
     "markdown": "![Prefect](https://img.shields.io/badge/Prefect-%23ffffff.svg?style=for-the-badge&logo=prefect&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "prettier",
+    "name": "Prettier",
+    "url": "https://img.shields.io/badge/prettier-%23192a32?style=for-the-badge&logo=prettier&logoColor=dc524a",
+    "markdown": "![Prettier](https://img.shields.io/badge/prettier-%23192a32?style=for-the-badge&logo=prettier&logoColor=dc524a)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "primefaces",
+    "name": "PrimeFaces",
+    "url": "https://img.shields.io/badge/primefaces-%23263238.svg?style=for-the-badge&logo=for-the-badge&logoColor=white",
+    "markdown": "![PrimeFaces](https://img.shields.io/badge/primefaces-%23263238.svg?style=for-the-badge&logo=for-the-badge&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1729,10 +2226,24 @@
     "category": "Frameworks"
   },
   {
+    "id": "pydantic",
+    "name": "Pydantic",
+    "url": "https://img.shields.io/badge/pydantic-%23E92063.svg?style=for-the-badge&logo=pydantic&logoColor=white",
+    "markdown": "![Pydantic](https://img.shields.io/badge/pydantic-%23E92063.svg?style=for-the-badge&logo=pydantic&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
     "id": "qt",
     "name": "Qt",
     "url": "https://img.shields.io/badge/Qt-%23217346.svg?style=for-the-badge&logo=Qt&logoColor=white",
     "markdown": "![Qt](https://img.shields.io/badge/Qt-%23217346.svg?style=for-the-badge&logo=Qt&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "quarkus",
+    "name": "Quarkus",
+    "url": "https://img.shields.io/badge/quarkus-%234794EB.svg?style=for-the-badge&logo=quarkus&logoColor=white",
+    "markdown": "![Quarkus](https://img.shields.io/badge/quarkus-%234794EB.svg?style=for-the-badge&logo=quarkus&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1743,17 +2254,17 @@
     "category": "Frameworks"
   },
   {
-    "id": "ros",
-    "name": "ROS",
-    "url": "https://img.shields.io/badge/ros-%230A0FF9.svg?style=for-the-badge&logo=ros&logoColor=white",
-    "markdown": "![ROS](https://img.shields.io/badge/ros-%230A0FF9.svg?style=for-the-badge&logo=ros&logoColor=white)",
+    "id": "qwik",
+    "name": "Qwik",
+    "url": "https://img.shields.io/badge/qwik-%23AC7EF4.svg?style=for-the-badge&logo=qwik&logoColor=white",
+    "markdown": "![Qwik](https://img.shields.io/badge/qwik-%23AC7EF4.svg?style=for-the-badge&logo=qwik&logoColor=white)",
     "category": "Frameworks"
   },
   {
     "id": "rabbitmq",
     "name": "RabbitMQ",
-    "url": "https://img.shields.io/badge/rabbitmq-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white",
-    "markdown": "![RabbitMQ](https://img.shields.io/badge/rabbitmq-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white)",
+    "url": "https://img.shields.io/badge/Rabbitmq-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white",
+    "markdown": "![RabbitMQ](https://img.shields.io/badge/Rabbitmq-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1764,24 +2275,17 @@
     "category": "Frameworks"
   },
   {
-    "id": "rails",
-    "name": "Rails",
-    "url": "https://img.shields.io/badge/rails-%23CC0000.svg?style=for-the-badge&logo=ruby-on-rails&logoColor=white",
-    "markdown": "![Rails](https://img.shields.io/badge/rails-%23CC0000.svg?style=for-the-badge&logo=ruby-on-rails&logoColor=white)",
+    "id": "raylib",
+    "name": "RayLib",
+    "url": "https://img.shields.io/badge/RAYLIB-FFFFFF?style=for-the-badge&logo=raylib&logoColor=black",
+    "markdown": "![RayLib](https://img.shields.io/badge/RAYLIB-FFFFFF?style=for-the-badge&logo=raylib&logoColor=black)",
     "category": "Frameworks"
   },
   {
-    "id": "react",
-    "name": "React",
-    "url": "https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB",
-    "markdown": "![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "react-native",
-    "name": "React Native",
-    "url": "https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB",
-    "markdown": "![React Native](https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
+    "id": "react-hook-form",
+    "name": "React Hook Form",
+    "url": "https://img.shields.io/badge/React%20Hook%20Form-%23EC5990.svg?style=for-the-badge&logo=reacthookform&logoColor=white",
+    "markdown": "![React Hook Form](https://img.shields.io/badge/React%20Hook%20Form-%23EC5990.svg?style=for-the-badge&logo=reacthookform&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1799,13 +2303,6 @@
     "category": "Frameworks"
   },
   {
-    "id": "react-hook-form",
-    "name": "React Hook Form",
-    "url": "https://img.shields.io/badge/React%20Hook%20Form-%23EC5990.svg?style=for-the-badge&logo=reacthookform&logoColor=white",
-    "markdown": "![React Hook Form](https://img.shields.io/badge/React%20Hook%20Form-%23EC5990.svg?style=for-the-badge&logo=reacthookform&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
     "id": "redux",
     "name": "Redux",
     "url": "https://img.shields.io/badge/redux-%23593d88.svg?style=for-the-badge&logo=redux&logoColor=white",
@@ -1820,17 +2317,24 @@
     "category": "Frameworks"
   },
   {
-    "id": "rollupjs",
-    "name": "RollupJS",
-    "url": "https://img.shields.io/badge/RollupJS-ef3335?style=for-the-badge&logo=rollup.js&logoColor=white",
-    "markdown": "![RollupJS](https://img.shields.io/badge/RollupJS-ef3335?style=for-the-badge&logo=rollup.js&logoColor=white)",
+    "id": "risc-v",
+    "name": "RISC-V",
+    "url": "https://img.shields.io/badge/riscv-%23283272.svg?style=for-the-badge&logo=riscv&logoColor=white",
+    "markdown": "![RISC-V](https://img.shields.io/badge/riscv-%23283272.svg?style=for-the-badge&logo=riscv&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "ros",
+    "name": "ROS",
+    "url": "https://img.shields.io/badge/ros-%230A0FF9.svg?style=for-the-badge&logo=ros&logoColor=white",
+    "markdown": "![ROS](https://img.shields.io/badge/ros-%230A0FF9.svg?style=for-the-badge&logo=ros&logoColor=white)",
     "category": "Frameworks"
   },
   {
     "id": "rxdb",
     "name": "RxDB",
-    "url": "https://img.shields.io/badge/rxdb-%238D1F89.svg?style=for-the-badge&logo=rxdb&logoColor=white",
-    "markdown": "![RxDB](https://img.shields.io/badge/rxdb-%238D1F89.svg?style=for-the-badge&logo=rxdb&logoColor=white)",
+    "url": "https://img.shields.io/badge/rxjs-%23B7178C.svg?style=for-the-badge&logo=reactivex&logoColor=white",
+    "markdown": "![RxDB](https://img.shields.io/badge/rxjs-%23B7178C.svg?style=for-the-badge&logo=reactivex&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1844,7 +2348,7 @@
     "id": "sap-commerce-cloud",
     "name": "SAP Commerce Cloud",
     "url": "https://img.shields.io/badge/SAP%20Commerce%20Cloud-%230057D2.svg?style=for-the-badge&logo=sap&logoColor=white",
-    "markdown": "![SAP](https://img.shields.io/badge/SAP%20Commerce%20Cloud-%230057D2.svg?style=for-the-badge&logo=sap&logoColor=white)",
+    "markdown": "![SAP Commerce Cloud](https://img.shields.io/badge/SAP%20Commerce%20Cloud-%230057D2.svg?style=for-the-badge&logo=sap&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1855,10 +2359,24 @@
     "category": "Frameworks"
   },
   {
+    "id": "scrapy",
+    "name": "Scrapy",
+    "url": "https://img.shields.io/badge/scrapy-%2360a839.svg?style=for-the-badge&logo=scrapy&logoColor=d1d2d3",
+    "markdown": "![Scrapy](https://img.shields.io/badge/scrapy-%2360a839.svg?style=for-the-badge&logo=scrapy&logoColor=d1d2d3)",
+    "category": "Frameworks"
+  },
+  {
     "id": "semantic-ui-react",
     "name": "Semantic UI React",
     "url": "https://img.shields.io/badge/Semantic%20UI%20React-%2335BDB2.svg?style=for-the-badge&logo=SemanticUIReact&logoColor=white",
     "markdown": "![Semantic UI React](https://img.shields.io/badge/Semantic%20UI%20React-%2335BDB2.svg?style=for-the-badge&logo=SemanticUIReact&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "snowflake",
+    "name": "Snowflake",
+    "url": "https://img.shields.io/badge/snowflake-%2329B5E8.svg?style=for-the-badge&logo=snowflake&logoColor=white",
+    "markdown": "![Snowflake](https://img.shields.io/badge/snowflake-%2329B5E8.svg?style=for-the-badge&logo=snowflake&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1873,13 +2391,6 @@
     "name": "SolidJS",
     "url": "https://img.shields.io/badge/SolidJS-2c4f7c?style=for-the-badge&logo=solid&logoColor=c8c9cb",
     "markdown": "![SolidJS](https://img.shields.io/badge/SolidJS-2c4f7c?style=for-the-badge&logo=solid&logoColor=c8c9cb)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "spring",
-    "name": "Spring",
-    "url": "https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white",
-    "markdown": "![Spring](https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1911,10 +2422,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "svelte",
-    "name": "Svelte",
-    "url": "https://img.shields.io/badge/svelte-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white",
-    "markdown": "![Svelte](https://img.shields.io/badge/svelte-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white)",
+    "id": "sveltekit",
+    "name": "SvelteKit",
+    "url": "https://img.shields.io/badge/sveltekit-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white",
+    "markdown": "![Svelte](https://img.shields.io/badge/sveltekit-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1925,24 +2436,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "tailwindcss",
-    "name": "TailwindCSS",
-    "url": "https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white",
-    "markdown": "![TailwindCSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "tauri",
-    "name": "Tauri",
-    "url": "https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF",
-    "markdown": "![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF)",
-    "category": "Frameworks"
-  },
-  {
     "id": "three.js",
     "name": "Three.js",
     "url": "https://img.shields.io/badge/threejs-black?style=for-the-badge&logo=three.js&logoColor=white",
-    "markdown": "![Three js](https://img.shields.io/badge/threejs-black?style=for-the-badge&logo=three.js&logoColor=white)",
+    "markdown": "![Threejs](https://img.shields.io/badge/threejs-black?style=for-the-badge&logo=three.js&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1956,7 +2453,14 @@
     "id": "trpc",
     "name": "tRPC",
     "url": "https://img.shields.io/badge/tRPC-%232596BE.svg?style=for-the-badge&logo=tRPC&logoColor=white",
-    "markdown": "![Badge Name](https://img.shields.io/badge/tRPC-%232596BE.svg?style=for-the-badge&logo=tRPC&logoColor=white)",
+    "markdown": "![tRPC](https://img.shields.io/badge/tRPC-%232596BE.svg?style=for-the-badge&logo=tRPC&logoColor=white)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "turborepo",
+    "name": "Turborepo",
+    "url": "https://img.shields.io/badge/turborepo-%23EF4444.svg?style=for-the-badge&logo=turborepo&logoColor=white",
+    "markdown": "![Turborepo](https://img.shields.io/badge/turborepo-%23EF4444.svg?style=for-the-badge&logo=turborepo&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1967,10 +2471,10 @@
     "category": "Frameworks"
   },
   {
-    "id": "unocss",
-    "name": "UnoCSS",
-    "url": "https://img.shields.io/badge/unocss-333333.svg?style=for-the-badge&logo=unocss&logoColor=white",
-    "markdown": "![UnoCSS](https://img.shields.io/badge/unocss-333333.svg?style=for-the-badge&logo=unocss&logoColor=white)",
+    "id": "uikit",
+    "name": "UIkit",
+    "url": "https://img.shields.io/badge/UIkit-%232396F3?style=for-the-badge&logo=uikit&logoColor=white",
+    "markdown": "![UIkit](https://img.shields.io/badge/UIkit-%232396F3?style=for-the-badge&logo=uikit&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -1981,31 +2485,38 @@
     "category": "Frameworks"
   },
   {
-    "id": "vite",
-    "name": "Vite",
-    "url": "https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white",
-    "markdown": "![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)",
+    "id": "unocss",
+    "name": "UnoCSS",
+    "url": "https://img.shields.io/badge/unocss-333333.svg?style=for-the-badge&logo=unocss&logoColor=white",
+    "markdown": "![UnoCSS](https://img.shields.io/badge/unocss-333333.svg?style=for-the-badge&logo=unocss&logoColor=white)",
     "category": "Frameworks"
   },
   {
-    "id": "vue.js",
-    "name": "Vue.js",
-    "url": "https://img.shields.io/badge/vue.js-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D",
-    "markdown": "![Vue.js](https://img.shields.io/badge/vue.js-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D)",
+    "id": "unpkg",
+    "name": "unpkg",
+    "url": "https://img.shields.io/badge/unpkg-%23000000.svg?style=for-the-badge&logo=unpkg&logoColor=white",
+    "markdown": "![unpkg](https://img.shields.io/badge/unpkg-%23000000.svg?style=for-the-badge&logo=unpkg&logoColor=white)",
     "category": "Frameworks"
   },
   {
-    "id": "vuetify",
-    "name": "Vuetify",
-    "url": "https://img.shields.io/badge/Vuetify-1867C0?style=for-the-badge&logo=vuetify&logoColor=AEDDFF",
-    "markdown": "![Vuetify](https://img.shields.io/badge/Vuetify-1867C0?style=for-the-badge&logo=vuetify&logoColor=AEDDFF)",
+    "id": "uv",
+    "name": "uv",
+    "url": "https://img.shields.io/badge/uv-%23DE5FE9.svg?style=for-the-badge&logo=uv&logoColor=white",
+    "markdown": "![uv](https://img.shields.io/badge/uv-%23DE5FE9.svg?style=for-the-badge&logo=uv&logoColor=white)",
     "category": "Frameworks"
   },
   {
-    "id": "vulkan-api",
-    "name": "Vulkan API",
+    "id": "vulkan",
+    "name": "Vulkan",
     "url": "https://img.shields.io/badge/Vulkan-AC162C.svg?style=for-the-badge&logo=vulkan&logoColor=white&logoSize=auto",
     "markdown": "![Vulkan API](https://img.shields.io/badge/Vulkan-AC162C.svg?style=for-the-badge&logo=vulkan&logoColor=white&logoSize=auto)",
+    "category": "Frameworks"
+  },
+  {
+    "id": "web3.js",
+    "name": "Web3.js",
+    "url": "https://img.shields.io/badge/web3.js-F16822?style=for-the-badge&logo=web3.js&logoColor=white",
+    "markdown": "![Web3.js](https://img.shields.io/badge/web3.js-F16822?style=for-the-badge&logo=web3.js&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -2020,20 +2531,6 @@
     "name": "WebGL",
     "url": "https://img.shields.io/badge/WebGL-990000?logo=webgl&logoColor=white&style=for-the-badge",
     "markdown": "![WebGL](https://img.shields.io/badge/WebGL-990000?logo=webgl&logoColor=white&style=for-the-badge)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "webpack",
-    "name": "Webpack",
-    "url": "https://img.shields.io/badge/webpack-%238DD6F9.svg?style=for-the-badge&logo=webpack&logoColor=black",
-    "markdown": "![Webpack](https://img.shields.io/badge/webpack-%238DD6F9.svg?style=for-the-badge&logo=webpack&logoColor=black)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "web3.js",
-    "name": "Web3.js",
-    "url": "https://img.shields.io/badge/web3.js-F16822?style=for-the-badge&logo=web3.js&logoColor=white",
-    "markdown": "![Web3.js](https://img.shields.io/badge/web3.js-F16822?style=for-the-badge&logo=web3.js&logoColor=white)",
     "category": "Frameworks"
   },
   {
@@ -2068,22 +2565,309 @@
     "id": "zod",
     "name": "Zod",
     "url": "https://img.shields.io/badge/zod-%233068b7.svg?style=for-the-badge&logo=zod&logoColor=white",
-    "markdown": "`![Zod](https://img.shields.io/badge/zod-%233068b7.svg?style=for-the-badge&logo=zod&logoColor=white)`",
+    "markdown": "![Zod](https://img.shields.io/badge/zod-%233068b7.svg?style=for-the-badge&logo=zod&logoColor=white)",
     "category": "Frameworks"
   },
   {
-    "id": "livewire",
-    "name": "Livewire",
-    "url": "https://img.shields.io/badge/livewire-%234e56a6.svg?style=for-the-badge&logo=livewire&logoColor=white",
-    "markdown": "![Livewire](https://img.shields.io/badge/livewire-%234e56a6.svg?style=for-the-badge&logo=livewire&logoColor=white)",
-    "category": "Frameworks"
+    "id": "angular",
+    "name": "Angular",
+    "url": "https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white",
+    "markdown": "![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white)",
+    "category": "Frontend"
   },
   {
-    "id": "cuda",
-    "name": "CUDA",
-    "url": "https://img.shields.io/badge/cuda-000000.svg?style=for-the-badge&logo=nVIDIA&logoColor=green",
-    "markdown": "![nVIDIA](https://img.shields.io/badge/cuda-000000.svg?style=for-the-badge&logo=nVIDIA&logoColor=green)",
-    "category": "Frameworks"
+    "id": "astro",
+    "name": "Astro",
+    "url": "https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white",
+    "markdown": "![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)",
+    "category": "Frontend"
+  },
+  {
+    "id": "next-js",
+    "name": "Next JS",
+    "url": "https://img.shields.io/badge/Next-black.svg?style=for-the-badge&logo=next.js&logoColor=white",
+    "markdown": "![Next JS](https://img.shields.io/badge/Next-black.svg?style=for-the-badge&logo=next.js&logoColor=white)",
+    "category": "Frontend"
+  },
+  {
+    "id": "nuxt-js",
+    "name": "Nuxt JS",
+    "url": "https://img.shields.io/badge/Nuxt-002E3B.svg?style=for-the-badge&logo=nuxt&logoColor=#00DC82",
+    "markdown": "![Nuxt JS](https://img.shields.io/badge/Nuxt-002E3B.svg?style=for-the-badge&logo=nuxt&logoColor=#00DC82)",
+    "category": "Frontend"
+  },
+  {
+    "id": "react",
+    "name": "React",
+    "url": "https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB",
+    "markdown": "![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
+    "category": "Frontend"
+  },
+  {
+    "id": "svelte",
+    "name": "Svelte",
+    "url": "https://img.shields.io/badge/svelte-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white",
+    "markdown": "![Svelte](https://img.shields.io/badge/svelte-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white)",
+    "category": "Frontend"
+  },
+  {
+    "id": "vue.js",
+    "name": "Vue.js",
+    "url": "https://img.shields.io/badge/vue.js-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D",
+    "markdown": "![Vue.js](https://img.shields.io/badge/vue.js-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D)",
+    "category": "Frontend"
+  },
+  {
+    "id": "ant-design",
+    "name": "Ant Design",
+    "url": "https://img.shields.io/badge/-AntDesign-%230170FE.svg?style=for-the-badge&logo=ant-design&logoColor=white",
+    "markdown": "![Ant-Design](https://img.shields.io/badge/-AntDesign-%230170FE.svg?style=for-the-badge&logo=ant-design&logoColor=white)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "bootstrap",
+    "name": "Bootstrap",
+    "url": "https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white",
+    "markdown": "![Bootstrap](https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "bulma",
+    "name": "Bulma",
+    "url": "https://img.shields.io/badge/bulma-00D0B1.svg?style=for-the-badge&logo=bulma&logoColor=white",
+    "markdown": "![Bulma](https://img.shields.io/badge/bulma-00D0B1.svg?style=for-the-badge&logo=bulma&logoColor=white)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "mantine",
+    "name": "Mantine",
+    "url": "https://img.shields.io/badge/Mantine-ffffff.svg?style=for-the-badge&logo=Mantine&logoColor=339af0",
+    "markdown": "![Mantine](https://img.shields.io/badge/Mantine-ffffff.svg?style=for-the-badge&logo=Mantine&logoColor=339af0)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "material-ui",
+    "name": "Material UI",
+    "url": "https://img.shields.io/badge/Material%20UI-%23FFFFFF.svg?style=for-the-badge&logo=MUI&logoColor=#007FFF",
+    "markdown": "![MaterialUI](https://img.shields.io/badge/Material%20UI-%23FFFFFF.svg?style=for-the-badge&logo=MUI&logoColor=#007FFF)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "shadcn/ui",
+    "name": "Shadcn/UI",
+    "url": "https://img.shields.io/badge/shadcn/ui-%23000000.svg?style=for-the-badge&logo=shadcnui&logoColor=white",
+    "markdown": "![Shadcn/ui](https://img.shields.io/badge/shadcn/ui-%23000000.svg?style=for-the-badge&logo=shadcnui&logoColor=white)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "tailwindcss",
+    "name": "TailwindCSS",
+    "url": "https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white",
+    "markdown": "![TailwindCSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "vuetify",
+    "name": "Vuetify",
+    "url": "https://img.shields.io/badge/Vuetify-1867C0.svg?style=for-the-badge&logo=vuetify&logoColor=AEDDFF",
+    "markdown": "![Vuetify](https://img.shields.io/badge/Vuetify-1867C0.svg?style=for-the-badge&logo=vuetify&logoColor=AEDDFF)",
+    "category": "CSS Frameworks"
+  },
+  {
+    "id": "django",
+    "name": "Django",
+    "url": "https://img.shields.io/badge/django-%23092E20.svg?style=for-the-badge&logo=django&logoColor=white",
+    "markdown": "![Django](https://img.shields.io/badge/django-%23092E20.svg?style=for-the-badge&logo=django&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "express.js",
+    "name": "Express.js",
+    "url": "https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB",
+    "markdown": "![Express.js](https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB)",
+    "category": "Backend"
+  },
+  {
+    "id": "fastapi",
+    "name": "FastAPI",
+    "url": "https://img.shields.io/badge/FastAPI-005571.svg?style=for-the-badge&logo=fastapi",
+    "markdown": "![FastAPI](https://img.shields.io/badge/FastAPI-005571.svg?style=for-the-badge&logo=fastapi)",
+    "category": "Backend"
+  },
+  {
+    "id": "flask",
+    "name": "Flask",
+    "url": "https://img.shields.io/badge/flask-%23000.svg?style=for-the-badge&logo=flask&logoColor=white",
+    "markdown": "![Flask](https://img.shields.io/badge/flask-%23000.svg?style=for-the-badge&logo=flask&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "laravel",
+    "name": "Laravel",
+    "url": "https://img.shields.io/badge/laravel-%23FF2D20.svg?style=for-the-badge&logo=laravel&logoColor=white",
+    "markdown": "![Laravel](https://img.shields.io/badge/laravel-%23FF2D20.svg?style=for-the-badge&logo=laravel&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "nestjs",
+    "name": "NestJS",
+    "url": "https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white",
+    "markdown": "![NestJS](https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "node.js",
+    "name": "Node.js",
+    "url": "https://img.shields.io/badge/node.js-6DA55F.svg?style=for-the-badge&logo=node.js&logoColor=white",
+    "markdown": "![NodeJS](https://img.shields.io/badge/node.js-6DA55F.svg?style=for-the-badge&logo=node.js&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "rails",
+    "name": "Rails",
+    "url": "https://img.shields.io/badge/rails-%23CC0000.svg?style=for-the-badge&logo=ruby-on-rails&logoColor=white",
+    "markdown": "![Rails](https://img.shields.io/badge/rails-%23CC0000.svg?style=for-the-badge&logo=ruby-on-rails&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "spring",
+    "name": "Spring",
+    "url": "https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white",
+    "markdown": "![Spring](https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white)",
+    "category": "Backend"
+  },
+  {
+    "id": "expo",
+    "name": "Expo",
+    "url": "https://img.shields.io/badge/expo-1C1E24.svg?style=for-the-badge&logo=expo&logoColor=#D04A37",
+    "markdown": "![Expo](https://img.shields.io/badge/expo-1C1E24.svg?style=for-the-badge&logo=expo&logoColor=#D04A37)",
+    "category": "Mobile"
+  },
+  {
+    "id": "flutter",
+    "name": "Flutter",
+    "url": "https://img.shields.io/badge/Flutter-%2302569B.svg?style=for-the-badge&logo=Flutter&logoColor=white",
+    "markdown": "![Flutter](https://img.shields.io/badge/Flutter-%2302569B.svg?style=for-the-badge&logo=Flutter&logoColor=white)",
+    "category": "Mobile"
+  },
+  {
+    "id": "ionic",
+    "name": "Ionic",
+    "url": "https://img.shields.io/badge/Ionic-%233880FF.svg?style=for-the-badge&logo=Ionic&logoColor=white",
+    "markdown": "![Ionic](https://img.shields.io/badge/Ionic-%233880FF.svg?style=for-the-badge&logo=Ionic&logoColor=white)",
+    "category": "Mobile"
+  },
+  {
+    "id": "react-native",
+    "name": "React Native",
+    "url": "https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB",
+    "markdown": "![React Native](https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
+    "category": "Mobile"
+  },
+  {
+    "id": "tauri",
+    "name": "Tauri",
+    "url": "https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF",
+    "markdown": "![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF)",
+    "category": "Mobile"
+  },
+  {
+    "id": "keras",
+    "name": "Keras",
+    "url": "https://img.shields.io/badge/Keras-D00000.svg?style=for-the-badge&logo=keras&logoColor=white",
+    "markdown": "![Keras](https://img.shields.io/badge/Keras-D00000.svg?style=for-the-badge&logo=keras&logoColor=white)",
+    "category": "ML/AI"
+  },
+  {
+    "id": "numpy",
+    "name": "NumPy",
+    "url": "https://img.shields.io/badge/NumPy-013243.svg?style=for-the-badge&logo=numpy&logoColor=white",
+    "markdown": "![NumPy](https://img.shields.io/badge/NumPy-013243.svg?style=for-the-badge&logo=numpy&logoColor=white)",
+    "category": "ML/AI"
+  },
+  {
+    "id": "opencv",
+    "name": "OpenCV",
+    "url": "https://img.shields.io/badge/opencv-%23white.svg?style=for-the-badge&logo=opencv&logoColor=white",
+    "markdown": "![OpenCV](https://img.shields.io/badge/opencv-%23white.svg?style=for-the-badge&logo=opencv&logoColor=white)",
+    "category": "ML/AI"
+  },
+  {
+    "id": "pandas",
+    "name": "Pandas",
+    "url": "https://img.shields.io/badge/Pandas-150458.svg?style=for-the-badge&logo=pandas&logoColor=white",
+    "markdown": "![Pandas](https://img.shields.io/badge/Pandas-150458.svg?style=for-the-badge&logo=pandas&logoColor=white)",
+    "category": "ML/AI"
+  },
+  {
+    "id": "pytorch",
+    "name": "PyTorch",
+    "url": "https://img.shields.io/badge/PyTorch-EE4C2C.svg?style=for-the-badge&logo=pytorch&logoColor=white",
+    "markdown": "![PyTorch](https://img.shields.io/badge/PyTorch-EE4C2C.svg?style=for-the-badge&logo=pytorch&logoColor=white)",
+    "category": "ML/AI"
+  },
+  {
+    "id": "tensorflow",
+    "name": "TensorFlow",
+    "url": "https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=tensorflow&logoColor=white",
+    "markdown": "![TensorFlow](https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=tensorflow&logoColor=white)",
+    "category": "ML/AI"
+  },
+  {
+    "id": "bun",
+    "name": "Bun",
+    "url": "https://img.shields.io/badge/Bun-%23000000.svg?style=for-the-badge&logo=bun&logoColor=white",
+    "markdown": "![Bun](https://img.shields.io/badge/Bun-%23000000.svg?style=for-the-badge&logo=bun&logoColor=white)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "esbuild",
+    "name": "ESBuild",
+    "url": "https://img.shields.io/badge/esbuild-%23FFCF00.svg?style=for-the-badge&logo=esbuild&logoColor=black",
+    "markdown": "![Esbuild](https://img.shields.io/badge/esbuild-%23FFCF00.svg?style=for-the-badge&logo=esbuild&logoColor=black)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "gulp",
+    "name": "Gulp",
+    "url": "https://img.shields.io/badge/GULP-%23CF4647.svg?style=for-the-badge&logo=gulp&logoColor=white",
+    "markdown": "![Gulp](https://img.shields.io/badge/GULP-%23CF4647.svg?style=for-the-badge&logo=gulp&logoColor=white)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "nx",
+    "name": "Nx",
+    "url": "https://img.shields.io/badge/nx-143055.svg?style=for-the-badge&logo=nx&logoColor=white",
+    "markdown": "![Nx](https://img.shields.io/badge/nx-143055.svg?style=for-the-badge&logo=nx&logoColor=white)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "rollupjs",
+    "name": "RollupJS",
+    "url": "https://img.shields.io/badge/RollupJS-ef3335.svg?style=for-the-badge&logo=rollup.js&logoColor=white",
+    "markdown": "![RollupJS](https://img.shields.io/badge/RollupJS-ef3335.svg?style=for-the-badge&logo=rollup.js&logoColor=white)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "vite",
+    "name": "Vite",
+    "url": "https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white",
+    "markdown": "![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "webpack",
+    "name": "Webpack",
+    "url": "https://img.shields.io/badge/webpack-%238DD6F9.svg?style=for-the-badge&logo=webpack&logoColor=black",
+    "markdown": "![Webpack](https://img.shields.io/badge/webpack-%238DD6F9.svg?style=for-the-badge&logo=webpack&logoColor=black)",
+    "category": "Build Tools"
+  },
+  {
+    "id": "amd-gaming",
+    "name": "AMD",
+    "url": "https://img.shields.io/badge/AMD-%23000000.svg?style=for-the-badge&logo=amd&logoColor=white",
+    "markdown": "![AMD](https://img.shields.io/badge/AMD-%23000000.svg?style=for-the-badge&logo=amd&logoColor=white)",
+    "category": "Gaming"
   },
   {
     "id": "analogue",
@@ -2097,6 +2881,13 @@
     "name": "Battle.net",
     "url": "https://img.shields.io/badge/battle.net-%2300AEFF.svg?style=for-the-badge&logo=battle.net&logoColor=white",
     "markdown": "![Battle.net](https://img.shields.io/badge/battle.net-%2300AEFF.svg?style=for-the-badge&logo=battle.net&logoColor=white)",
+    "category": "Gaming"
+  },
+  {
+    "id": "bevy",
+    "name": "Bevy",
+    "url": "https://img.shields.io/badge/bevy-%23232326.svg?style=for-the-badge&logo=bevy&logoColor=white",
+    "markdown": "![Bevy](https://img.shields.io/badge/bevy-%23232326.svg?style=for-the-badge&logo=bevy&logoColor=white)",
     "category": "Gaming"
   },
   {
@@ -2121,10 +2912,10 @@
     "category": "Gaming"
   },
   {
-    "id": "roblox",
-    "name": "Roblox",
-    "url": "https://img.shields.io/badge/Roblox-0a0b0b?style=for-the-badge&logo=Roblox&logoColor=white",
-    "markdown": "![Roblox](https://img.shields.io/badge/Roblox-0a0b0b?style=for-the-badge&logo=Roblox&logoColor=white)",
+    "id": "hearthstone-collection",
+    "name": "Hearthstone Collection",
+    "url": "https://img.shields.io/badge/Hearthstone-%23FA830D.svg?style=for-the-badge&logo=hearthstone-collection&logoColor=white",
+    "markdown": "![Hearthstone Collection](https://img.shields.io/badge/Hearthstone-%23FA830D.svg?style=for-the-badge&logo=hearthstone-collection&logoColor=white)",
     "category": "Gaming"
   },
   {
@@ -2132,6 +2923,13 @@
     "name": "Humble Bundle",
     "url": "https://img.shields.io/badge/HumbleBundle-%23494F5C.svg?style=for-the-badge&logo=HumbleBundle&logoColor=white",
     "markdown": "![Humble Bundle](https://img.shields.io/badge/HumbleBundle-%23494F5C.svg?style=for-the-badge&logo=HumbleBundle&logoColor=white)",
+    "category": "Gaming"
+  },
+  {
+    "id": "intel",
+    "name": "Intel",
+    "url": "https://img.shields.io/badge/intel-%230068B5%20.svg?style=for-the-badge&logo=intel&logoColor=white",
+    "markdown": "![Intel](https://img.shields.io/badge/intel-%230068B5%20.svg?style=for-the-badge&logo=intel&logoColor=white)",
     "category": "Gaming"
   },
   {
@@ -2149,6 +2947,13 @@
     "category": "Gaming"
   },
   {
+    "id": "opengl-gaming",
+    "name": "OpenGL",
+    "url": "https://img.shields.io/badge/OpenGL-white?logo=OpenGL&style=for-the-badge",
+    "markdown": "![OpenGL](https://img.shields.io/badge/OpenGL-white?logo=OpenGL&style=for-the-badge)",
+    "category": "Gaming"
+  },
+  {
     "id": "playstation-network",
     "name": "PlayStation Network",
     "url": "https://img.shields.io/badge/PSN-%230070D1.svg?style=for-the-badge&logo=Playstation&logoColor=white",
@@ -2160,6 +2965,20 @@
     "name": "Riot Games",
     "url": "https://img.shields.io/badge/riotgames-D32936.svg?style=for-the-badge&logo=riotgames&logoColor=white",
     "markdown": "![Riot Games](https://img.shields.io/badge/riotgames-D32936.svg?style=for-the-badge&logo=riotgames&logoColor=white)",
+    "category": "Gaming"
+  },
+  {
+    "id": "roblox",
+    "name": "Roblox",
+    "url": "https://img.shields.io/badge/Roblox-%230a0b0b.svg?style=for-the-badge&logo=Roblox&logoColor=white",
+    "markdown": "![Roblox](https://img.shields.io/badge/Roblox-%230a0b0b.svg?style=for-the-badge&logo=Roblox&logoColor=white)",
+    "category": "Gaming"
+  },
+  {
+    "id": "sidequest",
+    "name": "Sidequest",
+    "url": "https://img.shields.io/badge/sidequest-%23101227.svg?style=for-the-badge&logo=sidequest&logoColor=white",
+    "markdown": "![Sidequest](https://img.shields.io/badge/sidequest-%23101227.svg?style=for-the-badge&logo=sidequest&logoColor=white)",
     "category": "Gaming"
   },
   {
@@ -2196,6 +3015,27 @@
     "url": "https://img.shields.io/badge/unrealengine-%23313131.svg?style=for-the-badge&logo=unrealengine&logoColor=white",
     "markdown": "![Unreal Engine](https://img.shields.io/badge/unrealengine-%23313131.svg?style=for-the-badge&logo=unrealengine&logoColor=white)",
     "category": "Gaming"
+  },
+  {
+    "id": "xbox",
+    "name": "Xbox",
+    "url": "https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white",
+    "markdown": "![Xbox](https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white)",
+    "category": "Gaming"
+  },
+  {
+    "id": "google-earth-engine",
+    "name": "Google Earth Engine",
+    "url": "https://img.shields.io/badge/google%20earth%20engine-%234285F4?style=for-the-badge&logo=googleearthengine&logoColor=white",
+    "markdown": "![GoogleEarthEngine](https://img.shields.io/badge/google%20earth%20engine-%234285F4?style=for-the-badge&logo=googleearthengine&logoColor=white)",
+    "category": "Geospatial"
+  },
+  {
+    "id": "qgis",
+    "name": "QGIS",
+    "url": "https://img.shields.io/badge/qgis-%2393b023?&style=for-the-badge&logo=qgis&logoColor=white",
+    "markdown": "![QGIS](https://img.shields.io/badge/qgis-%2393b023?&style=for-the-badge&logo=qgis&logoColor=white)",
+    "category": "Geospatial"
   },
   {
     "id": "3ds",
@@ -2275,17 +3115,45 @@
     "category": "Game Consoles"
   },
   {
-    "id": "asana",
-    "name": "Asana",
-    "url": "https://img.shields.io/badge/asana-F06A6A.svg?style=for-the-badge&logo=asana&logoColor=white",
-    "markdown": "![Asana](https://img.shields.io/badge/asana-F06A6A.svg?style=for-the-badge&logo=asana&logoColor=white)",
-    "category": "SaaS"
+    "id": "xbox-game-consoles",
+    "name": "Xbox",
+    "url": "https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white",
+    "markdown": "![Xbox](https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white)",
+    "category": "Game Consoles"
+  },
+  {
+    "id": "adafruit",
+    "name": "Adafruit",
+    "url": "https://img.shields.io/badge/Adafruit-%23000000.svg?style=for-the-badge&logo=adafruit&logoColor=white",
+    "markdown": "![Adafruit](https://img.shields.io/badge/Adafruit-%23000000.svg?style=for-the-badge&logo=adafruit&logoColor=white)",
+    "category": "Hardware"
+  },
+  {
+    "id": "alienware",
+    "name": "Alienware",
+    "url": "https://img.shields.io/badge/Alienware-%23541BAE.svg?style=for-the-badge&logo=alienware&logoColor=white",
+    "markdown": "![Alienware](https://img.shields.io/badge/Alienware-%23541BAE.svg?style=for-the-badge&logo=alienware&logoColor=white)",
+    "category": "Hardware"
+  },
+  {
+    "id": "msi",
+    "name": "MSI",
+    "url": "https://img.shields.io/badge/msi-%23000000.svg?style=for-the-badge&logo=msi&logoColor=%23FF0000",
+    "markdown": "![MSI](https://img.shields.io/badge/msi-%23000000.svg?style=for-the-badge&logo=msi&logoColor=%23FF0000)",
+    "category": "Hardware"
   },
   {
     "id": "alibaba-cloud",
     "name": "Alibaba Cloud",
     "url": "https://img.shields.io/badge/AlibabaCloud-%23FF6701.svg?style=for-the-badge&logo=alibabacloud&logoColor=white",
     "markdown": "![Alibaba Cloud](https://img.shields.io/badge/AlibabaCloud-%23FF6701.svg?style=for-the-badge&logo=alibabacloud&logoColor=white)",
+    "category": "SaaS"
+  },
+  {
+    "id": "asana",
+    "name": "Asana",
+    "url": "https://img.shields.io/badge/asana-F06A6A.svg?style=for-the-badge&logo=asana&logoColor=white",
+    "markdown": "![Asana](https://img.shields.io/badge/asana-F06A6A.svg?style=for-the-badge&logo=asana&logoColor=white)",
     "category": "SaaS"
   },
   {
@@ -2306,7 +3174,7 @@
     "id": "clickup",
     "name": "Clickup",
     "url": "https://img.shields.io/badge/clickup-7B68EE.svg?style=for-the-badge&logo=clickup&logoColor=white",
-    "markdown": "![Clickup](https://img.shields.io/badge/clickup-7B68EE.svg?style=for-the-badge&logo=clickup&logoColor=white)",
+    "markdown": "![ClickUp](https://img.shields.io/badge/clickup-7B68EE.svg?style=for-the-badge&logo=clickup&logoColor=white)",
     "category": "SaaS"
   },
   {
@@ -2338,10 +3206,17 @@
     "category": "SaaS"
   },
   {
+    "id": "firebase-saas",
+    "name": "Firebase",
+    "url": "https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase",
+    "markdown": "![Firebase](https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase)",
+    "category": "SaaS"
+  },
+  {
     "id": "github-pages",
     "name": "Github Pages",
     "url": "https://img.shields.io/badge/github%20pages-121013?style=for-the-badge&logo=github&logoColor=white",
-    "markdown": "![GithubPages](https://img.shields.io/badge/github%20pages-121013?style=for-the-badge&logo=github&logoColor=white)",
+    "markdown": "![Github Pages](https://img.shields.io/badge/github%20pages-121013?style=for-the-badge&logo=github&logoColor=white)",
     "category": "SaaS"
   },
   {
@@ -2366,6 +3241,20 @@
     "category": "SaaS"
   },
   {
+    "id": "hostinger",
+    "name": "Hostinger",
+    "url": "https://img.shields.io/badge/hostinger-%23673DE6.svg?style=for-the-badge&logo=hostinger&logoColor=white",
+    "markdown": "![Hostinger](https://img.shields.io/badge/hostinger-%23673DE6.svg?style=for-the-badge&logo=hostinger&logoColor=white)",
+    "category": "SaaS"
+  },
+  {
+    "id": "infomaniak",
+    "name": "Infomaniak",
+    "url": "https://img.shields.io/badge/infomaniak-%230098FF?style=for-the-badge&logo=infomaniak&logoColor=white",
+    "markdown": "![Infomaniak](https://img.shields.io/badge/infomaniak-%230098FF?style=for-the-badge&logo=infomaniak&logoColor=white)",
+    "category": "SaaS"
+  },
+  {
     "id": "linear",
     "name": "Linear",
     "url": "https://img.shields.io/badge/linear-5E6AD2.svg?style=for-the-badge&logo=linear&logoColor=white",
@@ -2387,13 +3276,6 @@
     "category": "SaaS"
   },
   {
-    "id": "oracle",
-    "name": "Oracle",
-    "url": "https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white",
-    "markdown": "![Oracle](https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white)",
-    "category": "SaaS"
-  },
-  {
     "id": "openstack",
     "name": "OpenStack",
     "url": "https://img.shields.io/badge/Openstack-%23f01742.svg?style=for-the-badge&logo=openstack&logoColor=white",
@@ -2401,10 +3283,24 @@
     "category": "SaaS"
   },
   {
+    "id": "oracle",
+    "name": "Oracle",
+    "url": "https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white",
+    "markdown": "![Oracle](https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white)",
+    "category": "SaaS"
+  },
+  {
     "id": "ovh",
     "name": "OVH",
     "url": "https://img.shields.io/badge/ovh-%23123F6D.svg?style=for-the-badge&logo=ovh&logoColor=#123F6D",
     "markdown": "![OVH](https://img.shields.io/badge/ovh-%23123F6D.svg?style=for-the-badge&logo=ovh&logoColor=#123F6D)",
+    "category": "SaaS"
+  },
+  {
+    "id": "proxmox",
+    "name": "Proxmox",
+    "url": "https://img.shields.io/badge/proxmox-proxmox?style=for-the-badge&logo=proxmox&logoColor=%23E57000&labelColor=%232b2a33&color=%232b2a33",
+    "markdown": "![Proxmox](https://img.shields.io/badge/proxmox-proxmox?style=for-the-badge&logo=proxmox&logoColor=%23E57000&labelColor=%232b2a33&color=%232b2a33)",
     "category": "SaaS"
   },
   {
@@ -2429,13 +3325,6 @@
     "category": "SaaS"
   },
   {
-    "id": "tableau",
-    "name": "Tableau",
-    "url": "https://img.shields.io/badge/Tableau-%23FFFFFF.svg?style=for-the-badge&logo=Tableau&logoColor=1C4481",
-    "markdown": "![Tableau](https://img.shields.io/badge/Tableau-%23FFFFFF.svg?style=for-the-badge&logo=Tableau&logoColor=1C4481)",
-    "category": "SaaS"
-  },
-  {
     "id": "vercel",
     "name": "Vercel",
     "url": "https://img.shields.io/badge/vercel-%23000000.svg?style=for-the-badge&logo=vercel&logoColor=white",
@@ -2452,8 +3341,15 @@
   {
     "id": "android-studio",
     "name": "Android Studio",
-    "url": "https://img.shields.io/badge/android%20studio-346ac1?style=for-the-badge&logo=android%20studio&logoColor=white",
-    "markdown": "![Android Studio](https://img.shields.io/badge/android%20studio-346ac1?style=for-the-badge&logo=android%20studio&logoColor=white)",
+    "url": "https://img.shields.io/badge/Android%20Studio-3DDC84.svg?style=for-the-badge&logo=android-studio&logoColor=white",
+    "markdown": "![Android Studio](https://img.shields.io/badge/Android%20Studio-3DDC84.svg?style=for-the-badge&logo=android-studio&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
+    "id": "arduino-ide",
+    "name": "Arduino IDE",
+    "url": "https://img.shields.io/badge/Arduino%20IDE-%2300979D.svg?style=for-the-badge&logo=Arduino&logoColor=white",
+    "markdown": "![Arduino IDE](https://img.shields.io/badge/Arduino%20IDE-%2300979D.svg?style=for-the-badge&logo=Arduino&logoColor=white)",
     "category": "IDEs"
   },
   {
@@ -2471,7 +3367,7 @@
     "category": "IDEs"
   },
   {
-    "id": "codepen",
+    "id": "codepen-ides",
     "name": "CodePen",
     "url": "https://img.shields.io/badge/CodePen-white?style=for-the-badge&logo=codepen&logoColor=black",
     "markdown": "![CodePen](https://img.shields.io/badge/CodePen-white?style=for-the-badge&logo=codepen&logoColor=black)",
@@ -2489,6 +3385,13 @@
     "name": "Cursor",
     "url": "https://img.shields.io/badge/Cursor-%23000000?style=for-the-badge&logo=Cursor&logoColor=white",
     "markdown": "![Cursor](https://img.shields.io/badge/Cursor-%23000000?style=for-the-badge&logo=Cursor&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
+    "id": "datagrip",
+    "name": "Datagrip",
+    "url": "https://img.shields.io/badge/DataGrip-%23000000.svg?style=for-the-badge&logo=DataGrip&logoColor=white",
+    "markdown": "![Datagrip](https://img.shields.io/badge/DataGrip-%23000000.svg?style=for-the-badge&logo=DataGrip&logoColor=white)",
     "category": "IDEs"
   },
   {
@@ -2527,10 +3430,24 @@
     "category": "IDEs"
   },
   {
+    "id": "helix",
+    "name": "Helix",
+    "url": "https://img.shields.io/badge/Helix-%2328153e.svg?style=for-the-badge&logo=helix&logoColor=white",
+    "markdown": "![Helix](https://img.shields.io/badge/Helix-%2328153e.svg?style=for-the-badge&logo=helix&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
     "id": "intellij-idea",
     "name": "IntelliJ IDEA",
     "url": "https://img.shields.io/badge/IntelliJIDEA-000000.svg?style=for-the-badge&logo=intellij-idea&logoColor=white",
     "markdown": "![IntelliJ IDEA](https://img.shields.io/badge/IntelliJIDEA-000000.svg?style=for-the-badge&logo=intellij-idea&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
+    "id": "jetbrains",
+    "name": "JetBrains",
+    "url": "https://img.shields.io/badge/jetbrains-%23000000.svg?style=for-the-badge&logo=jetbrains&logoColor=white",
+    "markdown": "![JetBrains](https://img.shields.io/badge/jetbrains-%23000000.svg?style=for-the-badge&logo=jetbrains&logoColor=white)",
     "category": "IDEs"
   },
   {
@@ -2571,8 +3488,8 @@
   {
     "id": "p5js-editor",
     "name": "P5js Editor",
-    "url": "https://img.shields.io/badge/p5.js%20editor-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF",
-    "markdown": "![P5js Editor](https://img.shields.io/badge/p5.js%20editor-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF)",
+    "url": "https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF",
+    "markdown": "![p5js Editor](https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF)",
     "category": "IDEs"
   },
   {
@@ -2597,6 +3514,13 @@
     "category": "IDEs"
   },
   {
+    "id": "resharper",
+    "name": "ReSharper",
+    "url": "https://img.shields.io/badge/ReSharper-%23000000.svg?style=for-the-badge&logo=ReSharper&logoColor=white",
+    "markdown": "![ReSharper](https://img.shields.io/badge/ReSharper-%23000000.svg?style=for-the-badge&logo=ReSharper&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
     "id": "rider",
     "name": "Rider",
     "url": "https://img.shields.io/badge/Rider-000000.svg?style=for-the-badge&logo=Rider&logoColor=white&color=black&labelColor=crimson",
@@ -2608,6 +3532,13 @@
     "name": "RStudio",
     "url": "https://img.shields.io/badge/RStudio-4285F4?style=for-the-badge&logo=rstudio&logoColor=white",
     "markdown": "![RStudio](https://img.shields.io/badge/RStudio-4285F4?style=for-the-badge&logo=rstudio&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
+    "id": "rubymine",
+    "name": "RubyMine",
+    "url": "https://img.shields.io/badge/RubyMine-%23000000.svg?style=for-the-badge&logo=RubyMine&logoColor=white",
+    "markdown": "![RubyMine](https://img.shields.io/badge/RubyMine-%23000000.svg?style=for-the-badge&logo=RubyMine&logoColor=white)",
     "category": "IDEs"
   },
   {
@@ -2632,6 +3563,13 @@
     "category": "IDEs"
   },
   {
+    "id": "visual-studio",
+    "name": "Visual Studio",
+    "url": "https://img.shields.io/badge/Visual%20Studio-5C2D91.svg?style=for-the-badge&logo=visual-studio&logoColor=white",
+    "markdown": "![Visual Studio](https://img.shields.io/badge/Visual%20Studio-5C2D91.svg?style=for-the-badge&logo=visual-studio&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
     "id": "visual-studio-code",
     "name": "Visual Studio Code",
     "url": "https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white",
@@ -2643,13 +3581,6 @@
     "name": "VS Code Insiders",
     "url": "https://img.shields.io/badge/VS%20Code%20Insiders-35b393.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white",
     "markdown": "![VS Code Insiders](https://img.shields.io/badge/VS%20Code%20Insiders-35b393.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white)",
-    "category": "IDEs"
-  },
-  {
-    "id": "visual-studio",
-    "name": "Visual Studio",
-    "url": "https://img.shields.io/badge/Visual%20Studio-5C2D91.svg?style=for-the-badge&logo=visual-studio&logoColor=white",
-    "markdown": "![Visual Studio](https://img.shields.io/badge/Visual%20Studio-5C2D91.svg?style=for-the-badge&logo=visual-studio&logoColor=white)",
     "category": "IDEs"
   },
   {
@@ -2667,17 +3598,17 @@
     "category": "IDEs"
   },
   {
+    "id": "zed",
+    "name": "Zed",
+    "url": "https://img.shields.io/badge/zedindustries-084CCF.svg?style=for-the-badge&logo=zedindustries&logoColor=white",
+    "markdown": "![Zed](https://img.shields.io/badge/zedindustries-084CCF.svg?style=for-the-badge&logo=zedindustries&logoColor=white)",
+    "category": "IDEs"
+  },
+  {
     "id": "zend",
     "name": "Zend",
     "url": "https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA",
     "markdown": "![Zend](https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA)",
-    "category": "IDEs"
-  },
-  {
-    "id": "stackblitz",
-    "name": "Stackblitz",
-    "url": "https://img.shields.io/badge/Stackblitz-fff?style=for-the-badge&logo=Stackblitz&logoColor=1389FD",
-    "markdown": "![Stackblitz](https://img.shields.io/badge/Stackblitz-fff?style=for-the-badge&logo=Stackblitz&logoColor=1389FD)",
     "category": "IDEs"
   },
   {
@@ -2695,6 +3626,13 @@
     "category": "Languages"
   },
   {
+    "id": "bash-script",
+    "name": "Bash Script",
+    "url": "https://img.shields.io/badge/bash_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white",
+    "markdown": "![Bash Script](https://img.shields.io/badge/bash_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white)",
+    "category": "Languages"
+  },
+  {
     "id": "c",
     "name": "C",
     "url": "https://img.shields.io/badge/c-%2300599C.svg?style=for-the-badge&logo=c&logoColor=white",
@@ -2702,7 +3640,7 @@
     "category": "Languages"
   },
   {
-    "id": "c#",
+    "id": "c%23",
     "name": "C#",
     "url": "https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white",
     "markdown": "![C#](https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white)",
@@ -2723,6 +3661,13 @@
     "category": "Languages"
   },
   {
+    "id": "coffeescript",
+    "name": "CoffeeScript",
+    "url": "https://img.shields.io/badge/CoffeeScript-%232F2625.svg?style=for-the-badge&logo=CoffeeScript&logoColor=white",
+    "markdown": "![CoffeeScript](https://img.shields.io/badge/CoffeeScript-%232F2625.svg?style=for-the-badge&logo=CoffeeScript&logoColor=white)",
+    "category": "Languages"
+  },
+  {
     "id": "crystal",
     "name": "Crystal",
     "url": "https://img.shields.io/badge/crystal-%23000000.svg?style=for-the-badge&logo=crystal&logoColor=white",
@@ -2733,7 +3678,7 @@
     "id": "css",
     "name": "CSS",
     "url": "https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white",
-    "markdown": "![CSS3](https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white)",
+    "markdown": "![CSS](https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -2741,13 +3686,6 @@
     "name": "CSS3",
     "url": "https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white",
     "markdown": "![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white)",
-    "category": "Languages"
-  },
-  {
-    "id": "coffeescript",
-    "name": "CoffeeScript",
-    "url": "https://img.shields.io/badge/CoffeeScript-%232F2625.svg?style=for-the-badge&logo=CoffeeScript&logoColor=white",
-    "markdown": "![CoffeeScript](https://img.shields.io/badge/CoffeeScript-%232F2625.svg?style=for-the-badge&logo=CoffeeScript&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -2760,8 +3698,15 @@
   {
     "id": "delphi",
     "name": "Delphi",
-    "url": "https://img.shields.io/badge/delphi%20-%20%23B21F24?style=for-the-badge&logo=delphi&logoColor=white",
-    "markdown": "![Delphi](https://img.shields.io/badge/delphi%20-%20%23B21F24?style=for-the-badge&logo=delphi&logoColor=white)",
+    "url": "https://img.shields.io/badge/delphi-%23B21F24?style=for-the-badge&logo=delphi&logoColor=white",
+    "markdown": "![Delphi](https://img.shields.io/badge/delphi-%23B21F24?style=for-the-badge&logo=delphi&logoColor=white)",
+    "category": "Languages"
+  },
+  {
+    "id": "dgraph",
+    "name": "Dgraph",
+    "url": "https://img.shields.io/badge/dgraph-%23E50695.svg?style=for-the-badge&logo=dgraph&logoColor=white",
+    "markdown": "![Dgraph](https://img.shields.io/badge/dgraph-%23E50695.svg?style=for-the-badge&logo=dgraph&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -2797,6 +3742,13 @@
     "name": "GDScript",
     "url": "https://img.shields.io/badge/GDScript-%2374267B.svg?style=for-the-badge&logo=godotengine&logoColor=white",
     "markdown": "![GDScript](https://img.shields.io/badge/GDScript-%2374267B.svg?style=for-the-badge&logo=godotengine&logoColor=white)",
+    "category": "Languages"
+  },
+  {
+    "id": "gleam",
+    "name": "Gleam",
+    "url": "https://img.shields.io/badge/gleam-%23FFAFF3.svg?style=for-the-badge&logo=gleam&logoColor=white",
+    "markdown": "![gleam](https://img.shields.io/badge/gleam-%23FFAFF3.svg?style=for-the-badge&logo=gleam&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -2856,6 +3808,13 @@
     "category": "Languages"
   },
   {
+    "id": "labview",
+    "name": "LabView",
+    "url": "https://img.shields.io/badge/labview-%23FFDB00.svg?style=for-the-badge&logo=labview&logoColor=black",
+    "markdown": "![LabVIEW](https://img.shields.io/badge/labview-%23FFDB00.svg?style=for-the-badge&logo=labview&logoColor=black)",
+    "category": "Languages"
+  },
+  {
     "id": "latex",
     "name": "LaTeX",
     "url": "https://img.shields.io/badge/latex-%23008080.svg?style=for-the-badge&logo=latex&logoColor=white",
@@ -2867,13 +3826,6 @@
     "name": "Lua",
     "url": "https://img.shields.io/badge/lua-%232C2D72.svg?style=for-the-badge&logo=lua&logoColor=white",
     "markdown": "![Lua](https://img.shields.io/badge/lua-%232C2D72.svg?style=for-the-badge&logo=lua&logoColor=white)",
-    "category": "Languages"
-  },
-  {
-    "id": "labview",
-    "name": "LabVIEW",
-    "url": "https://img.shields.io/badge/labview-%23FFDB00.svg?style=for-the-badge&logo=labview&logoColor=white",
-    "markdown": "![LabVIEW](https://img.shields.io/badge/labview-%23FFDB00.svg?style=for-the-badge&logo=labview&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -2935,8 +3887,8 @@
   {
     "id": "pascal",
     "name": "Pascal",
-    "url": "https://img.shields.io/badge/pascal%20-%20%230288d1?style=for-the-badge&logo=lazarus&logoColor=white",
-    "markdown": "![Pascal](https://img.shields.io/badge/pascal%20-%20%230288d1?style=for-the-badge&logo=lazarus&logoColor=white)",
+    "url": "https://img.shields.io/badge/pascal-%230288d1?style=for-the-badge&logo=lazarus&logoColor=white",
+    "markdown": "![Pascal](https://img.shields.io/badge/pascal-%230288d1?style=for-the-badge&logo=lazarus&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -2975,6 +3927,13 @@
     "category": "Languages"
   },
   {
+    "id": "racket",
+    "name": "Racket",
+    "url": "https://img.shields.io/badge/Racket-%239F1D20.svg?style=for-the-badge&logo=racket&logoColor=white",
+    "markdown": "![Racket](https://img.shields.io/badge/Racket-%239F1D20.svg?style=for-the-badge&logo=racket&logoColor=white)",
+    "category": "Languages"
+  },
+  {
     "id": "rescript",
     "name": "ReScript",
     "url": "https://img.shields.io/badge/rescript-%2314162c?style=for-the-badge&logo=rescript&logoColor=e34c4c",
@@ -3005,15 +3964,8 @@
   {
     "id": "scratch",
     "name": "Scratch",
-    "url": "https://img.shields.io/badge/Scratch-%23F7A028.svg?style=for-the-badge&logo=scratch&logoColor=%23FEFEFF",
-    "markdown": "![Scratch](https://img.shields.io/badge/Scratch-%23F7A028.svg?style=for-the-badge&logo=scratch&logoColor=%23FEFEFF)",
-    "category": "Languages"
-  },
-  {
-    "id": "shell-script",
-    "name": "Shell Script",
-    "url": "https://img.shields.io/badge/shell_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white",
-    "markdown": "![Shell Script](https://img.shields.io/badge/shell_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white)",
+    "url": "https://img.shields.io/badge/Scratch-%23FF6600.svg?style=for-the-badge&logo=scratch&logoColor=white",
+    "markdown": "![Scratch](https://img.shields.io/badge/Scratch-%23FF6600.svg?style=for-the-badge&logo=scratch&logoColor=white)",
     "category": "Languages"
   },
   {
@@ -3045,6 +3997,13 @@
     "category": "Languages"
   },
   {
+    "id": "webassembly",
+    "name": "WebAssembly",
+    "url": "https://img.shields.io/badge/webassembly-%23654FF0.svg?style=for-the-badge&logo=webassembly&logoColor=white",
+    "markdown": "![WebAssembly](https://img.shields.io/badge/webassembly-%23654FF0.svg?style=for-the-badge&logo=webassembly&logoColor=white)",
+    "category": "Languages"
+  },
+  {
     "id": "windows-terminal",
     "name": "Windows Terminal",
     "url": "https://img.shields.io/badge/Windows%20Terminal-%234D4D4D.svg?style=for-the-badge&logo=windows-terminal&logoColor=white",
@@ -3066,7 +4025,7 @@
     "category": "Languages"
   },
   {
-    "id": "keras",
+    "id": "keras-ml-dl",
     "name": "Keras",
     "url": "https://img.shields.io/badge/Keras-%23D00000.svg?style=for-the-badge&logo=Keras&logoColor=white",
     "markdown": "![Keras](https://img.shields.io/badge/Keras-%23D00000.svg?style=for-the-badge&logo=Keras&logoColor=white)",
@@ -3087,14 +4046,21 @@
     "category": "ML/DL"
   },
   {
-    "id": "numpy",
+    "id": "numpy-ml-dl",
     "name": "NumPy",
     "url": "https://img.shields.io/badge/numpy-%23013243.svg?style=for-the-badge&logo=numpy&logoColor=white",
     "markdown": "![NumPy](https://img.shields.io/badge/numpy-%23013243.svg?style=for-the-badge&logo=numpy&logoColor=white)",
     "category": "ML/DL"
   },
   {
-    "id": "pandas",
+    "id": "onnx",
+    "name": "ONNX",
+    "url": "https://img.shields.io/badge/onnx-%23ffffff.svg?style=for-the-badge&logo=onnx&logoColor=black",
+    "markdown": "![ONNX](https://img.shields.io/badge/onnx-%23ffffff.svg?style=for-the-badge&logo=onnx&logoColor=black)",
+    "category": "ML/DL"
+  },
+  {
+    "id": "pandas-ml-dl",
     "name": "Pandas",
     "url": "https://img.shields.io/badge/pandas-%23150458.svg?style=for-the-badge&logo=pandas&logoColor=white",
     "markdown": "![Pandas](https://img.shields.io/badge/pandas-%23150458.svg?style=for-the-badge&logo=pandas&logoColor=white)",
@@ -3108,10 +4074,31 @@
     "category": "ML/DL"
   },
   {
-    "id": "pytorch",
+    "id": "polars",
+    "name": "Polars",
+    "url": "https://img.shields.io/badge/polars-0075ff?style=for-the-badge&logo=polars&logoColor=white",
+    "markdown": "![Polars](https://img.shields.io/badge/polars-0075ff?style=for-the-badge&logo=polars&logoColor=white)",
+    "category": "ML/DL"
+  },
+  {
+    "id": "pytorch-ml-dl",
     "name": "PyTorch",
     "url": "https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=for-the-badge&logo=PyTorch&logoColor=white",
     "markdown": "![PyTorch](https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=for-the-badge&logo=PyTorch&logoColor=white)",
+    "category": "ML/DL"
+  },
+  {
+    "id": "pytorch-geometric",
+    "name": "PyTorch Geometric",
+    "url": "https://img.shields.io/badge/PyTorch%20Geometric-%233C2179.svg?style=for-the-badge&logo=pyg&logoColor=white",
+    "markdown": "![PyTorch Geometric](https://img.shields.io/badge/PyTorch%20Geometric-%233C2179.svg?style=for-the-badge&logo=pyg&logoColor=white)",
+    "category": "ML/DL"
+  },
+  {
+    "id": "roboflow",
+    "name": "Roboflow",
+    "url": "https://img.shields.io/badge/roboflow-%23EE4C2C.svg?style=for-the-badge&logo=roboflow&logoColor=white",
+    "markdown": "![Roboflow](https://img.shields.io/badge/roboflow-%23EE4C2C.svg?style=for-the-badge&logo=roboflow&logoColor=white)",
     "category": "ML/DL"
   },
   {
@@ -3125,21 +4112,21 @@
     "id": "scipy",
     "name": "SciPy",
     "url": "https://img.shields.io/badge/SciPy-%230C55A5.svg?style=for-the-badge&logo=scipy&logoColor=%white",
-    "markdown": "![Scipy](https://img.shields.io/badge/SciPy-%230C55A5.svg?style=for-the-badge&logo=scipy&logoColor=%white)",
+    "markdown": "![SciPy](https://img.shields.io/badge/SciPy-%230C55A5.svg?style=for-the-badge&logo=scipy&logoColor=%white)",
     "category": "ML/DL"
   },
   {
-    "id": "tensorflow",
+    "id": "tensorflow-ml-dl",
     "name": "TensorFlow",
     "url": "https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=TensorFlow&logoColor=white",
     "markdown": "![TensorFlow](https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=TensorFlow&logoColor=white)",
     "category": "ML/DL"
   },
   {
-    "id": "onnx",
-    "name": "ONNX",
-    "url": "https://img.shields.io/badge/onnx-%23ffffff.svg?style=for-the-badge&logo=onnx&logoColor=black",
-    "markdown": "![ONNX](https://img.shields.io/badge/onnx-%23ffffff.svg?style=for-the-badge&logo=onnx&logoColor=black)",
+    "id": "ultralytics",
+    "name": "Ultralytics",
+    "url": "https://img.shields.io/badge/ultralytics-%23111F68.svg?style=for-the-badge&logo=ultralytics&logoColor=white",
+    "markdown": "![Ultralytics](https://img.shields.io/badge/ultralytics-%23111F68.svg?style=for-the-badge&logo=ultralytics&logoColor=white)",
     "category": "ML/DL"
   },
   {
@@ -3164,17 +4151,17 @@
     "category": "Music"
   },
   {
-    "id": "sound-cloud",
-    "name": "Sound Cloud",
-    "url": "https://img.shields.io/badge/sound%20cloud-FF5500?style=for-the-badge&logo=soundcloud&logoColor=white",
-    "markdown": "![Sound Cloud](https://img.shields.io/badge/sound%20cloud-FF5500?style=for-the-badge&logo=soundcloud&logoColor=white)",
+    "id": "last.fm",
+    "name": "Last.fm",
+    "url": "https://img.shields.io/badge/last.fm-D51007?style=for-the-badge&logo=last.fm&logoColor=white",
+    "markdown": "![Last.fm](https://img.shields.io/badge/last.fm-D51007?style=for-the-badge&logo=last.fm&logoColor=white)",
     "category": "Music"
   },
   {
-    "id": "spotify",
-    "name": "Spotify",
-    "url": "https://img.shields.io/badge/Spotify-1ED760?style=for-the-badge&logo=spotify&logoColor=white",
-    "markdown": "![Spotify](https://img.shields.io/badge/Spotify-1ED760?style=for-the-badge&logo=spotify&logoColor=white)",
+    "id": "musixmatch",
+    "name": "Musixmatch",
+    "url": "https://img.shields.io/badge/Musixmatch-%23FF5353.svg?style=for-the-badge&logo=Musixmatch&logoColor=white",
+    "markdown": "![Musixmatch](https://img.shields.io/badge/Musixmatch-%23FF5353.svg?style=for-the-badge&logo=Musixmatch&logoColor=white)",
     "category": "Music"
   },
   {
@@ -3182,6 +4169,20 @@
     "name": "Shazam",
     "url": "https://img.shields.io/badge/shazam-1476FE?style=for-the-badge&logo=shazam&logoColor=white",
     "markdown": "![Shazam](https://img.shields.io/badge/shazam-1476FE?style=for-the-badge&logo=shazam&logoColor=white)",
+    "category": "Music"
+  },
+  {
+    "id": "soundcloud",
+    "name": "SoundCloud",
+    "url": "https://img.shields.io/badge/soundcloud-FF5500?style=for-the-badge&logo=soundcloud&logoColor=white",
+    "markdown": "![SoundCloud](https://img.shields.io/badge/soundcloud-FF5500?style=for-the-badge&logo=soundcloud&logoColor=white)",
+    "category": "Music"
+  },
+  {
+    "id": "spotify",
+    "name": "Spotify",
+    "url": "https://img.shields.io/badge/Spotify-1ED760?style=for-the-badge&logo=spotify&logoColor=white",
+    "markdown": "![Spotify](https://img.shields.io/badge/Spotify-1ED760?style=for-the-badge&logo=spotify&logoColor=white)",
     "category": "Music"
   },
   {
@@ -3197,6 +4198,13 @@
     "url": "https://img.shields.io/badge/YouTube_Music-FF0000?style=for-the-badge&logo=youtube-music&logoColor=white",
     "markdown": "![YouTube Music](https://img.shields.io/badge/YouTube_Music-FF0000?style=for-the-badge&logo=youtube-music&logoColor=white)",
     "category": "Music"
+  },
+  {
+    "id": "google-sheets",
+    "name": "Google Sheets",
+    "url": "https://img.shields.io/badge/Google%20Sheets-%2334A853?style=for-the-badge&logo=googlesheets&logoColor=white",
+    "markdown": "![Google Sheets](https://img.shields.io/badge/Google%20Sheets-%2334A853?style=for-the-badge&logo=googlesheets&logoColor=white)",
+    "category": "Office"
   },
   {
     "id": "libreoffice",
@@ -3339,6 +4347,13 @@
     "category": "Operating System"
   },
   {
+    "id": "gnu",
+    "name": "GNU",
+    "url": "https://img.shields.io/badge/gnu-%23A42E2B.svg?style=for-the-badge&logo=gnu&logoColor=white",
+    "markdown": "![gnu](https://img.shields.io/badge/gnu-%23A42E2B.svg?style=for-the-badge&logo=gnu&logoColor=white)",
+    "category": "Operating System"
+  },
+  {
     "id": "ios",
     "name": "iOS",
     "url": "https://img.shields.io/badge/iOS-000000?style=for-the-badge&logo=ios&logoColor=white",
@@ -3357,6 +4372,13 @@
     "name": "Kubuntu",
     "url": "https://img.shields.io/badge/-KUbuntu-%230079C1?style=for-the-badge&logo=kubuntu&logoColor=white",
     "markdown": "![Kubuntu](https://img.shields.io/badge/-KUbuntu-%230079C1?style=for-the-badge&logo=kubuntu&logoColor=white)",
+    "category": "Operating System"
+  },
+  {
+    "id": "lineageos",
+    "name": "Lineageos",
+    "url": "https://img.shields.io/badge/lineageos-167C80?style=for-the-badge&logo=lineageos&logoColor=white",
+    "markdown": "![Lineageos](https://img.shields.io/badge/lineageos-167C80?style=for-the-badge&logo=lineageos&logoColor=white)",
     "category": "Operating System"
   },
   {
@@ -3381,10 +4403,10 @@
     "category": "Operating System"
   },
   {
-    "id": "lineageos",
-    "name": "Lineageos",
-    "url": "https://img.shields.io/badge/lineageos-167C80?style=for-the-badge&logo=lineageos&logoColor=white",
-    "markdown": "![Lineageos](https://img.shields.io/badge/lineageos-167C80?style=for-the-badge&logo=lineageos&logoColor=white)",
+    "id": "macos",
+    "name": "macOS",
+    "url": "https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0",
+    "markdown": "![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0)",
     "category": "Operating System"
   },
   {
@@ -3402,24 +4424,10 @@
     "category": "Operating System"
   },
   {
-    "id": "macos",
-    "name": "macOS",
-    "url": "https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0",
-    "markdown": "![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0)",
-    "category": "Operating System"
-  },
-  {
     "id": "nixos",
     "name": "NixOS",
     "url": "https://img.shields.io/badge/NIXOS-5277C3.svg?style=for-the-badge&logo=NixOS&logoColor=white",
     "markdown": "![NixOS](https://img.shields.io/badge/NIXOS-5277C3.svg?style=for-the-badge&logo=NixOS&logoColor=white)",
-    "category": "Operating System"
-  },
-  {
-    "id": "openwrt",
-    "name": "OpenWRT",
-    "url": "https://img.shields.io/badge/OpenWrt-00B5E2?style=for-the-badge&logo=OpenWrt&logoColor=white",
-    "markdown": "![OpenWRT](https://img.shields.io/badge/OpenWrt-00B5E2?style=for-the-badge&logo=OpenWrt&logoColor=white)",
     "category": "Operating System"
   },
   {
@@ -3437,7 +4445,21 @@
     "category": "Operating System"
   },
   {
-    "id": "pop-os",
+    "id": "openwrt",
+    "name": "OpenWRT",
+    "url": "https://img.shields.io/badge/OpenWRT-00B5E2?style=for-the-badge&logo=OpenWrt&logoColor=white",
+    "markdown": "![Openwrt](https://img.shields.io/badge/OpenWRT-00B5E2?style=for-the-badge&logo=OpenWrt&logoColor=white)",
+    "category": "Operating System"
+  },
+  {
+    "id": "parrot-security",
+    "name": "Parrot Security",
+    "url": "https://img.shields.io/badge/parrot_security-%23000000.svg?style=for-the-badge&logo=parrotsecurity&logoColor=#15E0ED",
+    "markdown": "![Parrot Security](https://img.shields.io/badge/parrot_security-%23000000.svg?style=for-the-badge&logo=parrotsecurity&logoColor=#15E0ED)",
+    "category": "Operating System"
+  },
+  {
+    "id": "pop!_os",
     "name": "Pop!_OS",
     "url": "https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white",
     "markdown": "![Pop!\\_OS](https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white)",
@@ -3458,6 +4480,13 @@
     "category": "Operating System"
   },
   {
+    "id": "slackware",
+    "name": "Slackware",
+    "url": "https://img.shields.io/badge/-Slackware-%231357BD?style=for-the-badge&logo=slackware&logoColor=white",
+    "markdown": "![Slackware](https://img.shields.io/badge/-Slackware-%231357BD?style=for-the-badge&logo=slackware&logoColor=white)",
+    "category": "Operating System"
+  },
+  {
     "id": "solus",
     "name": "Solus",
     "url": "https://img.shields.io/badge/Solus-%23f2f2f2.svg?style=for-the-badge&logo=solus&logoColor=5294E2",
@@ -3468,14 +4497,7 @@
     "id": "suse",
     "name": "SUSE",
     "url": "https://img.shields.io/badge/SUSE-0C322C?style=for-the-badge&logo=SUSE&logoColor=white",
-    "markdown": "![SUSE](https://img.shields.io/badge/SUSE-0C322C?style=for-the-badge&logo=SUSE&logoColor=white)",
-    "category": "Operating System"
-  },
-  {
-    "id": "slackware",
-    "name": "Slackware",
-    "url": "https://img.shields.io/badge/-Slackware-%231357BD?style=for-the-badge&logo=slackware&logoColor=white",
-    "markdown": "![Slackware](https://img.shields.io/badge/-Slackware-%231357BD?style=for-the-badge&logo=slackware&logoColor=white)",
+    "markdown": "![Suse](https://img.shields.io/badge/SUSE-0C322C?style=for-the-badge&logo=SUSE&logoColor=white)",
     "category": "Operating System"
   },
   {
@@ -3490,6 +4512,13 @@
     "name": "Ubuntu",
     "url": "https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white",
     "markdown": "![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)",
+    "category": "Operating System"
+  },
+  {
+    "id": "ubuntu-mate",
+    "name": "Ubuntu MATE",
+    "url": "https://img.shields.io/badge/Ubuntu%20MATE-84A454.svg?style=for-the-badge&logo=Ubuntu-MATE&logoColor=white",
+    "markdown": "![Ubuntu MATE](https://img.shields.io/badge/Ubuntu%20MATE-84A454.svg?style=for-the-badge&logo=Ubuntu-MATE&logoColor=white)",
     "category": "Operating System"
   },
   {
@@ -3542,6 +4571,20 @@
     "category": "Operating System"
   },
   {
+    "id": "doctrine",
+    "name": "Doctrine",
+    "url": "https://img.shields.io/badge/Doctrine-%23326CE5?style=for-the-badge&logo=doctrine&logoColor=white",
+    "markdown": "![Doctrine](https://img.shields.io/badge/Doctrine-%23326CE5?style=for-the-badge&logo=doctrine&logoColor=white)",
+    "category": "ORM"
+  },
+  {
+    "id": "drizzle",
+    "name": "Drizzle",
+    "url": "https://img.shields.io/badge/Drizzle-%23000000?style=for-the-badge&logo=drizzle&logoColor=C5F74F",
+    "markdown": "![Drizzle](https://img.shields.io/badge/Drizzle-%23000000?style=for-the-badge&logo=drizzle&logoColor=C5F74F)",
+    "category": "ORM"
+  },
+  {
     "id": "hibernate",
     "name": "Hibernate",
     "url": "https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white",
@@ -3556,6 +4599,13 @@
     "category": "ORM"
   },
   {
+    "id": "quill",
+    "name": "Quill",
+    "url": "https://img.shields.io/badge/Quill-52B0E7?style=for-the-badge&logo=apache&logoColor=white",
+    "markdown": "![Quill](https://img.shields.io/badge/Quill-52B0E7?style=for-the-badge&logo=apache&logoColor=white)",
+    "category": "ORM"
+  },
+  {
     "id": "sequelize",
     "name": "Sequelize",
     "url": "https://img.shields.io/badge/Sequelize-52B0E7?style=for-the-badge&logo=Sequelize&logoColor=white",
@@ -3563,17 +4613,17 @@
     "category": "ORM"
   },
   {
+    "id": "sqlalchemy",
+    "name": "SQLAlchemy",
+    "url": "https://img.shields.io/badge/sqlalchemy-%23D71F00.svg?style=for-the-badge&logo=sqlalchemy&logoColor=white",
+    "markdown": "![SQLAlchemy](https://img.shields.io/badge/sqlalchemy-%23D71F00.svg?style=for-the-badge&logo=sqlalchemy&logoColor=white)",
+    "category": "ORM"
+  },
+  {
     "id": "typeorm",
     "name": "TypeORM",
     "url": "https://img.shields.io/badge/TypeORM-FE0803.svg?style=for-the-badge&logo=typeorm&logoColor=white",
     "markdown": "![TypeORM](https://img.shields.io/badge/TypeORM-FE0803.svg?style=for-the-badge&logo=typeorm&logoColor=white)",
-    "category": "ORM"
-  },
-  {
-    "id": "quill",
-    "name": "Quill",
-    "url": "https://img.shields.io/badge/Quill-52B0E7?style=for-the-badge&logo=apache&logoColor=white",
-    "markdown": "![Quill](https://img.shields.io/badge/Quill-52B0E7?style=for-the-badge&logo=apache&logoColor=white)",
     "category": "ORM"
   },
   {
@@ -3598,52 +4648,10 @@
     "category": "Other"
   },
   {
-    "id": "ansible",
-    "name": "Ansible",
-    "url": "https://img.shields.io/badge/ansible-%231A1918.svg?style=for-the-badge&logo=ansible&logoColor=white",
-    "markdown": "![Ansible](https://img.shields.io/badge/ansible-%231A1918.svg?style=for-the-badge&logo=ansible&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "aqua-sec",
-    "name": "Aqua Sec",
-    "url": "https://img.shields.io/badge/aqua-%231904DA.svg?style=for-the-badge&logo=aqua&logoColor=#0018A8",
-    "markdown": "![AquaSec](https://img.shields.io/badge/aqua-%231904DA.svg?style=for-the-badge&logo=aqua&logoColor=#0018A8)",
-    "category": "Other"
-  },
-  {
-    "id": "arduino",
-    "name": "Arduino",
-    "url": "https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white",
-    "markdown": "![Arduino](https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "babel",
-    "name": "Babel",
-    "url": "https://img.shields.io/badge/Babel-F9DC3e?style=for-the-badge&logo=babel&logoColor=black",
-    "markdown": "![Babel](https://img.shields.io/badge/Babel-F9DC3e?style=for-the-badge&logo=babel&logoColor=black)",
-    "category": "Other"
-  },
-  {
-    "id": "bitwarden",
-    "name": "Bitwarden",
-    "url": "https://img.shields.io/badge/bitwarden-%23175DDC.svg?style=for-the-badge&logo=bitwarden&logoColor=white",
-    "markdown": "![Bitwarden](https://img.shields.io/badge/bitwarden-%23175DDC.svg?style=for-the-badge&logo=bitwarden&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "cisco",
-    "name": "Cisco",
-    "url": "https://img.shields.io/badge/cisco-%23049fd9.svg?style=for-the-badge&logo=cisco&logoColor=black",
-    "markdown": "![Cisco](https://img.shields.io/badge/cisco-%23049fd9.svg?style=for-the-badge&logo=cisco&logoColor=black)",
-    "category": "Other"
-  },
-  {
-    "id": "cmake",
-    "name": "CMake",
-    "url": "https://img.shields.io/badge/CMake-%23008FBA.svg?style=for-the-badge&logo=cmake&logoColor=white",
-    "markdown": "![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?style=for-the-badge&logo=cmake&logoColor=white)",
+    "id": "apex",
+    "name": "Apex",
+    "url": "https://img.shields.io/badge/Apex-blue?style=for-the-badge&logo=salesforce&logoColor=white",
+    "markdown": "![Apex](https://img.shields.io/badge/Apex-blue?style=for-the-badge&logo=salesforce&logoColor=white)",
     "category": "Other"
   },
   {
@@ -3654,13 +4662,6 @@
     "category": "Other"
   },
   {
-    "id": "confluence",
-    "name": "Confluence",
-    "url": "https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white",
-    "markdown": "![Confluence](https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white)",
-    "category": "Other"
-  },
-  {
     "id": "crowdin",
     "name": "Crowdin",
     "url": "https://img.shields.io/badge/Crowdin-2E3340.svg?style=for-the-badge&logo=Crowdin&logoColor=white",
@@ -3668,10 +4669,10 @@
     "category": "Other"
   },
   {
-    "id": "docker",
-    "name": "Docker",
-    "url": "https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white",
-    "markdown": "![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)",
+    "id": "elasticsearch-other",
+    "name": "ElasticSearch",
+    "url": "https://img.shields.io/badge/-ElasticSearch-005571?style=for-the-badge&logo=elasticsearch",
+    "markdown": "![ElasticSearch](https://img.shields.io/badge/-ElasticSearch-005571?style=for-the-badge&logo=elasticsearch)",
     "category": "Other"
   },
   {
@@ -3682,52 +4683,17 @@
     "category": "Other"
   },
   {
-    "id": "elasticsearch",
-    "name": "ElasticSearch",
-    "url": "https://img.shields.io/badge/-ElasticSearch-005571?style=for-the-badge&logo=elasticsearch",
-    "markdown": "![ElasticSearch](https://img.shields.io/badge/-ElasticSearch-005571?style=for-the-badge&logo=elasticsearch)",
-    "category": "Other"
-  },
-  {
-    "id": "espressif",
-    "name": "Espressif",
-    "url": "https://img.shields.io/badge/espressif-E7352C.svg?style=for-the-badge&logo=espressif&logoColor=white",
-    "markdown": "![Espressif](https://img.shields.io/badge/espressif-E7352C.svg?style=for-the-badge&logo=espressif&logoColor=white)",
+    "id": "ffmpeg",
+    "name": "FFmpeg",
+    "url": "https://shields.io/badge/FFmpeg-%23171717.svg?logo=ffmpeg&style=for-the-badge&labelColor=171717&logoColor=5cb85c",
+    "markdown": "![FFmpeg](https://shields.io/badge/FFmpeg-%23171717.svg?logo=ffmpeg&style=for-the-badge&labelColor=171717&logoColor=5cb85c)",
     "category": "Other"
   },
   {
     "id": "google-talkback",
     "name": "Google TalkBack",
-    "url": "https://img.shields.io/badge/Google%20TalkBack-%236636B4.svg?style=for-the-badge&logo=GoogleTalkBack&logoColor=whitee",
+    "url": "https://img.shields.io/badge/Google%20TalkBack-%236636B4.svg?style=for-the-badge&logo=GoogleTalkBack&logoColor=white",
     "markdown": "![Google TalkBack](https://img.shields.io/badge/Google%20TalkBack-%236636B4.svg?style=for-the-badge&logo=GoogleTalkBack&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "gradle",
-    "name": "Gradle",
-    "url": "https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white",
-    "markdown": "![Gradle](https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "grafana",
-    "name": "Grafana",
-    "url": "https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white",
-    "markdown": "![Grafana](https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "home-assistant",
-    "name": "Home Assistant",
-    "url": "https://img.shields.io/badge/home%20assistant-%2341BDF5.svg?style=for-the-badge&logo=home-assistant&logoColor=white",
-    "markdown": "![Home Assistant](https://img.shields.io/badge/home%20assistant-%2341BDF5.svg?style=for-the-badge&logo=home-assistant&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "homebridge",
-    "name": "Homebridge",
-    "url": "https://img.shields.io/badge/homebridge-%23491F59.svg?style=for-the-badge&logo=homebridge&logoColor=white",
-    "markdown": "![Homebridge](https://img.shields.io/badge/homebridge-%23491F59.svg?style=for-the-badge&logo=homebridge&logoColor=white)",
     "category": "Other"
   },
   {
@@ -3745,20 +4711,6 @@
     "category": "Other"
   },
   {
-    "id": "jira",
-    "name": "Jira",
-    "url": "https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white",
-    "markdown": "![Jira](https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "kubernetes",
-    "name": "Kubernetes",
-    "url": "https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white",
-    "markdown": "![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)",
-    "category": "Other"
-  },
-  {
     "id": "meta",
     "name": "Meta",
     "url": "https://img.shields.io/badge/Meta-%230467DF.svg?style=for-the-badge&logo=Meta&logoColor=white",
@@ -3766,10 +4718,10 @@
     "category": "Other"
   },
   {
-    "id": "mosquitto",
-    "name": "Mosquitto",
-    "url": "https://img.shields.io/badge/mosquitto-%233C5280.svg?style=for-the-badge&logo=eclipsemosquitto&logoColor=white",
-    "markdown": "![Mosquitto](https://img.shields.io/badge/mosquitto-%233C5280.svg?style=for-the-badge&logo=eclipsemosquitto&logoColor=white)",
+    "id": "miro",
+    "name": "Miro",
+    "url": "https://img.shields.io/badge/Miro-%23F2CA02.svg?style=for-the-badge&logo=miro&logoColor=black",
+    "markdown": "![Miro](https://img.shields.io/badge/Miro-%23F2CA02.svg?style=for-the-badge&logo=miro&logoColor=black)",
     "category": "Other"
   },
   {
@@ -3797,28 +4749,7 @@
     "id": "openapi-specification",
     "name": "OpenAPI Specification",
     "url": "https://img.shields.io/badge/openapiinitiative-%23000000.svg?style=for-the-badge&logo=openapiinitiative&logoColor=white",
-    "markdown": "![OpenAPI Specification](https://img.shields.io/badge/openapiinitiative-%23000000.svg?style=for-the-badge&logo=openapiinitiative&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "opensea",
-    "name": "OpenSea",
-    "url": "https://img.shields.io/badge/OpenSea-%232081E2.svg?style=for-the-badge&logo=opensea&logoColor=white",
-    "markdown": "![OpenSea](https://img.shields.io/badge/OpenSea-%232081E2.svg?style=for-the-badge&logo=opensea&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "packer",
-    "name": "Packer",
-    "url": "https://img.shields.io/badge/packer-%23E7EEF0.svg?style=for-the-badge&logo=packer&logoColor=%2302A8EF",
-    "markdown": "![Packer](https://img.shields.io/badge/packer-%23E7EEF0.svg?style=for-the-badge&logo=packer&logoColor=%2302A8EF)",
-    "category": "Other"
-  },
-  {
-    "id": "pi-hole",
-    "name": "Pi-Hole",
-    "url": "https://img.shields.io/badge/pihole-%2396060C.svg?style=for-the-badge&logo=pi-hole&logoColor=white",
-    "markdown": "![Pi-Hole](https://img.shields.io/badge/pihole-%2396060C.svg?style=for-the-badge&logo=pi-hole&logoColor=white)",
+    "markdown": "![openapi initiative](https://img.shields.io/badge/openapiinitiative-%23000000.svg?style=for-the-badge&logo=openapiinitiative&logoColor=white)",
     "category": "Other"
   },
   {
@@ -3850,6 +4781,13 @@
     "category": "Other"
   },
   {
+    "id": "prettier-other",
+    "name": "Prettier",
+    "url": "https://img.shields.io/badge/prettier-%23F7B93E.svg?style=for-the-badge&logo=prettier&logoColor=black",
+    "markdown": "![Prettier](https://img.shields.io/badge/prettier-%23F7B93E.svg?style=for-the-badge&logo=prettier&logoColor=black)",
+    "category": "Other"
+  },
+  {
     "id": "prezi",
     "name": "Prezi",
     "url": "https://img.shields.io/badge/Prezi-%23000000.svg?style=for-the-badge&logo=Prezi&logoColor=white",
@@ -3857,24 +4795,17 @@
     "category": "Other"
   },
   {
-    "id": "prometheus",
-    "name": "Prometheus",
-    "url": "https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white",
-    "markdown": "![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white)",
+    "id": "pypi",
+    "name": "PyPi",
+    "url": "https://img.shields.io/badge/pypi-%23ececec.svg?style=for-the-badge&logo=pypi&logoColor=1f73b7",
+    "markdown": "![PyPi](https://img.shields.io/badge/pypi-%23ececec.svg?style=for-the-badge&logo=pypi&logoColor=1f73b7)",
     "category": "Other"
   },
   {
-    "id": "rancher",
-    "name": "Rancher",
-    "url": "https://img.shields.io/badge/rancher-%230075A8.svg?style=for-the-badge&logo=rancher&logoColor=white",
-    "markdown": "![Rancher](https://img.shields.io/badge/rancher-%230075A8.svg?style=for-the-badge&logo=rancher&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "raspberry-pi",
-    "name": "Raspberry Pi",
-    "url": "https://img.shields.io/badge/-RaspberryPi-C51A4A?style=for-the-badge&logo=Raspberry-Pi",
-    "markdown": "![Raspberry Pi](https://img.shields.io/badge/-RaspberryPi-C51A4A?style=for-the-badge&logo=Raspberry-Pi)",
+    "id": "salesforce",
+    "name": "Salesforce",
+    "url": "https://img.shields.io/badge/Salesforce-blue?style=for-the-badge&logo=salesforce&logoColor=white",
+    "markdown": "![Salesforce](https://img.shields.io/badge/Salesforce-blue?style=for-the-badge&logo=salesforce&logoColor=white)",
     "category": "Other"
   },
   {
@@ -3892,24 +4823,10 @@
     "category": "Other"
   },
   {
-    "id": "splunk",
-    "name": "Splunk",
-    "url": "https://img.shields.io/badge/splunk-%23000000.svg?style=for-the-badge&logo=splunk&logoColor=white",
-    "markdown": "![Splunk](https://img.shields.io/badge/splunk-%23000000.svg?style=for-the-badge&logo=splunk&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "swagger",
-    "name": "Swagger",
-    "url": "https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white",
-    "markdown": "![Swagger](https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "terraform",
-    "name": "Terraform",
-    "url": "https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white",
-    "markdown": "![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)",
+    "id": "tampermonkey",
+    "name": "Tampermonkey",
+    "url": "https://img.shields.io/badge/tampermonkey-%2300485B.svg?style=for-the-badge&logo=tampermonkey&logoColor=white",
+    "markdown": "![Tampermonkey](https://img.shields.io/badge/tampermonkey-%2300485B.svg?style=for-the-badge&logo=tampermonkey&logoColor=white)",
     "category": "Other"
   },
   {
@@ -3922,8 +4839,8 @@
   {
     "id": "twilio",
     "name": "Twilio",
-    "url": "https://img.shields.io/badge/Twilio-F22F46?style=for-the-badge&logo=Twilio&logoColor=white",
-    "markdown": "![Twilio](https://img.shields.io/badge/Twilio-F22F46?style=for-the-badge&logo=Twilio&logoColor=white)",
+    "url": "https://img.shields.io/badge/Twilio-F22F46?style=for-the-badge&logo=Twilio logoColor=white",
+    "markdown": "![Twilio](https://img.shields.io/badge/Twilio-F22F46?style=for-the-badge&logo=Twilio logoColor=white)",
     "category": "Other"
   },
   {
@@ -3934,24 +4851,10 @@
     "category": "Other"
   },
   {
-    "id": "ubiquiti",
-    "name": "Ubiquiti",
-    "url": "https://img.shields.io/badge/ubiquiti-%230559C9.svg?style=for-the-badge&logo=ubiquiti&logoColor=white",
-    "markdown": "![Ubiquiti](https://img.shields.io/badge/ubiquiti-%230559C9.svg?style=for-the-badge&logo=ubiquiti&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "vagrant",
-    "name": "Vagrant",
-    "url": "https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white",
-    "markdown": "![Vagrant](https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white)",
-    "category": "Other"
-  },
-  {
     "id": "virtualbox",
     "name": "VirtualBox",
-    "url": "https://img.shields.io/badge/virtualbox-183A61.svg?style=for-the-badge&logo=virtualbox&logoColor=white",
-    "markdown": "![VirtualBox](https://img.shields.io/badge/virtualbox-183A61.svg?style=for-the-badge&logo=virtualbox&logoColor=white)",
+    "url": "https://img.shields.io/badge/virtualbox-%23183A61.svg?style=for-the-badge&logo=virtualbox&logoColor=white",
+    "markdown": "![VirtualBox](https://img.shields.io/badge/virtualbox-%23183A61.svg?style=for-the-badge&logo=virtualbox&logoColor=white)",
     "category": "Other"
   },
   {
@@ -3969,31 +4872,10 @@
     "category": "Other"
   },
   {
-    "id": "wireguard",
-    "name": "Wireguard",
-    "url": "https://img.shields.io/badge/wireguard-%2388171A.svg?style=for-the-badge&logo=wireguard&logoColor=white",
-    "markdown": "![Wireguard](https://img.shields.io/badge/wireguard-%2388171A.svg?style=for-the-badge&logo=wireguard&logoColor=white)",
-    "category": "Other"
-  },
-  {
     "id": "xfce",
     "name": "XFCE",
     "url": "https://img.shields.io/badge/XFCE-%232284F2.svg?style=for-the-badge&logo=xfce&logoColor=white",
     "markdown": "![XFCE](https://img.shields.io/badge/XFCE-%232284F2.svg?style=for-the-badge&logo=xfce&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "zigbee",
-    "name": "Zigbee",
-    "url": "https://img.shields.io/badge/zigbee-%23EB0443.svg?style=for-the-badge&logo=zigbee&logoColor=white",
-    "markdown": "![Zigbee](https://img.shields.io/badge/zigbee-%23EB0443.svg?style=for-the-badge&logo=zigbee&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "platformio",
-    "name": "PlatformIO",
-    "url": "https://img.shields.io/badge/PlatformIO-%23222.svg?style=for-the-badge&logo=platformio&logoColor=%23f5822a",
-    "markdown": "![PlatformIO](https://img.shields.io/badge/PlatformIO-%23222.svg?style=for-the-badge&logo=platformio&logoColor=%23f5822a",
     "category": "Other"
   },
   {
@@ -4002,6 +4884,230 @@
     "url": "https://img.shields.io/badge/XO-%235ED9C7.svg?style=for-the-badge&logo=xo&logoColor=black",
     "markdown": "![XO](https://img.shields.io/badge/XO-%235ED9C7.svg?style=for-the-badge&logo=xo&logoColor=black)",
     "category": "Other"
+  },
+  {
+    "id": "ansible",
+    "name": "Ansible",
+    "url": "https://img.shields.io/badge/ansible-%231A1918.svg?style=for-the-badge&logo=ansible&logoColor=white",
+    "markdown": "![Ansible](https://img.shields.io/badge/ansible-%231A1918.svg?style=for-the-badge&logo=ansible&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "docker",
+    "name": "Docker",
+    "url": "https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white",
+    "markdown": "![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "grafana",
+    "name": "Grafana",
+    "url": "https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white",
+    "markdown": "![Grafana](https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "jira",
+    "name": "Jira",
+    "url": "https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white",
+    "markdown": "![Jira](https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "kubernetes",
+    "name": "Kubernetes",
+    "url": "https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white",
+    "markdown": "![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "opentelemetry",
+    "name": "OpenTelemetry",
+    "url": "https://img.shields.io/badge/OpenTelemetry-FFFFFF?&style=for-the-badge&logo=opentelemetry&logoColor=black",
+    "markdown": "![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-FFFFFF?&style=for-the-badge&logo=opentelemetry&logoColor=black)",
+    "category": "DevOps"
+  },
+  {
+    "id": "packer",
+    "name": "Packer",
+    "url": "https://img.shields.io/badge/packer-%23E7EEF0.svg?style=for-the-badge&logo=packer&logoColor=%2302A8EF",
+    "markdown": "![Packer](https://img.shields.io/badge/packer-%23E7EEF0.svg?style=for-the-badge&logo=packer&logoColor=%2302A8EF)",
+    "category": "DevOps"
+  },
+  {
+    "id": "prometheus",
+    "name": "Prometheus",
+    "url": "https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white",
+    "markdown": "![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "pulumi",
+    "name": "Pulumi",
+    "url": "https://img.shields.io/badge/Pulumi-%238A3391.svg?style=for-the-badge&logo=Pulumi&logoColor=%23f7bf2a",
+    "markdown": "![Pulumi](https://img.shields.io/badge/Pulumi-%238A3391.svg?style=for-the-badge&logo=Pulumi&logoColor=%23f7bf2a)",
+    "category": "DevOps"
+  },
+  {
+    "id": "rancher",
+    "name": "Rancher",
+    "url": "https://img.shields.io/badge/rancher-%230075A8.svg?style=for-the-badge&logo=rancher&logoColor=white",
+    "markdown": "![Rancher](https://img.shields.io/badge/rancher-%230075A8.svg?style=for-the-badge&logo=rancher&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "splunk",
+    "name": "Splunk",
+    "url": "https://img.shields.io/badge/splunk-%23000000.svg?style=for-the-badge&logo=splunk&logoColor=white",
+    "markdown": "![Splunk](https://img.shields.io/badge/splunk-%23000000.svg?style=for-the-badge&logo=splunk&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "terraform",
+    "name": "Terraform",
+    "url": "https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white",
+    "markdown": "![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "vagrant",
+    "name": "Vagrant",
+    "url": "https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white",
+    "markdown": "![Vagrant](https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white)",
+    "category": "DevOps"
+  },
+  {
+    "id": "babel",
+    "name": "Babel",
+    "url": "https://img.shields.io/badge/Babel-F9DC3e?style=for-the-badge&logo=babel&logoColor=black",
+    "markdown": "![Babel](https://img.shields.io/badge/Babel-F9DC3e?style=for-the-badge&logo=babel&logoColor=black)",
+    "category": "Build Toolchains"
+  },
+  {
+    "id": "cmake",
+    "name": "CMake",
+    "url": "https://img.shields.io/badge/CMake-%23008FBA.svg?style=for-the-badge&logo=cmake&logoColor=white",
+    "markdown": "![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?style=for-the-badge&logo=cmake&logoColor=white)",
+    "category": "Build Toolchains"
+  },
+  {
+    "id": "gradle",
+    "name": "Gradle",
+    "url": "https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white",
+    "markdown": "![Gradle](https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white)",
+    "category": "Build Toolchains"
+  },
+  {
+    "id": "platformio-build-toolchains",
+    "name": "PlatformIO",
+    "url": "https://img.shields.io/badge/PlatformIO-%23222.svg?style=for-the-badge&logo=platformio&logoColor=%23f5822a",
+    "markdown": "![PlatformIO](https://img.shields.io/badge/PlatformIO-%23222.svg?style=for-the-badge&logo=platformio&logoColor=%23f5822a)",
+    "category": "Build Toolchains"
+  },
+  {
+    "id": "arduino",
+    "name": "Arduino",
+    "url": "https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white",
+    "markdown": "![Arduino](https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "espressif",
+    "name": "Espressif",
+    "url": "https://img.shields.io/badge/espressif-E7352C.svg?style=for-the-badge&logo=espressif&logoColor=white",
+    "markdown": "![Espressif](https://img.shields.io/badge/espressif-E7352C.svg?style=for-the-badge&logo=espressif&logoColor=white)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "home-assistant",
+    "name": "Home Assistant",
+    "url": "https://img.shields.io/badge/home%20assistant-%2341BDF5.svg?style=for-the-badge&logo=home-assistant&logoColor=white",
+    "markdown": "![Home Assistant](https://img.shields.io/badge/home%20assistant-%2341BDF5.svg?style=for-the-badge&logo=home-assistant&logoColor=white)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "homebridge",
+    "name": "Homebridge",
+    "url": "https://img.shields.io/badge/homebridge-%23491F59.svg?style=for-the-badge&logo=homebridge&logoColor=white",
+    "markdown": "![Homebridge](https://img.shields.io/badge/homebridge-%23491F59.svg?style=for-the-badge&logo=homebridge&logoColor=white)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "mosquitto",
+    "name": "Mosquitto",
+    "url": "https://img.shields.io/badge/mosquitto-%233C5280.svg?style=for-the-badge&logo=eclipsemosquitto&logoColor=white",
+    "markdown": "![Mosquitto](https://img.shields.io/badge/mosquitto-%233C5280.svg?style=for-the-badge&logo=eclipsemosquitto&logoColor=white)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "raspberry-pi",
+    "name": "Raspberry Pi",
+    "url": "https://img.shields.io/badge/-Raspberry_Pi-C51A4A?style=for-the-badge&logo=Raspberry-Pi",
+    "markdown": "![Raspberry Pi](https://img.shields.io/badge/-Raspberry_Pi-C51A4A?style=for-the-badge&logo=Raspberry-Pi)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "zigbee",
+    "name": "Zigbee",
+    "url": "https://img.shields.io/badge/zigbee-%23EB0443.svg?style=for-the-badge&logo=zigbee&logoColor=white",
+    "markdown": "![Zigbee](https://img.shields.io/badge/zigbee-%23EB0443.svg?style=for-the-badge&logo=zigbee&logoColor=white)",
+    "category": "Home Automation"
+  },
+  {
+    "id": "cisco",
+    "name": "Cisco",
+    "url": "https://img.shields.io/badge/cisco-%23049fd9.svg?style=for-the-badge&logo=cisco&logoColor=black",
+    "markdown": "![Cisco](https://img.shields.io/badge/cisco-%23049fd9.svg?style=for-the-badge&logo=cisco&logoColor=black)",
+    "category": "Networking"
+  },
+  {
+    "id": "pi-hole",
+    "name": "Pi-Hole",
+    "url": "https://img.shields.io/badge/pihole-%2396060C.svg?style=for-the-badge&logo=pi-hole&logoColor=white",
+    "markdown": "![Pi-Hole](https://img.shields.io/badge/pihole-%2396060C.svg?style=for-the-badge&logo=pi-hole&logoColor=white)",
+    "category": "Networking"
+  },
+  {
+    "id": "ubiquiti",
+    "name": "Ubiquiti",
+    "url": "https://img.shields.io/badge/ubiquiti-%230559C9.svg?style=for-the-badge&logo=ubiquiti&logoColor=white",
+    "markdown": "![Ubiquiti](https://img.shields.io/badge/ubiquiti-%230559C9.svg?style=for-the-badge&logo=ubiquiti&logoColor=white)",
+    "category": "Networking"
+  },
+  {
+    "id": "wireguard",
+    "name": "Wireguard",
+    "url": "https://img.shields.io/badge/wireguard-%2388171A.svg?style=for-the-badge&logo=wireguard&logoColor=white",
+    "markdown": "![Wireguard](https://img.shields.io/badge/wireguard-%2388171A.svg?style=for-the-badge&logo=wireguard&logoColor=white)",
+    "category": "Networking"
+  },
+  {
+    "id": "aqua-sec",
+    "name": "Aqua Sec",
+    "url": "https://img.shields.io/badge/aqua-%231904DA.svg?style=for-the-badge&logo=aqua&logoColor=#0018A8",
+    "markdown": "![AquaSec](https://img.shields.io/badge/aqua-%231904DA.svg?style=for-the-badge&logo=aqua&logoColor=#0018A8)",
+    "category": "Security"
+  },
+  {
+    "id": "bitwarden",
+    "name": "Bitwarden",
+    "url": "https://img.shields.io/badge/bitwarden-%23175DDC.svg?style=for-the-badge&logo=bitwarden&logoColor=white",
+    "markdown": "![Bitwarden](https://img.shields.io/badge/bitwarden-%23175DDC.svg?style=for-the-badge&logo=bitwarden&logoColor=white)",
+    "category": "Security"
+  },
+  {
+    "id": "tor-security",
+    "name": "TOR",
+    "url": "https://img.shields.io/badge/tor-%237E4798.svg?style=for-the-badge&logo=tor-project&logoColor=white",
+    "markdown": "![TOR](https://img.shields.io/badge/tor-%237E4798.svg?style=for-the-badge&logo=tor-project&logoColor=white)",
+    "category": "Security"
+  },
+  {
+    "id": "d-wave",
+    "name": "D-Wave",
+    "url": "https://img.shields.io/badge/dwave-%23008CD7.svg?style=for-the-badge&logo=dwavesystems&logoColor=white",
+    "markdown": "![D-Wave](https://img.shields.io/badge/dwave-%23008CD7.svg?style=for-the-badge&logo=dwavesystems&logoColor=white)",
+    "category": "Quantum Programming"
   },
   {
     "id": "qiskit",
@@ -4025,10 +5131,24 @@
     "category": "Search Engines"
   },
   {
-    "id": "duckduckgo",
+    "id": "brave-search-engines",
+    "name": "Brave",
+    "url": "https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white",
+    "markdown": "![Brave](https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "duckduckgo-search-engines",
     "name": "DuckDuckGo",
     "url": "https://img.shields.io/badge/DuckDuckGo-DE5833?style=for-the-badge&logo=DuckDuckGo&logoColor=white",
     "markdown": "![DuckDuckGo](https://img.shields.io/badge/DuckDuckGo-DE5833?style=for-the-badge&logo=DuckDuckGo&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "ecosia",
+    "name": "Ecosia",
+    "url": "https://img.shields.io/badge/ecosia-%23008009.svg?style=for-the-badge&logo=ecosia&logoColor=white",
+    "markdown": "![Ecosia](https://img.shields.io/badge/ecosia-%23008009.svg?style=for-the-badge&logo=ecosia&logoColor=white)",
     "category": "Search Engines"
   },
   {
@@ -4036,6 +5156,48 @@
     "name": "Google",
     "url": "https://img.shields.io/badge/google-4285F4?style=for-the-badge&logo=google&logoColor=white",
     "markdown": "![Google](https://img.shields.io/badge/google-4285F4?style=for-the-badge&logo=google&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "kagi",
+    "name": "Kagi",
+    "url": "https://img.shields.io/badge/kagi-%23FFB319.svg?style=for-the-badge&logo=kagi&logoColor=black",
+    "markdown": "![Kagi](https://img.shields.io/badge/kagi-%23FFB319.svg?style=for-the-badge&logo=kagi&logoColor=black)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "mojeek",
+    "name": "Mojeek",
+    "url": "https://img.shields.io/badge/mojeek-%237AB93C.svg?style=for-the-badge&logo=mojeek&logoColor=white",
+    "markdown": "![Mojeek](https://img.shields.io/badge/mojeek-%237AB93C.svg?style=for-the-badge&logo=mojeek&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "naver",
+    "name": "Naver",
+    "url": "https://img.shields.io/badge/naver-%2303C75A.svg?style=for-the-badge&logo=naver&logoColor=white",
+    "markdown": "![Naver](https://img.shields.io/badge/naver-%2303C75A.svg?style=for-the-badge&logo=naver&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "qwant",
+    "name": "Qwant",
+    "url": "https://img.shields.io/badge/qwant-%23282B2F.svg?style=for-the-badge&logo=qwant&logoColor=white",
+    "markdown": "![Qwant](https://img.shields.io/badge/qwant-%23282B2F.svg?style=for-the-badge&logo=qwant&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "searxng",
+    "name": "Searxng",
+    "url": "https://img.shields.io/badge/searxng-%233050FF.svg?style=for-the-badge&logo=searxng&logoColor=white",
+    "markdown": "![Searxng](https://img.shields.io/badge/searxng-%233050FF.svg?style=for-the-badge&logo=searxng&logoColor=white)",
+    "category": "Search Engines"
+  },
+  {
+    "id": "startpage",
+    "name": "Startpage",
+    "url": "https://img.shields.io/badge/startpage-%236563FF.svg?style=for-the-badge&logo=startpage&logoColor=white",
+    "markdown": "![Startpage](https://img.shields.io/badge/startpage-%236563FF.svg?style=for-the-badge&logo=startpage&logoColor=white)",
     "category": "Search Engines"
   },
   {
@@ -4102,17 +5264,38 @@
     "category": "Servers"
   },
   {
-    "id": "kemp-vlm",
-    "name": "Kemp VLM",
+    "id": "nginx",
+    "name": "Nginx",
+    "url": "https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white",
+    "markdown": "![Nginx](https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white)",
+    "category": "Servers"
+  },
+  {
+    "id": "nginx-proxy-manager",
+    "name": "Nginx Proxy Manager",
+    "url": "https://img.shields.io/badge/nginx_proxy_manager-%23F15833.svg?style=for-the-badge&logo=nginxproxymanager&logoColor=white",
+    "markdown": "![Nginx Proxy Manager](https://img.shields.io/badge/nginx_proxy_manager-%23F15833.svg?style=for-the-badge&logo=nginxproxymanager&logoColor=white)",
+    "category": "Servers"
+  },
+  {
+    "id": "portainer",
+    "name": "Portainer",
+    "url": "https://img.shields.io/badge/portainer-%2313BEF9.svg?style=for-the-badge&logo=portainer&logoColor=white",
+    "markdown": "![Portainer](https://img.shields.io/badge/portainer-%2313BEF9.svg?style=for-the-badge&logo=portainer&logoColor=white)",
+    "category": "Servers"
+  },
+  {
+    "id": "progress-kemp-virtual-loadmaster",
+    "name": "Progress Kemp Virtual LoadMaster",
     "url": "https://img.shields.io/badge/Kemp%20VLM-%23fedd00.svg?style=for-the-badge&logo=progress&logoColor=%235ce500",
     "markdown": "![Kemp VLM](https://img.shields.io/badge/Kemp%20VLM-%23fedd00.svg?style=for-the-badge&logo=progress&logoColor=%235ce500)",
     "category": "Servers"
   },
   {
-    "id": "nginx",
-    "name": "Nginx",
-    "url": "https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white",
-    "markdown": "![Nginx](https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white)",
+    "id": "traefikproxy",
+    "name": "TraefikProxy",
+    "url": "https://img.shields.io/badge/Traefik-%252300314b.svg?style=for-the-badge&logo=traefikproxy&logoColor=white",
+    "markdown": "![TraefikProxy](https://img.shields.io/badge/Traefik-%252300314b.svg?style=for-the-badge&logo=traefikproxy&logoColor=white)",
     "category": "Servers"
   },
   {
@@ -4127,6 +5310,27 @@
     "name": "Bluesky",
     "url": "https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=Bluesky&logoColor=white",
     "markdown": "![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=Bluesky&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "buy-me-a-coffee-social",
+    "name": "Buy Me a Coffee",
+    "url": "https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black",
+    "markdown": "![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)",
+    "category": "Social"
+  },
+  {
+    "id": "calendly",
+    "name": "Calendly",
+    "url": "https://img.shields.io/badge/Calendly-%23006BFF.svg?style=for-the-badge&logo=Calendly&logoColor=white",
+    "markdown": "![Calendly](https://img.shields.io/badge/Calendly-%23006BFF.svg?style=for-the-badge&logo=Calendly&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "chess.com",
+    "name": "Chess.com",
+    "url": "https://img.shields.io/badge/Chess.com-81B64C?style=for-the-badge&logo=chessdotcom&logoColor=white",
+    "markdown": "![Chess.com](https://img.shields.io/badge/Chess.com-81B64C?style=for-the-badge&logo=chessdotcom&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4186,6 +5390,13 @@
     "category": "Social"
   },
   {
+    "id": "lichess",
+    "name": "Lichess",
+    "url": "https://img.shields.io/badge/Lichess-000000?style=for-the-badge&logo=lichess&logoColor=white",
+    "markdown": "![Lichess](https://img.shields.io/badge/Lichess-000000?style=for-the-badge&logo=lichess&logoColor=white)",
+    "category": "Social"
+  },
+  {
     "id": "line",
     "name": "Line",
     "url": "https://img.shields.io/badge/Line-00C300?style=for-the-badge&logo=line&logoColor=white",
@@ -4207,6 +5418,20 @@
     "category": "Social"
   },
   {
+    "id": "mastodon",
+    "name": "Mastodon",
+    "url": "https://img.shields.io/badge/-MASTODON-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white",
+    "markdown": "![Mastodon](https://img.shields.io/badge/-MASTODON-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "matrix",
+    "name": "Matrix",
+    "url": "https://img.shields.io/badge/matrix-%23000000?style=for-the-badge&logo=matrix&logoColor=white",
+    "markdown": "![Matrix](https://img.shields.io/badge/matrix-%23000000?style=for-the-badge&logo=matrix&logoColor=white)",
+    "category": "Social"
+  },
+  {
     "id": "meetup",
     "name": "Meetup",
     "url": "https://img.shields.io/badge/Meetup-f64363?style=for-the-badge&logo=meetup&logoColor=white",
@@ -4221,10 +5446,17 @@
     "category": "Social"
   },
   {
-    "id": "mastodon",
-    "name": "Mastodon",
-    "url": "https://img.shields.io/badge/-MASTODON-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white",
-    "markdown": "![Mastodon](https://img.shields.io/badge/-MASTODON-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white)",
+    "id": "misskey",
+    "name": "Misskey",
+    "url": "https://img.shields.io/badge/Misskey-%232EC866.svg?style=for-the-badge&logo=misskey&logoColor=white",
+    "markdown": "![Misskey](https://img.shields.io/badge/Misskey-%232EC866.svg?style=for-the-badge&logo=misskey&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "odysee",
+    "name": "Odysee",
+    "url": "https://img.shields.io/badge/odysee-EF1970?style=for-the-badge&logo=Odysee&logoColor=white",
+    "markdown": "![Odysee](https://img.shields.io/badge/odysee-EF1970?style=for-the-badge&logo=Odysee&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4235,24 +5467,10 @@
     "category": "Social"
   },
   {
-    "id": "odysee",
-    "name": "Odysee",
-    "url": "https://img.shields.io/badge/odysee-EF1970?style=for-the-badge&logo=Odysee&logoColor=white",
-    "markdown": "![OutOdyseelook](https://img.shields.io/badge/odysee-EF1970?style=for-the-badge&logo=Odysee&logoColor=white)",
-    "category": "Social"
-  },
-  {
     "id": "pinterest",
     "name": "Pinterest",
     "url": "https://img.shields.io/badge/Pinterest-%23E60023.svg?style=for-the-badge&logo=Pinterest&logoColor=white",
     "markdown": "![Pinterest](https://img.shields.io/badge/Pinterest-%23E60023.svg?style=for-the-badge&logo=Pinterest&logoColor=white)",
-    "category": "Social"
-  },
-  {
-    "id": "protonmail",
-    "name": "Protonmail",
-    "url": "https://img.shields.io/badge/ProtonMail-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white",
-    "markdown": "![Protonmail](https://img.shields.io/badge/ProtonMail-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4263,10 +5481,31 @@
     "category": "Social"
   },
   {
-    "id": "reddit",
+    "id": "protonmail",
+    "name": "Protonmail",
+    "url": "https://img.shields.io/badge/ProtonMail-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white",
+    "markdown": "![Protonmail](https://img.shields.io/badge/ProtonMail-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "reddit-social",
     "name": "Reddit",
     "url": "https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white",
     "markdown": "![Reddit](https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "session",
+    "name": "Session",
+    "url": "https://img.shields.io/badge/Session-%23000000.svg?style=for-the-badge&logo=Session&logoColor=02f780",
+    "markdown": "![Session](https://img.shields.io/badge/Session-%23000000.svg?style=for-the-badge&logo=Session&logoColor=02f780)",
+    "category": "Social"
+  },
+  {
+    "id": "showwcase",
+    "name": "Showwcase",
+    "url": "https://img.shields.io/badge/showwcase-%230A0D14.svg?style=for-the-badge&logo=showwcase&logoColor=white",
+    "markdown": "![Showwcase](https://img.shields.io/badge/showwcase-%230A0D14.svg?style=for-the-badge&logo=showwcase&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4314,15 +5553,15 @@
   {
     "id": "tencent-qq",
     "name": "Tencent QQ",
-    "url": "https://img.shields.io/badge/Tencent%23QQ-%2312B7F5?style=for-the-badge&logo=tencentqq&logoColor=white",
-    "markdown": "![Tencent QQ](https://img.shields.io/badge/Tencent%23QQ-%2312B7F5?style=for-the-badge&logo=tencentqq&logoColor=white)",
+    "url": "https://img.shields.io/badge/Tencent_QQ-%2312B7F5?style=for-the-badge&logo=qq&logoColor=white",
+    "markdown": "![Tencent QQ](https://img.shields.io/badge/Tencent_QQ-%2312B7F5?style=for-the-badge&logo=qq&logoColor=white)",
     "category": "Social"
   },
   {
-    "id": "tiktok",
-    "name": "TikTok",
-    "url": "https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white",
-    "markdown": "![TikTok](https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white)",
+    "id": "threads",
+    "name": "Threads",
+    "url": "https://img.shields.io/badge/Threads-000000?style=for-the-badge&logo=Threads&logoColor=white",
+    "markdown": "![Threads](https://img.shields.io/badge/Threads-000000?style=for-the-badge&logo=Threads&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4330,6 +5569,13 @@
     "name": "Thunderbird",
     "url": "https://img.shields.io/badge/Thunderbird-0A84FF.svg?style=for-the-badge&logo=Thunderbird&logoColor=white",
     "markdown": "![Thunderbird](https://img.shields.io/badge/Thunderbird-0A84FF.svg?style=for-the-badge&logo=Thunderbird&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "tiktok",
+    "name": "TikTok",
+    "url": "https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white",
+    "markdown": "![TikTok](https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4344,6 +5590,13 @@
     "name": "Tutanota",
     "url": "https://img.shields.io/badge/Tutanota-840010?style=for-the-badge&logo=Tutanota&logoColor=white",
     "markdown": "![Tutanota](https://img.shields.io/badge/Tutanota-840010?style=for-the-badge&logo=Tutanota&logoColor=white)",
+    "category": "Social"
+  },
+  {
+    "id": "twitch",
+    "name": "Twitch",
+    "url": "https://img.shields.io/badge/Twitch-%239146FF.svg?style=for-the-badge&logo=Twitch&logoColor=white",
+    "markdown": "![Twitch](https://img.shields.io/badge/Twitch-%239146FF.svg?style=for-the-badge&logo=Twitch&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4382,7 +5635,7 @@
     "category": "Social"
   },
   {
-    "id": "xbox",
+    "id": "xbox-social",
     "name": "Xbox",
     "url": "https://img.shields.io/badge/Xbox-%23107C10.svg?style=for-the-badge&logo=Xbox&logoColor=white",
     "markdown": "![Xbox](https://img.shields.io/badge/Xbox-%23107C10.svg?style=for-the-badge&logo=Xbox&logoColor=white)",
@@ -4407,13 +5660,6 @@
     "name": "Zoom",
     "url": "https://img.shields.io/badge/Zoom-2D8CFF?style=for-the-badge&logo=zoom&logoColor=white",
     "markdown": "![Zoom](https://img.shields.io/badge/Zoom-2D8CFF?style=for-the-badge&logo=zoom&logoColor=white)",
-    "category": "Social"
-  },
-  {
-    "id": "threads",
-    "name": "Threads",
-    "url": "https://img.shields.io/badge/Threads-000000?style=for-the-badge&logo=Threads&logoColor=white",
-    "markdown": "![Threads](https://img.shields.io/badge/Threads-000000?style=for-the-badge&logo=Threads&logoColor=white)",
     "category": "Social"
   },
   {
@@ -4459,13 +5705,6 @@
     "category": "Smartphone"
   },
   {
-    "id": "oneplus",
-    "name": "OnePlus",
-    "url": "https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white",
-    "markdown": "![OnePlus](https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white)",
-    "category": "Smartphone"
-  },
-  {
     "id": "motorola",
     "name": "Motorola",
     "url": "https://img.shields.io/badge/Motorola-%23E1140A.svg?style=for-the-badge&logo=motorola&logoColor=white",
@@ -4480,10 +5719,31 @@
     "category": "Smartphone"
   },
   {
+    "id": "oneplus",
+    "name": "OnePlus",
+    "url": "https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white",
+    "markdown": "![OnePlus](https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white)",
+    "category": "Smartphone"
+  },
+  {
+    "id": "oppo",
+    "name": "Oppo",
+    "url": "https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white",
+    "markdown": "![Oppo](https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white)",
+    "category": "Smartphone"
+  },
+  {
     "id": "samsung",
     "name": "Samsung",
     "url": "https://img.shields.io/badge/Samsung-%231428A0.svg?style=for-the-badge&logo=samsung&logoColor=white",
     "markdown": "![Samsung](https://img.shields.io/badge/Samsung-%231428A0.svg?style=for-the-badge&logo=samsung&logoColor=white)",
+    "category": "Smartphone"
+  },
+  {
+    "id": "vivo",
+    "name": "Vivo",
+    "url": "https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black",
+    "markdown": "![Vivo](https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black)",
     "category": "Smartphone"
   },
   {
@@ -4501,17 +5761,17 @@
     "category": "Store"
   },
   {
+    "id": "appgallery",
+    "name": "AppGallery",
+    "url": "https://img.shields.io/badge/AppGallery-C80A2D?style=for-the-badge&logo=huawei&logoColor=white",
+    "markdown": "![AppGallery](https://img.shields.io/badge/AppGallery-C80A2D?style=for-the-badge&logo=huawei&logoColor=white)",
+    "category": "Store"
+  },
+  {
     "id": "f-droid",
     "name": "F-Droid",
     "url": "https://img.shields.io/badge/F_Droid-1976D2?style=for-the-badge&logo=f-droid&logoColor=white",
     "markdown": "![F Droid](https://img.shields.io/badge/F_Droid-1976D2?style=for-the-badge&logo=f-droid&logoColor=white)",
-    "category": "Store"
-  },
-  {
-    "id": "play-store",
-    "name": "Play Store",
-    "url": "https://img.shields.io/badge/Google_Play-414141?style=for-the-badge&logo=google-play&logoColor=white",
-    "markdown": "![Play Store](https://img.shields.io/badge/Google_Play-414141?style=for-the-badge&logo=google-play&logoColor=white)",
     "category": "Store"
   },
   {
@@ -4522,24 +5782,10 @@
     "category": "Store"
   },
   {
-    "id": "appgallery",
-    "name": "AppGallery",
-    "url": "https://img.shields.io/badge/AppGallery-C80A2D?style=for-the-badge&logo=huawei&logoColor=white",
-    "markdown": "![AppGallery](https://img.shields.io/badge/AppGallery-C80A2D?style=for-the-badge&logo=huawei&logoColor=white)",
-    "category": "Store"
-  },
-  {
     "id": "amazon-prime",
     "name": "Amazon Prime",
     "url": "https://img.shields.io/badge/Amazon%20Prime-0F79AF?style=for-the-badge&logo=amazonprime&logoColor=white",
     "markdown": "![Amazon Prime](https://img.shields.io/badge/Amazon%20Prime-0F79AF?style=for-the-badge&logo=amazonprime&logoColor=white)",
-    "category": "Streaming"
-  },
-  {
-    "id": "bilibili",
-    "name": "Bilibili",
-    "url": "https://img.shields.io/badge/bilibili-00A1D6.svg?style=for-the-badge&logo=bilibili&logoColor=white",
-    "markdown": "![Bilibili](https://img.shields.io/badge/bilibili-00A1D6.svg?style=for-the-badge&logo=bilibili&logoColor=white)",
     "category": "Streaming"
   },
   {
@@ -4550,10 +5796,24 @@
     "category": "Streaming"
   },
   {
+    "id": "bilibili",
+    "name": "Bilibili",
+    "url": "https://img.shields.io/badge/bilibili-00A1D6.svg?style=for-the-badge&logo=bilibili&logoColor=white",
+    "markdown": "![Bilibili](https://img.shields.io/badge/bilibili-00A1D6.svg?style=for-the-badge&logo=bilibili&logoColor=white)",
+    "category": "Streaming"
+  },
+  {
     "id": "crunchyroll",
     "name": "Crunchyroll",
     "url": "https://img.shields.io/badge/Crunchyroll-F47521?style=for-the-badge&logo=crunchyroll&logoColor=white",
-    "markdown": "![Crunchroll](https://img.shields.io/badge/Crunchyroll-F47521?style=for-the-badge&logo=crunchyroll&logoColor=white)",
+    "markdown": "![Crunchyroll](https://img.shields.io/badge/Crunchyroll-F47521?style=for-the-badge&logo=crunchyroll&logoColor=white)",
+    "category": "Streaming"
+  },
+  {
+    "id": "disney",
+    "name": "Disney",
+    "url": "https://img.shields.io/badge/Disney-%23006E99.svg?style=for-the-badge&logo=disney&logoColor=white",
+    "markdown": "![Disney](https://img.shields.io/badge/Disney-%23006E99.svg?style=for-the-badge&logo=disney&logoColor=white)",
     "category": "Streaming"
   },
   {
@@ -4599,17 +5859,17 @@
     "category": "Streaming"
   },
   {
+    "id": "kick",
+    "name": "Kick",
+    "url": "https://img.shields.io/badge/kick-53FC18?style=for-the-badge&logo=kick&logoColor=white",
+    "markdown": "![Kick](https://img.shields.io/badge/kick-53FC18?style=for-the-badge&logo=kick&logoColor=white)",
+    "category": "Streaming"
+  },
+  {
     "id": "netflix",
     "name": "Netflix",
     "url": "https://img.shields.io/badge/Netflix-E50914?style=for-the-badge&logo=netflix&logoColor=white",
     "markdown": "![Netflix](https://img.shields.io/badge/Netflix-E50914?style=for-the-badge&logo=netflix&logoColor=white)",
-    "category": "Streaming"
-  },
-  {
-    "id": "tubi",
-    "name": "Tubi",
-    "url": "https://img.shields.io/badge/Tubi-6A18F5?style=for-the-badge&logo=tubi&logoColor=white",
-    "markdown": "![Tubi](https://img.shields.io/badge/Tubi-6A18F5?style=for-the-badge&logo=tubi&logoColor=white)",
     "category": "Streaming"
   },
   {
@@ -4620,7 +5880,14 @@
     "category": "Streaming"
   },
   {
-    "id": "twitch",
+    "id": "tubi",
+    "name": "Tubi",
+    "url": "https://img.shields.io/badge/Tubi-6A18F5?style=for-the-badge&logo=tubi&logoColor=white",
+    "markdown": "![Tubi](https://img.shields.io/badge/Tubi-6A18F5?style=for-the-badge&logo=tubi&logoColor=white)",
+    "category": "Streaming"
+  },
+  {
+    "id": "twitch-streaming",
     "name": "Twitch",
     "url": "https://img.shields.io/badge/Twitch-9347FF?style=for-the-badge&logo=twitch&logoColor=white",
     "markdown": "![Twitch](https://img.shields.io/badge/Twitch-9347FF?style=for-the-badge&logo=twitch&logoColor=white)",
@@ -4634,14 +5901,84 @@
     "category": "Streaming"
   },
   {
-    "id": "cypress",
-    "name": "Cypress",
-    "url": "https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e",
-    "markdown": "![Cypress](https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e)",
+    "id": "alacritty",
+    "name": "Alacritty",
+    "url": "https://img.shields.io/badge/alacritty-%23F46D01?style=for-the-badge&logo=alacritty&logoColor=white",
+    "markdown": "![Alacritty](https://img.shields.io/badge/alacritty-%23F46D01?style=for-the-badge&logo=alacritty&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "gnome-terminal",
+    "name": "GNOME Terminal",
+    "url": "https://img.shields.io/badge/gnometerminal-%23ffffff.svg?style=for-the-badge&logo=gnometerminal&logoColor=%23241F31",
+    "markdown": "![GNOME Terminal](https://img.shields.io/badge/gnometerminal-%23ffffff.svg?style=for-the-badge&logo=gnometerminal&logoColor=%23241F31)",
+    "category": "Terminals"
+  },
+  {
+    "id": "hyper",
+    "name": "Hyper",
+    "url": "https://img.shields.io/badge/Hyper-%23000000?style=for-the-badge&logo=hyper&logoColor=white",
+    "markdown": "![Hyper](https://img.shields.io/badge/Hyper-%23000000?style=for-the-badge&logo=hyper&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "iterm2",
+    "name": "iTerm2",
+    "url": "https://img.shields.io/badge/iTerm2-%23000000?style=for-the-badge&logo=iterm2&logoColor=white",
+    "markdown": "![iTerm2](https://img.shields.io/badge/iTerm2-%23000000?style=for-the-badge&logo=iterm2&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "starship",
+    "name": "Starship",
+    "url": "https://img.shields.io/badge/starship-%23DD0B78?style=for-the-badge&logo=starship&logoColor=white",
+    "markdown": "![Starship](https://img.shields.io/badge/starship-%23DD0B78?style=for-the-badge&logo=starship&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "termius",
+    "name": "Termius",
+    "url": "https://img.shields.io/badge/termius-%23000000?style=for-the-badge&logo=termius&logoColor=white",
+    "markdown": "![Termius](https://img.shields.io/badge/termius-%23000000?style=for-the-badge&logo=termius&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "tmux",
+    "name": "tmux",
+    "url": "https://img.shields.io/badge/tmux-%23000000?style=for-the-badge&logo=tmux&logoColor=%231BB91F",
+    "markdown": "![tmux](https://img.shields.io/badge/tmux-%23000000?style=for-the-badge&logo=tmux&logoColor=%231BB91F)",
+    "category": "Terminals"
+  },
+  {
+    "id": "warp",
+    "name": "Warp",
+    "url": "https://img.shields.io/badge/warp-%2301A4FF?style=for-the-badge&logo=warp&logoColor=white",
+    "markdown": "![Warp](https://img.shields.io/badge/warp-%2301A4FF?style=for-the-badge&logo=warp&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "wezterm",
+    "name": "WezTerm",
+    "url": "https://img.shields.io/badge/WezTerm-%234E49EE?style=for-the-badge&logo=wezterm&logoColor=white",
+    "markdown": "![WezTerm](https://img.shields.io/badge/WezTerm-%234E49EE?style=for-the-badge&logo=wezterm&logoColor=white)",
+    "category": "Terminals"
+  },
+  {
+    "id": "apifox",
+    "name": "Apifox",
+    "url": "https://img.shields.io/badge/Apifox-%23FF6600.svg?style=for-the-badge&logo=apifox&logoColor=white",
+    "markdown": "![Apifox](https://img.shields.io/badge/Apifox-%23FF6600.svg?style=for-the-badge&logo=apifox&logoColor=white)",
     "category": "Testing"
   },
   {
-    "id": "jasmine",
+    "id": "cypress",
+    "name": "Cypress",
+    "url": "https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e",
+    "markdown": "![cypress](https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e)",
+    "category": "Testing"
+  },
+  {
+    "id": "jasmine-testing",
     "name": "Jasmine",
     "url": "https://img.shields.io/badge/-Jasmine-%238A4182?style=for-the-badge&logo=Jasmine&logoColor=white",
     "markdown": "![Jasmine](https://img.shields.io/badge/-Jasmine-%238A4182?style=for-the-badge&logo=Jasmine&logoColor=white)",
@@ -4662,6 +5999,27 @@
     "category": "Testing"
   },
   {
+    "id": "playwright",
+    "name": "Playwright",
+    "url": "https://img.shields.io/badge/-playwright-%232EAD33?style=for-the-badge&logo=playwright&logoColor=white",
+    "markdown": "![Playwright](https://img.shields.io/badge/-playwright-%232EAD33?style=for-the-badge&logo=playwright&logoColor=white)",
+    "category": "Testing"
+  },
+  {
+    "id": "puppeteer",
+    "name": "Puppeteer",
+    "url": "https://img.shields.io/badge/Puppeteer-%2340B5A4.svg?style=for-the-badge&logo=Puppeteer&logoColor=black",
+    "markdown": "![Puppeteer](https://img.shields.io/badge/Puppeteer-%2340B5A4.svg?style=for-the-badge&logo=Puppeteer&logoColor=black)",
+    "category": "Testing"
+  },
+  {
+    "id": "pytest",
+    "name": "Pytest",
+    "url": "https://img.shields.io/badge/pytest-%23ffffff.svg?style=for-the-badge&logo=pytest&logoColor=2f9fe3",
+    "markdown": "![Pytest](https://img.shields.io/badge/pytest-%23ffffff.svg?style=for-the-badge&logo=pytest&logoColor=2f9fe3)",
+    "category": "Testing"
+  },
+  {
     "id": "selenium",
     "name": "Selenium",
     "url": "https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white",
@@ -4669,10 +6027,24 @@
     "category": "Testing"
   },
   {
+    "id": "sentry",
+    "name": "Sentry",
+    "url": "https://img.shields.io/badge/sentry-%23362D59.svg?style=for-the-badge&logo=sentry&logoColor=white",
+    "markdown": "![Sentry](https://img.shields.io/badge/sentry-%23362D59.svg?style=for-the-badge&logo=sentry&logoColor=white)",
+    "category": "Testing"
+  },
+  {
     "id": "testing-library",
     "name": "Testing Library",
     "url": "https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white",
     "markdown": "![Testing-Library](https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white)",
+    "category": "Testing"
+  },
+  {
+    "id": "vitest",
+    "name": "Vitest",
+    "url": "https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B",
+    "markdown": "![Vitest](https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B)",
     "category": "Testing"
   },
   {
@@ -4748,8 +6120,8 @@
   {
     "id": "perforce-helix",
     "name": "Perforce Helix",
-    "url": "https://img.shields.io/badge/-PERFORCE%20HELIX-404040?style=for-the-badge&logo=Perforce&logoColor=white",
-    "markdown": "![Perforce Helix](https://img.shields.io/badge/-PERFORCE%20HELIX-404040?style=for-the-badge&logo=Perforce&logoColor=white)",
+    "url": "https://img.shields.io/badge/-PERFORCE%20HELIX-00AEEF?style=for-the-badge&logo=Perforce&logoColor=white",
+    "markdown": "![Perforce Helix](https://img.shields.io/badge/-PERFORCE%20HELIX-00AEEF?style=for-the-badge&logo=Perforce&logoColor=white)",
     "category": "Version Control"
   },
   {
@@ -4795,7 +6167,7 @@
     "category": "Jobs"
   },
   {
-    "id": "hackerrank",
+    "id": "hackerrank-jobs",
     "name": "HackerRank",
     "url": "https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white",
     "markdown": "![HackerRank](https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white)",
@@ -4813,27 +6185,6 @@
     "name": "Upwork",
     "url": "https://img.shields.io/badge/UpWork-6FDA44?style=for-the-badge&logo=Upwork&logoColor=white",
     "markdown": "![Upwork](https://img.shields.io/badge/UpWork-6FDA44?style=for-the-badge&logo=Upwork&logoColor=white)",
-    "category": "Jobs"
-  },
-  {
-    "id": "google-earth-engine",
-    "name": "Google Earth Engine",
-    "url": "https://img.shields.io/badge/google%20earth%20engine-%234285F4.svg?style=for-the-badge&logo=googleearthengine&logoColor=white",
-    "markdown": "![Google Earth Engine](https://img.shields.io/badge/google%20earth%20engine-%234285F4.svg?style=for-the-badge&logo=googleearthengine&logoColor=white)",
-    "category": "Jobs"
-  },
-  {
-    "id": "qgis",
-    "name": "QGIS",
-    "url": "https://img.shields.io/badge/qgis-%2393b023?&style=for-the-badge&logo=qgis&logoColor=white",
-    "markdown": "![QGIS](https://img.shields.io/badge/qgis-%2393b023?&style=for-the-badge&logo=qgis&logoColor=white)",
-    "category": "Jobs"
-  },
-  {
-    "id": "gsap",
-    "name": "GSAP",
-    "url": "https://img.shields.io/badge/GSAP-%2388CE02.svg?style=for-the-badge&logo=greensock&logoColor=black",
-    "markdown": "![GSAP](https://img.shields.io/badge/GSAP-%2388CE02.svg?style=for-the-badge&logo=greensock&logoColor=black)",
     "category": "Jobs"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "prebuild": "pnpm badges:generate",
+    "badges:generate": "node scripts/generate-badges.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.8",
@@ -38,6 +42,7 @@
   },
   "devDependencies": {
     "shadcn": "^3.8.5",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "vitest": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@24.12.0)(msw@2.12.11(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
 
 packages:
 
@@ -1654,6 +1657,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
@@ -1759,8 +1765,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1878,6 +1890,35 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -2015,6 +2056,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -2091,6 +2136,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2430,6 +2479,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2452,6 +2504,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.1:
     resolution: {integrity: sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==}
@@ -3360,6 +3416,9 @@ packages:
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -3369,10 +3428,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -3675,6 +3730,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3711,9 +3769,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3792,6 +3856,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.12:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -3803,6 +3870,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.26:
     resolution: {integrity: sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==}
@@ -4104,6 +4175,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -4229,6 +4341,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@6.2.0:
@@ -4706,10 +4823,10 @@ snapshots:
       dotenv: 17.3.1
       eciesjs: 0.4.18
       execa: 5.1.1
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       ignore: 5.3.2
       object-treeify: 1.1.33
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       which: 4.0.0
 
   '@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)':
@@ -5942,6 +6059,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.2.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6037,9 +6156,16 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -6102,7 +6228,7 @@ snapshots:
       glob: 13.0.6
       graceful-fs: 4.2.11
       node-gyp-build: 4.8.4
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - encoding
@@ -6134,6 +6260,48 @@ snapshots:
       vite: 7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(msw@2.12.11(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.11(@types/node@24.12.0)(typescript@5.9.3)
+      vite: 7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
@@ -6313,6 +6481,8 @@ snapshots:
 
   array-iterate@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -6477,6 +6647,8 @@ snapshots:
   caniuse-lite@1.0.30001779: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -6764,6 +6936,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   etag@1.8.1: {}
 
   eventemitter3@5.0.4: {}
@@ -6800,6 +6976,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.1(express@5.2.1):
     dependencies:
@@ -6870,9 +7048,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-blob@3.2.0:
     dependencies:
@@ -7870,13 +8048,13 @@ snapshots:
 
   path-to-regexp@8.3.0: {}
 
+  pathe@2.0.3: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -8375,6 +8553,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -8401,7 +8581,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -8478,14 +8662,18 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.12: {}
 
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.26: {}
 
@@ -8691,8 +8879,8 @@ snapshots:
   vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -8706,6 +8894,33 @@ snapshots:
   vitefu@1.1.2(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)):
     optionalDependencies:
       vite: 7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+
+  vitest@4.1.5(@types/node@24.12.0)(msw@2.12.11(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.12.11(@types/node@24.12.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.31.1)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.0
+    transitivePeerDependencies:
+      - msw
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -8835,6 +9050,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/scripts/generate-badges.js
+++ b/scripts/generate-badges.js
@@ -1,0 +1,116 @@
+/**
+ * Fetches the Ileriayo/markdown-badges README and extracts all badge definitions
+ * into badges.json with the schema expected by src/content.config.ts:
+ *   { id, name, url, markdown, category }
+ *
+ * Run with:  node scripts/generate-badges.js
+ * Output:    scripts/badges.json
+ */
+
+import { mkdirSync, writeFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import {
+  CATEGORY_MAP,
+  extractUrl,
+  nameToId,
+  parseTableRow,
+  sanitizeId,
+  stripEmoji,
+  stripMarkdownEscapes,
+} from "./utils.js";
+
+const README_URL =
+  "https://raw.githubusercontent.com/Ileriayo/markdown-badges/master/README.md";
+
+async function main() {
+  console.log("Fetching README…");
+  const res = await fetch(README_URL);
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  const text = await res.text();
+
+  const lines = text.split("\n");
+  const badges = [];
+  const seenIds = new Set();
+  let currentCategory = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // ── Category heading (###) ───────────────────────────────────────────────
+    const headingMatch = trimmed.match(/^###\s+(.+)$/);
+    if (headingMatch) {
+      const raw = stripEmoji(headingMatch[1]);
+      currentCategory = CATEGORY_MAP[raw] ?? raw;
+      continue;
+    }
+
+    // ── Table rows (only within a category section) ──────────────────────────
+    if (!currentCategory) continue;
+
+    const cells = parseTableRow(line);
+    if (!cells) continue;
+
+    // Strip markdown backslash escapes (e.g. Pop!\_OS → Pop!_OS) so the stored
+    // name is the clean display name, not the raw markdown-table source.
+    const name = stripMarkdownEscapes(cells[0]);
+    const markdownCol = cells[2];
+
+    // The markdown column wraps the badge string in backticks: `![Alt](url)`
+    const backtickMatch = markdownCol.match(/`([^`]+)`/);
+    if (!backtickMatch) continue;
+
+    const markdown = backtickMatch[1].trim();
+    const url = extractUrl(markdown);
+    if (!url) continue;
+
+    // Validate URL (schema requires z.url())
+    try {
+      new URL(url);
+    } catch {
+      console.warn(`  ⚠ Skipping "${name}" — malformed URL: ${url}`);
+      continue;
+    }
+
+    // sanitizeId encodes # → %23, ? → %3F, \ → %5C so the ID is safe
+    // to use as an Astro static route path segment.
+    let id = sanitizeId(nameToId(name));
+
+    // Resolve ID collisions by appending the category slug
+    if (seenIds.has(id)) {
+      const suffix = currentCategory.toLowerCase().replace(/[\s/]+/g, "-");
+      id = `${id}-${suffix}`;
+      console.warn(`  ⚠ Collision: renamed to "${id}"`);
+    }
+    seenIds.add(id);
+
+    badges.push({ id, name, url, markdown, category: currentCategory });
+  }
+
+  // ── Summary ─────────────────────────────────────────────────────────────────
+  const categories = [...new Set(badges.map((b) => b.category))];
+  console.log(
+    `\nExtracted ${badges.length} badges across ${categories.size ?? categories.length} categories:`,
+  );
+  for (const cat of categories) {
+    const count = badges.filter((b) => b.category === cat).length;
+    console.log(`  ${cat}: ${count}`);
+  }
+
+  // ── Write output ─────────────────────────────────────────────────────────────
+  const __filename = fileURLToPath(import.meta.url);
+  const __dir = dirname(__filename);
+  const rootDir = resolve(__dir, "..");
+  const dataDir = join(rootDir, "data");
+  const outputPath = join(dataDir, "badges.json");
+
+  mkdirSync(dataDir, { recursive: true });
+
+  writeFileSync(outputPath, JSON.stringify(badges, null, 2), "utf-8");
+  console.log(`\nWritten to ${outputPath}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err.message);
+  process.exit(1);
+});

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,151 @@
+/**
+ * Pure helper functions shared between generate-badges.js and the test suite.
+ * Every function here must be side-effect free so it can be unit-tested.
+ */
+
+export const CATEGORY_MAP = {
+  'Artificial Intelligence and Bots': 'Artificial Intelligence',
+  'Developer/Forums': 'Forums',
+  'Frameworks, Platforms and Libraries': 'Frameworks',
+  'Hosting/SaaS': 'SaaS',
+  'IDEs/Editors': 'IDEs',
+  'Smartphone Brands': 'Smartphone',
+  'Work/Jobs': 'Jobs',
+  'Quantum Programming Frameworks and Libraries': 'Quantum Programming',
+};
+
+/**
+ * Remove emoji codepoints and trim surrounding whitespace.
+ * Covers the full Extended_Pictographic range (including ⌚ U+231A, ⚙️ U+2699,
+ * ZWJ sequences like 🧑‍💻, and variation selectors).
+ */
+export function stripEmoji(str) {
+  return str
+    .replace(/\p{Extended_Pictographic}/gu, '')
+    .replace(/[\u{FE00}-\u{FE0F}]/gu, '')  // variation selectors
+    .replace(/‍/gu, '')               // ZWJ (U+200D)
+    .replace(/[\u{1F3FB}-\u{1F3FF}]/gu, '') // skin-tone modifiers
+    .trim();
+}
+
+/**
+ * Strip markdown backslash escape sequences from a string.
+ * In markdown table source, characters like _ are often escaped (\_) to prevent
+ * accidental italic/bold formatting. The backslash is not part of the actual name.
+ * Example: "Pop!\_OS" → "Pop!_OS"
+ */
+export function stripMarkdownEscapes(str) {
+  return str.replace(/\\(.)/g, '$1');
+}
+
+/**
+ * Convert a badge name to a slug id.
+ * Rule: lowercase + spaces → hyphens. All other characters (+ # .) are kept as-is.
+ * Examples: "C++" → "c++", ".NET" → ".net", "Google Chrome" → "google-chrome"
+ * Call sanitizeId() on the result to make it safe for use as a URL path segment.
+ */
+export function nameToId(name) {
+  return name.toLowerCase().replace(/\s+/g, '-');
+}
+
+/**
+ * Percent-encode characters that are unsafe in URL path segments.
+ *
+ * Characters encoded:
+ *   #  → %23  (fragment identifier — browsers strip everything from # onwards,
+ *               so /badges/c# is identical to /badges/c for the server)
+ *   ?  → %3F  (query-string separator)
+ *   \  → %5C  (non-standard in URLs; browsers normalize \ to /, creating
+ *               unintended nested paths like /badges/pop!/_os)
+ *
+ * Forward slashes are intentionally NOT encoded: the [‥‥id] spread route
+ * supports multi-segment paths, so IDs like "jwt/json-web-token" are valid.
+ */
+export function sanitizeId(id) {
+  return id
+    .replace(/#/g, '%23')
+    .replace(/\?/g, '%3F')
+    .replace(/\\/g, '%5C');
+}
+
+/**
+ * Extract the https URL from a markdown image string: `![Alt Text](url)`.
+ * Returns null if the input doesn't match the expected format.
+ */
+export function extractUrl(markdown) {
+  const match = markdown.match(/!\[.*?\]\((https?:\/\/[^)]+)\)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Parse one pipe-delimited markdown table row into trimmed cell strings.
+ * Returns null for header rows ("| Name |…"), separator rows ("| --- |…"),
+ * or rows with fewer than 3 cells.
+ */
+export function parseTableRow(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return null;
+
+  const cells = trimmed
+    .split('|')
+    .map(c => c.trim())
+    .filter(Boolean);
+
+  if (cells[0] === 'Name') return null;
+  if (cells.every(c => /^[-:\s]+$/.test(c))) return null;
+
+  return cells.length >= 3 ? cells : null;
+}
+
+/**
+ * Validate a single badge object against the content.config.ts schema.
+ * Returns an array of error messages; empty array means the badge is valid.
+ */
+export function validateBadge(badge) {
+  const errors = [];
+
+  const requiredFields = ['id', 'name', 'url', 'markdown', 'category'];
+  for (const field of requiredFields) {
+    if (!Object.hasOwn(badge, field)) {
+      errors.push(`missing field: ${field}`);
+      continue;
+    }
+    if (typeof badge[field] !== 'string' || badge[field].trim() === '') {
+      errors.push(`empty or non-string field: ${field}`);
+    }
+  }
+
+  if (badge.id && badge.id !== badge.id.toLowerCase()) {
+    errors.push(`id is not lowercase: ${badge.id}`);
+  }
+  if (badge.id && /\s/.test(badge.id)) {
+    errors.push(`id contains whitespace: ${badge.id}`);
+  }
+  if (badge.id && /[#?\\]/.test(badge.id)) {
+    errors.push(`id contains URL-unsafe characters (# ? or \\): ${badge.id}`);
+  }
+
+  if (badge.url) {
+    try {
+      new URL(badge.url);
+    } catch {
+      errors.push(`invalid URL: ${badge.url}`);
+    }
+  }
+
+  if (badge.markdown && !badge.markdown.startsWith('![')) {
+    errors.push(`markdown does not start with ![: ${badge.markdown}`);
+  }
+  if (badge.markdown && badge.url) {
+    const urlInMarkdown = extractUrl(badge.markdown);
+    if (urlInMarkdown !== badge.url) {
+      errors.push(`url field does not match URL in markdown`);
+    }
+  }
+
+  if (badge.category && /\p{Extended_Pictographic}/u.test(badge.category)) {
+    errors.push(`category contains emoji: ${badge.category}`);
+  }
+
+  return errors;
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,7 +3,7 @@ import { z } from "astro/zod";
 import { defineCollection } from "astro:content";
 
 const badges = defineCollection({
-  loader: file("src/data/badges.json"),
+  loader: file("data/badges.json"),
   schema: z.object({
     id: z.string(),
     name: z.string(),

--- a/src/services/badges.ts
+++ b/src/services/badges.ts
@@ -1,6 +1,6 @@
 import { filter as fuzzy } from "fuzzyjs";
 
-import badges from "@/data/badges.json";
+import badges from "~/data/badges.json";
 
 type BadgeFilters = {
   query?: string | null;

--- a/test/generate-badges.test.ts
+++ b/test/generate-badges.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Test suite for generate-badges.js
+ *
+ * Covers three layers:
+ *  1. Output validation  — the generated scripts/badges.json satisfies the schema
+ *  2. Negative cases     — validateBadge() correctly rejects malformed data
+ *  3. Unit tests         — pure helpers (stripEmoji, nameToId, extractUrl, parseTableRow,
+ *                          stripMarkdownEscapes, sanitizeId)
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  extractUrl,
+  nameToId,
+  parseTableRow,
+  sanitizeId,
+  stripEmoji,
+  stripMarkdownEscapes,
+  validateBadge,
+} from "../scripts/utils";
+
+// ── Load generated output ────────────────────────────────────────────────────
+
+type Badge = {
+  id: string;
+  name: string;
+  url: string;
+  markdown: string;
+  category: string;
+};
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const rootPath = resolve(__dir, "..");
+const BADGES_PATH = join(rootPath, "data", "badges.json");
+
+let badges: Badge[] = [];
+
+beforeAll(() => {
+  if (!existsSync(BADGES_PATH)) {
+    throw new Error(
+      `data/badges.json not found.\nRun "node scripts/generate-badges.js" first.`,
+    );
+  }
+  badges = JSON.parse(readFileSync(BADGES_PATH, "utf-8"));
+});
+
+// ── 1. Output validation (happy path) ────────────────────────────────────────
+
+describe("badges.json — output validation", () => {
+  describe("file integrity", () => {
+    it("is a non-empty array", () => {
+      expect(Array.isArray(badges)).toBe(true);
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    it("contains at least 800 badges", () => {
+      // sanity guard: upstream README currently has 880+
+      expect(badges.length).toBeGreaterThanOrEqual(800);
+    });
+
+    it("spans at least 40 categories", () => {
+      const cats = new Set(badges.map((b) => b.category));
+      expect(cats.size).toBeGreaterThanOrEqual(40);
+    });
+  });
+
+  describe("schema — required fields", () => {
+    it("every badge has id, name, url, markdown, category", () => {
+      for (const badge of badges) {
+        expect(badge, `badge: ${JSON.stringify(badge)}`).toMatchObject({
+          id: expect.any(String),
+          name: expect.any(String),
+          url: expect.any(String),
+          markdown: expect.any(String),
+          category: expect.any(String),
+        });
+      }
+    });
+
+    it("no field is an empty string", () => {
+      for (const badge of badges) {
+        expect(badge.id.trim(), `empty id in ${badge.name}`).not.toBe("");
+        expect(badge.name.trim(), `empty name`).not.toBe("");
+        expect(badge.url.trim(), `empty url in ${badge.name}`).not.toBe("");
+        expect(
+          badge.markdown.trim(),
+          `empty markdown in ${badge.name}`,
+        ).not.toBe("");
+        expect(
+          badge.category.trim(),
+          `empty category in ${badge.name}`,
+        ).not.toBe("");
+      }
+    });
+  });
+
+  describe("id format", () => {
+    it("all IDs are lowercase", () => {
+      const wrong = badges.filter((b) => b.id !== b.id.toLowerCase());
+      expect(wrong.map((b) => b.id)).toEqual([]);
+    });
+
+    it("no ID contains whitespace", () => {
+      const wrong = badges.filter((b) => /\s/.test(b.id));
+      expect(wrong.map((b) => b.id)).toEqual([]);
+    });
+
+    it("all IDs are unique (no duplicates)", () => {
+      const ids = badges.map((b) => b.id);
+      const unique = new Set(ids);
+      expect(unique.size).toBe(ids.length);
+    });
+  });
+
+  describe("url validity", () => {
+    it("all URLs are syntactically valid", () => {
+      const invalid = badges.filter((b) => {
+        try {
+          new URL(b.url);
+          return false;
+        } catch {
+          return true;
+        }
+      });
+      expect(invalid.map((b) => ({ name: b.name, url: b.url }))).toEqual([]);
+    });
+
+    it("all URLs point to shields.io (img.shields.io or shields.io)", () => {
+      const wrong = badges.filter((b) => {
+        try {
+          const host = new URL(b.url).hostname;
+          return host !== "img.shields.io" && host !== "shields.io";
+        } catch {
+          return true;
+        }
+      });
+      expect(wrong.map((b) => b.name)).toEqual([]);
+    });
+  });
+
+  describe("markdown format", () => {
+    it("all markdown strings start with ![", () => {
+      const wrong = badges.filter((b) => !b.markdown.startsWith("!["));
+      expect(wrong.map((b) => b.name)).toEqual([]);
+    });
+
+    it("all markdown strings follow ![Alt](url) format", () => {
+      const badFormat = badges.filter(
+        (b) => !/^!\[.*?\]\(https?:\/\/.+\)$/.test(b.markdown.trim()),
+      );
+      expect(badFormat.map((b) => b.name)).toEqual([]);
+    });
+
+    it("url field matches the URL embedded in markdown", () => {
+      const mismatch = badges.filter((b) => {
+        const inMarkdown = extractUrl(b.markdown);
+        return inMarkdown !== b.url;
+      });
+      expect(mismatch.map((b) => b.name)).toEqual([]);
+    });
+  });
+
+  describe("category format", () => {
+    it("no category contains emoji", () => {
+      const withEmoji = badges.filter((b) =>
+        /\p{Extended_Pictographic}/u.test(b.category),
+      );
+      expect(
+        withEmoji.map((b) => ({ name: b.name, category: b.category })),
+      ).toEqual([]);
+    });
+
+    it("no category is whitespace-only", () => {
+      const blank = badges.filter((b) => b.category.trim() === "");
+      expect(blank.map((b) => b.name)).toEqual([]);
+    });
+  });
+
+  describe("known badges — smoke tests", () => {
+    it("contains the Claude badge", () => {
+      const badge = badges.find((b) => b.id === "claude");
+      expect(badge).toBeDefined();
+      expect(badge?.category).toBe("Artificial Intelligence");
+    });
+
+    it('C++ → id "c++" (special chars preserved)', () => {
+      const badge = badges.find((b) => b.name === "C++");
+      expect(badge).toBeDefined();
+      expect(badge?.id).toBe("c++");
+    });
+
+    it('C# → id "c%23" (# percent-encoded for URL safety)', () => {
+      // Raw # in a URL path is treated as a fragment delimiter by browsers,
+      // making /badges/c# resolve identically to /badges/c — the badge
+      // would be unreachable. We encode it as %23 instead.
+      const badge = badges.find((b) => b.name === "C#");
+      expect(badge).toBeDefined();
+      expect(badge?.id).toBe("c%23");
+    });
+
+    it('.NET → id ".net" (leading dot preserved)', () => {
+      const badge = badges.find((b) => b.name === ".NET");
+      expect(badge).toBeDefined();
+      expect(badge?.id).toBe(".net");
+    });
+
+    it('Notepad++ → id "notepad++"', () => {
+      const badge = badges.find((b) => b.name === "Notepad++");
+      expect(badge).toBeDefined();
+      expect(badge?.id).toBe("notepad++");
+    });
+
+    it('Pop!_OS → id "pop!_os" (markdown escape \\_ stripped from name)', () => {
+      // In the upstream README the name appears as Pop!\_OS — the backslash
+      // escapes the underscore in markdown tables. The stored name and ID
+      // must use the clean form without the escape character.
+      const badge = badges.find((b) => b.name === "Pop!_OS");
+      expect(badge).toBeDefined();
+      expect(badge?.id).toBe("pop!_os");
+    });
+
+    it("no badge ID contains URL-unsafe characters (# ? or \\)", () => {
+      const unsafe = badges.filter((b) => /[#?\\]/.test(b.id));
+      expect(unsafe.map((b) => b.id)).toEqual([]);
+    });
+
+    it("Wearables category has no emoji (regression: ⌚ U+231A)", () => {
+      const wearable = badges.find((b) => b.category === "Wearables");
+      expect(wearable).toBeDefined();
+      expect(/\p{Extended_Pictographic}/u.test("Wearables")).toBe(false);
+    });
+
+    it("Quantum Programming category is correctly mapped", () => {
+      const badge = badges.find((b) => b.category === "Quantum Programming");
+      expect(badge).toBeDefined();
+    });
+  });
+});
+
+// ── 2. Negative cases — validateBadge() rejects malformed data ────────────────
+
+describe("validateBadge — negative cases", () => {
+  const VALID = {
+    id: "test-badge",
+    name: "Test Badge",
+    url: "https://img.shields.io/badge/test-badge-blue",
+    markdown: "![Test Badge](https://img.shields.io/badge/test-badge-blue)",
+    category: "Testing",
+  };
+
+  it("accepts a fully valid badge (zero errors)", () => {
+    expect(validateBadge(VALID)).toEqual([]);
+  });
+
+  it("rejects a badge missing the id field", () => {
+    const { id, ...noId } = VALID;
+    const errors = validateBadge(noId);
+    expect(errors.some((e) => e.includes("id"))).toBe(true);
+  });
+
+  it("rejects a badge missing the name field", () => {
+    const { name, ...noName } = VALID;
+    expect(validateBadge(noName).some((e) => e.includes("name"))).toBe(true);
+  });
+
+  it("rejects a badge missing the url field", () => {
+    const { url, ...noUrl } = VALID;
+    expect(validateBadge(noUrl).some((e) => e.includes("url"))).toBe(true);
+  });
+
+  it("rejects a badge missing the markdown field", () => {
+    const { markdown, ...noMd } = VALID;
+    expect(validateBadge(noMd).some((e) => e.includes("markdown"))).toBe(true);
+  });
+
+  it("rejects a badge missing the category field", () => {
+    const { category, ...noCat } = VALID;
+    expect(validateBadge(noCat).some((e) => e.includes("category"))).toBe(true);
+  });
+
+  it("rejects a badge with an empty id", () => {
+    expect(validateBadge({ ...VALID, id: "" }).length).toBeGreaterThan(0);
+  });
+
+  it("rejects a badge with a whitespace-only category", () => {
+    expect(validateBadge({ ...VALID, category: "   " }).length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("rejects a badge with an uppercase id", () => {
+    const errors = validateBadge({ ...VALID, id: "Test-Badge" });
+    expect(errors.some((e) => e.includes("lowercase"))).toBe(true);
+  });
+
+  it("rejects a badge with whitespace in the id", () => {
+    const errors = validateBadge({ ...VALID, id: "test badge" });
+    expect(errors.some((e) => e.includes("whitespace"))).toBe(true);
+  });
+
+  it("rejects a badge with a non-URL value in url", () => {
+    const errors = validateBadge({ ...VALID, url: "not-a-url" });
+    expect(errors.some((e) => e.includes("invalid URL"))).toBe(true);
+  });
+
+  it("rejects markdown that does not start with ![", () => {
+    const errors = validateBadge({
+      ...VALID,
+      markdown: "[Test Badge](https://img.shields.io/badge/test)",
+    });
+    expect(errors.some((e) => e.includes("markdown"))).toBe(true);
+  });
+
+  it("rejects when url field does not match the URL inside markdown", () => {
+    const errors = validateBadge({
+      ...VALID,
+      url: "https://img.shields.io/badge/a",
+      markdown: "![Test](https://img.shields.io/badge/b)",
+    });
+    expect(errors.some((e) => e.includes("match"))).toBe(true);
+  });
+
+  it("rejects a category that still contains emoji (⌚)", () => {
+    const errors = validateBadge({ ...VALID, category: "⌚ Wearables" });
+    expect(errors.some((e) => e.includes("emoji"))).toBe(true);
+  });
+
+  it("rejects a category that still contains emoji (🤖)", () => {
+    const errors = validateBadge({
+      ...VALID,
+      category: "🤖 Artificial Intelligence",
+    });
+    expect(errors.some((e) => e.includes("emoji"))).toBe(true);
+  });
+
+  it("rejects a badge whose id contains # (URL fragment delimiter)", () => {
+    const errors = validateBadge({ ...VALID, id: "c#" });
+    expect(errors.some((e) => e.includes("URL-unsafe"))).toBe(true);
+  });
+
+  it("rejects a badge whose id contains ? (URL query separator)", () => {
+    const errors = validateBadge({ ...VALID, id: "foo?bar" });
+    expect(errors.some((e) => e.includes("URL-unsafe"))).toBe(true);
+  });
+
+  it("rejects a badge whose id contains \\ (path separator / markdown escape)", () => {
+    const errors = validateBadge({ ...VALID, id: "pop!\\_os" });
+    expect(errors.some((e) => e.includes("URL-unsafe"))).toBe(true);
+  });
+
+  it("detects duplicate IDs in a collection", () => {
+    const collection = [VALID, { ...VALID, name: "Different Name" }];
+    const ids = collection.map((b) => b.id);
+    const unique = new Set(ids);
+    expect(unique.size).not.toBe(ids.length);
+  });
+});
+
+// ── 3. Unit tests — pure helper functions ────────────────────────────────────
+
+describe("stripEmoji", () => {
+  it("removes standard emoji 🤖 (U+1F916)", () => {
+    expect(stripEmoji("🤖 Artificial Intelligence")).toBe(
+      "Artificial Intelligence",
+    );
+  });
+
+  it("removes 📝 (U+1F4DD)", () => {
+    expect(stripEmoji("📝 Blog")).toBe("Blog");
+  });
+
+  it("removes ⌚ (U+231A) — regression for missed emoji range", () => {
+    expect(stripEmoji("⌚ Wearables")).toBe("Wearables");
+  });
+
+  it("removes ⚙️ (U+2699 + variation selector)", () => {
+    expect(stripEmoji("⚙️ Hardware")).toBe("Hardware");
+  });
+
+  it("removes 🧑‍💻 ZWJ sequence", () => {
+    expect(stripEmoji("🧑‍💻 Developer/Forums")).toBe("Developer/Forums");
+  });
+
+  it("removes 📚 (U+1F4DA)", () => {
+    expect(stripEmoji("📚 Frameworks, Platforms and Libraries")).toBe(
+      "Frameworks, Platforms and Libraries",
+    );
+  });
+
+  it("preserves regular ASCII text unchanged", () => {
+    expect(stripEmoji("Browsers")).toBe("Browsers");
+  });
+
+  it("preserves slashes and special chars used in category names", () => {
+    expect(stripEmoji("Developer/Forums")).toBe("Developer/Forums");
+  });
+
+  it("trims leading/trailing whitespace left after emoji removal", () => {
+    expect(stripEmoji("  🔗  Blockchain  ")).toBe("Blockchain");
+  });
+});
+
+describe("nameToId", () => {
+  it("lowercases single-word names", () => {
+    expect(nameToId("ChatGPT")).toBe("chatgpt");
+    expect(nameToId("YOLO")).toBe("yolo");
+  });
+
+  it("replaces spaces with hyphens", () => {
+    expect(nameToId("Google Chrome")).toBe("google-chrome");
+    expect(nameToId("Amazon Alexa")).toBe("amazon-alexa");
+  });
+
+  it("collapses multiple consecutive spaces into a single hyphen", () => {
+    // /\s+/ matches one-or-more whitespace, so "A  B" → "a-b" (not "a--b")
+    expect(nameToId("A  B")).toBe("a-b");
+  });
+
+  it("preserves + characters (C++, Notepad++)", () => {
+    expect(nameToId("C++")).toBe("c++");
+    expect(nameToId("Notepad++")).toBe("notepad++");
+  });
+
+  it("preserves # character (C#)", () => {
+    expect(nameToId("C#")).toBe("c#");
+  });
+
+  it("preserves leading dot (.NET)", () => {
+    expect(nameToId(".NET")).toBe(".net");
+  });
+
+  it("preserves dots in names (Micro.blog)", () => {
+    expect(nameToId("Micro.blog")).toBe("micro.blog");
+  });
+
+  it("does not alter an already-lowercase id", () => {
+    expect(nameToId("firebase")).toBe("firebase");
+  });
+});
+
+describe("extractUrl", () => {
+  it("extracts a plain shields.io URL", () => {
+    expect(
+      extractUrl(
+        "![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white)",
+      ),
+    ).toBe(
+      "https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white",
+    );
+  });
+
+  it("handles URLs with percent-encoded characters (%20, %2B)", () => {
+    const url =
+      "https://img.shields.io/badge/c++-%2300599C.svg?style=for-the-badge&logo=c%2B%2B&logoColor=white";
+    expect(extractUrl(`![C++](${url})`)).toBe(url);
+  });
+
+  it("returns null for a non-image markdown link [text](url)", () => {
+    expect(
+      extractUrl("[Claude](https://img.shields.io/badge/Claude)"),
+    ).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(extractUrl("")).toBeNull();
+  });
+
+  it("returns null for plain text", () => {
+    expect(extractUrl("no markdown here")).toBeNull();
+  });
+
+  it("returns null for an image with a relative path (no http)", () => {
+    expect(extractUrl("![Logo](/images/logo.png)")).toBeNull();
+  });
+
+  it("ignores content after the closing parenthesis", () => {
+    const url = "https://img.shields.io/badge/Test-blue";
+    expect(extractUrl(`![Test](${url}) extra text`)).toBe(url);
+  });
+});
+
+describe("parseTableRow", () => {
+  it("returns null for the header row", () => {
+    expect(parseTableRow("| Name | Badge | Markdown |")).toBeNull();
+  });
+
+  it("returns null for a separator row with dashes", () => {
+    expect(parseTableRow("| --- | --- | --- |")).toBeNull();
+    expect(parseTableRow("| :--- | :---: | ---: |")).toBeNull();
+  });
+
+  it("returns null for a non-table line", () => {
+    expect(parseTableRow("This is a paragraph")).toBeNull();
+    expect(parseTableRow("")).toBeNull();
+  });
+
+  it("returns null when there are fewer than 3 cells", () => {
+    expect(parseTableRow("| OnlyOne |")).toBeNull();
+    expect(parseTableRow("| One | Two |")).toBeNull();
+  });
+
+  it("parses a valid data row and returns trimmed cells", () => {
+    const row =
+      "| ChatGPT | ![ChatGPT](https://...) | `![ChatGPT](https://...)` |";
+    const cells = parseTableRow(row);
+    expect(cells).not.toBeNull();
+    expect(cells[0]).toBe("ChatGPT");
+    expect(cells[2]).toBe("`![ChatGPT](https://...)`");
+  });
+
+  it("trims extra whitespace from each cell", () => {
+    const row = "|  Padded Name  |  badge  |  `markdown`  |";
+    const cells = parseTableRow(row);
+    expect(cells[0]).toBe("Padded Name");
+    expect(cells[2]).toBe("`markdown`");
+  });
+});
+
+describe("stripMarkdownEscapes", () => {
+  it("strips backslash before underscore (Pop!\\_OS regression)", () => {
+    expect(stripMarkdownEscapes("Pop!\\_OS")).toBe("Pop!_OS");
+  });
+
+  it("strips backslash before asterisk", () => {
+    expect(stripMarkdownEscapes("foo\\*bar")).toBe("foo*bar");
+  });
+
+  it("strips backslash before hash", () => {
+    expect(stripMarkdownEscapes("foo\\#bar")).toBe("foo#bar");
+  });
+
+  it("strips multiple escapes in one string", () => {
+    expect(stripMarkdownEscapes("A\\_B\\*C")).toBe("A_B*C");
+  });
+
+  it("leaves strings with no backslash unchanged", () => {
+    expect(stripMarkdownEscapes("C#")).toBe("C#");
+    expect(stripMarkdownEscapes("C++")).toBe("C++");
+    expect(stripMarkdownEscapes(".NET")).toBe(".NET");
+    expect(stripMarkdownEscapes("Pop!_OS")).toBe("Pop!_OS");
+  });
+
+  it("removes a standalone double-backslash (escaped backslash in markdown)", () => {
+    expect(stripMarkdownEscapes("a\\\\b")).toBe("a\\b");
+  });
+});
+
+describe("sanitizeId", () => {
+  it("encodes # as %23 (fragment identifier fix for C#)", () => {
+    expect(sanitizeId("c#")).toBe("c%23");
+  });
+
+  it("encodes ? as %3F (query separator)", () => {
+    expect(sanitizeId("foo?bar")).toBe("foo%3Fbar");
+  });
+
+  it("encodes backslash as %5C (path separator / markdown escape)", () => {
+    expect(sanitizeId("pop!\\_os")).toBe("pop!%5C_os");
+  });
+
+  it("leaves safe characters unchanged (alphanumeric, hyphen, dot, +)", () => {
+    expect(sanitizeId("google-chrome")).toBe("google-chrome");
+    expect(sanitizeId("c++")).toBe("c++");
+    expect(sanitizeId(".net")).toBe(".net");
+    expect(sanitizeId("notepad++")).toBe("notepad++");
+  });
+
+  it("leaves forward slashes unchanged (intentional multi-segment paths)", () => {
+    // IDs like jwt/json-web-token create valid nested paths with [‥‥id] route
+    expect(sanitizeId("jwt/json-web-token")).toBe("jwt/json-web-token");
+    expect(sanitizeId("shadcn/ui")).toBe("shadcn/ui");
+  });
+
+  it("handles multiple problematic characters in one id", () => {
+    expect(sanitizeId("a#b?c\\d")).toBe("a%23b%3Fc%5Cd");
+  });
+
+  it("is idempotent when applied to an already-sanitized id", () => {
+    expect(sanitizeId("c%23")).toBe("c%23");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,15 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "src/*"
-      ]
+      "@/*": ["./src/*"],
+      "~/*": ["./*"]
     },
+    "strictNullChecks": true,
+    "allowJs": true,
     "jsx": "react-jsx",
     "jsxImportSource": "react"
   },
-  "include": [
-    ".astro/types.d.ts",
-    "**/*"
-  ],
-  "exclude": [
-    "dist"
-  ]
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,6 @@
+/// <reference types="vitest/config" />
+import { getViteConfig } from "astro/config";
+
+export default getViteConfig({
+  test: {},
+});


### PR DESCRIPTION
## Overview

This pull-request introduces a complete badge data pipeline that replaces the manually maintained `src/data/badges.json` with an automatically generated and validated dataset sourced from the upstream [Ileriayo/markdown-badges](https://github.com/Ileriayo/markdown-badges) README. It also fixes a class of URL routing bugs caused by characters in badge IDs that are unsafe in web paths.

---

## Changes

### 1. Badge data relocated — `src/data/badges.json` → `data/badges.json`

The source-of-truth JSON file was moved to the project root `data/` directory so the generation script, the Astro content loader, and the service layer all reference the same single path without aliasing confusion. All consumers updated accordingly:

- `src/content.config.ts` — `file("src/data/badges.json")` → `file("data/badges.json")`
- `src/services/badges.ts` — import alias changed from `@/data/badges.json` to `~/data/badges.json`
- `CLAUDE.md` — documentation references corrected

### 2. Badge generation script — `scripts/generate-badges.js` + `scripts/utils.js`

A Node.js script (`scripts/generate-badges.js`) fetches the upstream README and parses every markdown table inside a `###` section into a structured badge record `{ id, name, url, markdown, category }`.

Pure helper functions extracted into `scripts/utils.js` for testability:

| Function | Purpose |
|---|---|
| `CATEGORY_MAP` | Maps verbose upstream category names to shorter slugs used in the site |
| `stripEmoji` | Removes emoji codepoints (including ZWJ sequences and variation selectors) from category headings |
| `stripMarkdownEscapes` | Strips backslash escape sequences from raw markdown table cells (e.g. `Pop!\_OS` → `Pop!_OS`) |
| `nameToId` | Lowercases the name and replaces spaces with hyphens |
| `sanitizeId` | Percent-encodes characters that are unsafe in URL path segments (`#` → `%23`, `?` → `%3F`, `\` → `%5C`) |
| `extractUrl` | Extracts the `https://…` URL from a `![Alt](url)` markdown string |
| `parseTableRow` | Parses a pipe-delimited markdown table row into trimmed cell strings; rejects headers and separators |
| `validateBadge` | Validates a badge object against the schema; returns an array of error strings |

The script runs automatically before every build via the `prebuild` npm hook (`pnpm badges:generate`).

### 3. URL-safe badge IDs

**Problem:** The `[...id]` Astro spread route generates a static file per badge. Several badge IDs contained characters that break web routing:

| ID (before) | Character | Issue |
|---|---|---|
| `c#` | `#` | Browsers treat `#` and everything after it as a URL fragment — never sent to the server. `/badges/c#` resolves identically to `/badges/c`, making C# unreachable. |
| `pop!\_os` | `\` | `\_` is a markdown table escape for underscore; browsers normalize `\` to `/` in paths. `/badges/pop!\_os` becomes `/badges/pop!/_os` — an unintended nested route. |

**Fix:** Two-stage sanitization applied in the generation pipeline:

1. `stripMarkdownEscapes(cells[0])` — cleans the badge name before any processing. `Pop!\_OS` → `Pop!_OS`, ID becomes `pop!_os`.
2. `sanitizeId(nameToId(name))` — percent-encodes remaining URL-breaking characters. `c#` → `c%23`.

IDs with forward slashes (e.g. `jwt/json-web-token`, `shadcn/ui`) are intentionally left unchanged; the `[...id]` spread route captures multi-segment paths correctly.

`validateBadge` was also updated to reject IDs containing `#`, `?`, or `\`, so future regressions are caught at validation time.

### 4. Test suite — `test/generate-badges.test.ts` + `vitest.config.ts`

86 tests across three layers:

**Layer 1 — Output validation (against the generated `data/badges.json`)**
- File integrity: non-empty array, ≥ 800 badges, ≥ 40 categories
- Schema: all required fields present and non-empty
- ID format: all lowercase, no whitespace, no duplicates, no URL-unsafe characters
- URL validity: syntactically valid, all pointing to `img.shields.io` or `shields.io`
- Markdown format: correct `![Alt](url)` pattern, URL in markdown matches `url` field
- Category format: no emoji, no blank categories
- Smoke tests: Claude badge, C++, C#, .NET, Notepad++, Pop!_OS, Wearables, Quantum Programming

**Layer 2 — `validateBadge` negative cases**
- Missing / empty / non-string fields
- Uppercase ID, whitespace in ID
- IDs containing `#`, `?`, or `\`
- Malformed URL, wrong markdown format, URL/markdown mismatch
- Category with emoji

**Layer 3 — Unit tests for pure helpers**
- `stripEmoji` — 9 cases including ZWJ sequences and variation selectors
- `nameToId` — 8 cases including `C++`, `C#`, `.NET`, `Notepad++`
- `extractUrl` — 7 cases including percent-encoded URLs and null returns
- `parseTableRow` — 6 cases including headers, separators, short rows
- `stripMarkdownEscapes` — 6 cases including `\_`, `\*`, multiple escapes
- `sanitizeId` — 8 cases including idempotency and multi-character encoding

### 5. Weekly auto-update workflow — `.github/workflows/update-badges.yml`

A GitHub Actions workflow runs every Monday at 09:00 UTC (and can be triggered manually). Steps:

1. Backup `data/badges.json` and record the current badge count
2. Run `pnpm badges:generate` to fetch the latest upstream README
3. Run `pnpm test` — the workflow aborts if any test fails
4. Compare SHA-256 hashes of old vs. new files
5. If no content change, skip PR creation and write a summary
6. If content changed, open a PR targeting `main` via `peter-evans/create-pull-request@v7` with a summary table of badge count delta

### 6. Infrastructure

- `package.json` — added `prebuild`, `badges:generate`, `test`, `test:watch` scripts; added `vitest ^4.1.5` as dev dependency
- `tsconfig.json` — added `~/*` alias (project root), removed redundant `baseUrl`, enabled `strictNullChecks` and `allowJs`
- `.gitignore` — added `data/badges.old.json` (temporary file created during workflow badge comparison)

---

## Test plan

- [x] `pnpm badges:generate` — fetches upstream README and writes `data/badges.json` (884 badges, 52 categories as of this writing)
- [x] `pnpm test` — 86/86 tests pass
- [x] `c#` badge is accessible at `/badges/c%23`, distinct from `/badges/c`
- [x] `Pop!_OS` badge has ID `pop!_os` and name `Pop!_OS` (no backslash)
- [x] No badge ID in the generated dataset contains `#`, `?`, or `\`
- [x] `pnpm build` completes without errors (runs `badges:generate` as prebuild step)
