### PR TITLE
Visual Improvements & UI Consistency

### DIFF
--- a/src/components/badges/badge-sidebar.tsx
+++ b/src/components/badges/badge-sidebar.tsx
@@ -129,27 +129,29 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
                 }
               />
             </section>
-            <section>
-              <Typography as="h3" variant="muted" className="mb-1">
-                Related
-              </Typography>
-              <div className="grid grid-cols-2 gap-2">
-                {relatedBadges?.map((badge) => (
-                  <a key={badge.id} href={`/badges/${badge?.id}`}>
-                    <div className="bg-card rounded-md border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary">
-                      <img
-                        src={badge?.url}
-                        alt={`${badge?.name} badge`}
-                        width="50"
-                        height="20"
-                        className="h-5 w-auto mx-auto"
-                        loading="lazy"
-                      />
-                    </div>
-                  </a>
-                ))}
-              </div>
-            </section>
+            {relatedBadges && relatedBadges?.length > 0 && (
+              <section>
+                <Typography as="h3" variant="muted" className="mb-1">
+                  Related
+                </Typography>
+                <div className="grid grid-cols-2 gap-2">
+                  {relatedBadges?.map((badge) => (
+                    <a key={badge.id} href={`/badges/${badge?.id}`}>
+                      <div className="bg-card rounded-md border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary">
+                        <img
+                          src={badge?.url}
+                          alt={`${badge?.name} badge`}
+                          width="50"
+                          height="20"
+                          className="h-5 w-auto mx-auto"
+                          loading="lazy"
+                        />
+                      </div>
+                    </a>
+                  ))}
+                </div>
+              </section>
+            )}
           </div>
           <SheetFooter>
             <Button onClick={() => copy(badge?.markdown ?? "")}>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -5,6 +5,7 @@ import {
   CommandIcon,
   ExternalLinkIcon,
   SearchIcon,
+  ShieldIcon,
   ShieldOffIcon,
   XIcon,
 } from "lucide-react";
@@ -134,10 +135,12 @@ function SearchContent({
     setQuery("");
   };
 
+  const isFiltered = (query && query.length > 0) || !!categoryQuery;
+
   return (
     <>
-      <div className="flex md:flex-row flex-col gap-2 mb-4">
-        <Field>
+      <div className="flex md:flex-row flex-col gap-2 mb-6">
+        <Field className="flex-1">
           <FieldLabel htmlFor="badge-search" className="sr-only">
             Search Badges
           </FieldLabel>
@@ -150,7 +153,7 @@ function SearchContent({
               autoComplete="off"
               value={query ?? undefined}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder={`Search in ${badges.length} badges`}
+              placeholder="Search badges..."
             />
             <InputGroupAddon>
               <SearchIcon className="text-muted-foreground" />
@@ -187,7 +190,7 @@ function SearchContent({
             render={
               <Button
                 variant="outline"
-                className="w-50 justify-between"
+                className="w-50 justify-between text-muted-foreground"
                 aria-label="Select category"
               >
                 <ComboboxValue placeholder="All Categories" />
@@ -211,6 +214,31 @@ function SearchContent({
             </ComboboxList>
           </ComboboxContent>
         </Combobox>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 mb-3">
+        <div>
+          {isFiltered ? (
+            <Typography
+              as="span"
+              size="sm"
+              variant="muted"
+              className="flex items-center gap-1"
+            >
+              <SearchIcon /> {filteredBadges.length} result
+              {filteredBadges.length !== 1 ? "s" : ""}
+            </Typography>
+          ) : (
+            <Typography
+              as="span"
+              size="sm"
+              variant="muted"
+              className="flex items-center gap-1"
+            >
+              <ShieldIcon /> {badges.length} badges
+            </Typography>
+          )}
+        </div>
       </div>
 
       <div

--- a/src/pages/badges/[...id].astro
+++ b/src/pages/badges/[...id].astro
@@ -63,29 +63,31 @@ const badgeSEO = getBadgeSEOData(badge);
         </section>
       </div>
     </section>
-    <section>
-      <Typography as="h2" size="h3" className="mb-4">
-        Related Badges
-      </Typography>
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {
-          relatedBadges?.map((badge) => (
-            <a
-              href={`/badges/${badge?.id}`}
-              class="bg-card rounded-md border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary"
-            >
-              <img
-                src={badge?.url}
-                alt={`${badge?.name} badge`}
-                width={100}
-                height={28}
-                class="h-7 w-auto mx-auto"
-                loading="lazy"
-              />
-            </a>
-          ))
-        }
-      </div>
-    </section>
+    {
+      relatedBadges && relatedBadges?.length > 0 && (
+        <section>
+          <Typography as="h2" size="h3" className="mb-4">
+            Related Badges
+          </Typography>
+          <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {relatedBadges?.map((badge) => (
+              <a
+                href={`/badges/${badge?.id}`}
+                class="bg-card rounded-md border border-transparent transition p-6 text-center flex flex-col hover:bg-primary/20 hover:border-primary"
+              >
+                <img
+                  src={badge?.url}
+                  alt={`${badge?.name} badge`}
+                  width={100}
+                  height={28}
+                  class="h-7 w-auto mx-auto"
+                  loading="lazy"
+                />
+              </a>
+            ))}
+          </div>
+        </section>
+      )
+    }
   </div>
 </Layout>


### PR DESCRIPTION
## Overview

- Add a reusable `Link` component and replace all raw `<a>` tags across pages with it for consistent styling and safer external link handling (`noopener noreferrer`)
- Polish the search panel with a cleaner layout, a simplified placeholder, and a live counter that shows total badges or filtered result count depending on the current state
- Standardize card and sidebar styling to use theme-aware tokens (`bg-card`, `rounded-md`) instead of hard-coded dark colors (`#1e1e1e`, `rounded-sm`), making components work correctly in both light and dark mode
- Conditionally render the "Related Badges" section in both the badge detail page and the badge sidebar — it no longer renders an empty block when no related badges exist
- Fix favorite button colors to use `text-primary` / `text-foreground` instead of `text-destructive` / `text-white`, aligning with the design system
- Clean up sidebar typography by removing unnecessary `Typography` wrappers from nav items and switching section label variant from `accent` to `muted`
- Refactor the 404 page to use the existing `Empty` component family for visual consistency with the rest of the app, and add `noIndex` to prevent search engine indexing

## Changes

### New component
- `src/components/ui/link.tsx` — typed wrapper around `<a>` with an `external` boolean prop that automatically adds `target="_blank" rel="noopener noreferrer"`

### Search (`src/components/search.tsx`)
- Placeholder simplified to `"Search badges..."` (removed the dynamic badge count from placeholder)
- Added result counter row below the search bar: shows total badge count with a shield icon by default, switches to result count with a search icon when a query or category filter is active
- `Field` now takes `flex-1` so the input stretches to fill the row
- Bottom margin increased to `mb-6` for better visual breathing room

### Badge cards (`src/components/badges/badge-card.tsx`)
- Border radius: `rounded-sm` → `rounded-md`
- Focus ring: `focus:ring-*` → `focus-visible:ring-*` (only shown for keyboard navigation)
- Focus ring offset color: `ring-offset-card` → `ring-offset-background`

### Badge favorite button (`src/components/badges/badge-favorite-button.tsx`)
- Active state: `text-destructive` → `text-primary`
- Inactive hover: `hover:text-white` → `hover:text-foreground`

### Badge sidebar (`src/components/badges/badge-sidebar.tsx`)
- Section headings variant: `accent` → `muted`
- Related badges: wrapped in `relatedBadges && relatedBadges.length > 0` guard — no empty section when there are no related badges
- Related badge card backgrounds: `bg-[#1e1e1e]` → `bg-card`, `rounded-sm` → `rounded-md`

### App sidebar (`src/components/app-sidebar.tsx`, `src/components/ui/sidebar.tsx`)
- Nav item labels: `Typography as="span"` → plain `<span>` (no semantic need for the wrapper)
- Footer items: `isActive` prop now wired to the current pathname
- Group label color: `text-sidebar-foreground/70` → `text-muted-foreground/60`
- Menu button: base text color set to `text-muted-foreground`; `color` added to the CSS `transition` list

### Pages
- `src/pages/404.astro` — replaced manual markup with `Empty` / `EmptyHeader` / `EmptyTitle` / `EmptyDescription`; uses `Link` for the home link; added `noIndex`
- `src/pages/about.astro` — all `<a>` tags replaced with `Link`
- `src/pages/badges/[...id].astro` — badge preview card uses `bg-card` / `rounded-md`; related badges section is conditionally rendered
- `src/pages/docs/api.astro` — GitHub link replaced with `Link`