### PR TITLE
feat: support multiple categories per badge

### DIFF
--- a/data/badges.json
+++ b/data/badges.json
@@ -4,6187 +4,7746 @@
     "name": "Amazon Alexa",
     "url": "https://img.shields.io/badge/amazon%20alexa-52b5f7?style=for-the-badge&logo=amazon%20alexa&logoColor=white",
     "markdown": "![Amazon Alexa](https://img.shields.io/badge/amazon%20alexa-52b5f7?style=for-the-badge&logo=amazon%20alexa&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "chatgpt",
     "name": "ChatGPT",
     "url": "https://img.shields.io/badge/chatGPT-74aa9c?style=for-the-badge&logo=openai&logoColor=white",
     "markdown": "![ChatGPT](https://img.shields.io/badge/chatGPT-74aa9c?style=for-the-badge&logo=openai&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "claude",
     "name": "Claude",
     "url": "https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white",
     "markdown": "![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=claude&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "dependabot",
     "name": "Dependabot",
     "url": "https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot&logoColor=white",
     "markdown": "![Dependabot](https://img.shields.io/badge/dependabot-025E8C?style=for-the-badge&logo=dependabot&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "github-copilot",
     "name": "GitHub Copilot",
     "url": "https://img.shields.io/badge/github_copilot-8957E5?style=for-the-badge&logo=github-copilot&logoColor=white",
     "markdown": "![GitHub Copilot](https://img.shields.io/badge/github_copilot-8957E5?style=for-the-badge&logo=github-copilot&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "google-deepmind",
     "name": "Google Deepmind",
     "url": "https://img.shields.io/badge/deepmind-%234285F4.svg?style=for-the-badge&logo=deepmind&logoColor=white",
     "markdown": "![Google Deepmind](https://img.shields.io/badge/deepmind-%234285F4.svg?style=for-the-badge&logo=deepmind&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "google-gemini",
     "name": "Google Gemini",
     "url": "https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white",
     "markdown": "![Google Gemini](https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "huggingface",
     "name": "HuggingFace",
     "url": "https://img.shields.io/badge/huggingface-%23FFD21E.svg?style=for-the-badge&logo=huggingface&logoColor=white",
     "markdown": "![HuggingFace](https://img.shields.io/badge/huggingface-%23FFD21E.svg?style=for-the-badge&logo=huggingface&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "langchain",
     "name": "LangChain",
     "url": "https://img.shields.io/badge/langchain-%231C3C3C.svg?style=for-the-badge&logo=langchain&logoColor=white",
     "markdown": "![LangChain](https://img.shields.io/badge/langchain-%231C3C3C.svg?style=for-the-badge&logo=langchain&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "langflow",
     "name": "Langflow",
     "url": "https://img.shields.io/badge/langflow-%230066CC.svg?style=for-the-badge&logo=langflow&logoColor=white",
     "markdown": "![Langflow](https://img.shields.io/badge/langflow-%230066CC.svg?style=for-the-badge&logo=langflow&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "langgraph",
     "name": "LangGraph",
     "url": "https://img.shields.io/badge/langgraph-%231C3C3C.svg?style=for-the-badge&logo=langgraph&logoColor=white",
     "markdown": "![LangGraph](https://img.shields.io/badge/langgraph-%231C3C3C.svg?style=for-the-badge&logo=langgraph&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "minimax",
     "name": "Minimax",
     "url": "https://img.shields.io/badge/minimax-B4393C?style=for-the-badge&logo=minimax&logoColor=white",
     "markdown": "![Minimax](https://img.shields.io/badge/minimax-B4393C?style=for-the-badge&logo=minimax&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "mistralai",
     "name": "MistralAI",
     "url": "https://img.shields.io/badge/mistralai-FA520F?style=for-the-badge&logo=mistralai&logoColor=white",
     "markdown": "![MistralAI](https://img.shields.io/badge/mistralai-FA520F?style=for-the-badge&logo=mistralai&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "n8n",
     "name": "n8n",
     "url": "https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white",
     "markdown": "![n8n](https://img.shields.io/badge/n8n-EA4B71?style=for-the-badge&logo=n8n&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "ollama",
     "name": "Ollama",
     "url": "https://img.shields.io/badge/ollama-%23000000.svg?style=for-the-badge&logo=ollama&logoColor=white",
     "markdown": "![Ollama](https://img.shields.io/badge/ollama-%23000000.svg?style=for-the-badge&logo=ollama&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "perplexity",
     "name": "Perplexity",
     "url": "https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F",
     "markdown": "![Perplexity](https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "yolo",
     "name": "YOLO",
     "url": "https://img.shields.io/badge/YOLO-111F68?style=for-the-badge&logo=yolo&logoColor=white",
     "markdown": "![YOLO](https://img.shields.io/badge/YOLO-111F68?style=for-the-badge&logo=yolo&logoColor=white)",
-    "category": "Artificial Intelligence"
+    "categories": [
+      "Artificial Intelligence"
+    ]
   },
   {
     "id": "bitcoin",
     "name": "Bitcoin",
     "url": "https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white",
     "markdown": "![Bitcoin](https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain",
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "blockchain.com",
     "name": "Blockchain.com",
     "url": "https://img.shields.io/badge/blockchain.com-%232F3134?style=for-the-badge&logo=blockchaindotcom&logoColor=white",
     "markdown": "![Blockchaindotcom](https://img.shields.io/badge/blockchain.com-%232F3134?style=for-the-badge&logo=blockchaindotcom&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "cardano",
     "name": "Cardano",
     "url": "https://img.shields.io/badge/cardano-%230133AD.svg?style=for-the-badge&logo=cardano&logoColor=white",
     "markdown": "![Cardano](https://img.shields.io/badge/cardano-%230133AD.svg?style=for-the-badge&logo=cardano&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "ethers",
     "name": "Ethers",
     "url": "https://img.shields.io/badge/ethers-%232535A0.svg?style=for-the-badge&logo=ethers&logoColor=white",
     "markdown": "![Ethers](https://img.shields.io/badge/ethers-%232535A0.svg?style=for-the-badge&logo=ethers&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "hyperledger",
     "name": "Hyperledger",
     "url": "https://img.shields.io/badge/hyperledger-2F3134?style=for-the-badge&logo=hyperledger&logoColor=white",
     "markdown": "![Hyperledger](https://img.shields.io/badge/hyperledger-2F3134?style=for-the-badge&logo=hyperledger&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "ipfs",
     "name": "IPFS",
     "url": "https://img.shields.io/badge/IPFS-%2365C2CB.svg?style=for-the-badge&logo=IPFS&logoColor=white",
     "markdown": "![IPFS](https://img.shields.io/badge/IPFS-%2365C2CB.svg?style=for-the-badge&logo=IPFS&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "opensea",
     "name": "OpenSea",
     "url": "https://img.shields.io/badge/OpenSea-%232081E2.svg?style=for-the-badge&logo=opensea&logoColor=white",
     "markdown": "![OpenSea](https://img.shields.io/badge/OpenSea-%232081E2.svg?style=for-the-badge&logo=opensea&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "solana",
     "name": "Solana",
     "url": "https://img.shields.io/badge/solana-%239945FF.svg?style=for-the-badge&logo=solana&logoColor=white",
     "markdown": "![Solana](https://img.shields.io/badge/solana-%239945FF.svg?style=for-the-badge&logo=solana&logoColor=white)",
-    "category": "Blockchain"
+    "categories": [
+      "Blockchain"
+    ]
   },
   {
     "id": "blogger",
     "name": "Blogger",
     "url": "https://img.shields.io/badge/Blogger-FF5722?style=for-the-badge&logo=blogger&logoColor=white",
     "markdown": "![Blogger](https://img.shields.io/badge/Blogger-FF5722?style=for-the-badge&logo=blogger&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "daily.dev",
     "name": "daily.dev",
     "url": "https://img.shields.io/badge/daily.dev-CE3DF3?style=for-the-badge&logo=daily.dev&logoColor=white",
     "markdown": "![daily.dev](https://img.shields.io/badge/daily.dev-CE3DF3?style=for-the-badge&logo=daily.dev&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "dev",
     "name": "Dev",
     "url": "https://img.shields.io/badge/dev.to-0A0A0A?style=for-the-badge&logo=dev.to&logoColor=white",
     "markdown": "![Dev.to blog](https://img.shields.io/badge/dev.to-0A0A0A?style=for-the-badge&logo=dev.to&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "ghost",
     "name": "Ghost",
     "url": "https://img.shields.io/badge/ghost-000?style=for-the-badge&logo=ghost&logoColor=%23F7DF1E",
     "markdown": "![Ghost](https://img.shields.io/badge/ghost-000?style=for-the-badge&logo=ghost&logoColor=%23F7DF1E)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "hashnode",
     "name": "Hashnode",
     "url": "https://img.shields.io/badge/Hashnode-2962FF?style=for-the-badge&logo=hashnode&logoColor=white",
     "markdown": "![Hashnode](https://img.shields.io/badge/Hashnode-2962FF?style=for-the-badge&logo=hashnode&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "medium",
     "name": "Medium",
     "url": "https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white",
     "markdown": "![Medium](https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "micro.blog",
     "name": "Micro.blog",
     "url": "https://img.shields.io/badge/Micro.blog-FF8800?style=for-the-badge&logo=micro.blog&logoColor=white",
     "markdown": "![Micro.blog](https://img.shields.io/badge/Micro.blog-FF8800?style=for-the-badge&logo=micro.blog&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "rss",
     "name": "Rss",
     "url": "https://img.shields.io/badge/rss-F88900?style=for-the-badge&logo=rss&logoColor=white",
     "markdown": "![Rss](https://img.shields.io/badge/rss-F88900?style=for-the-badge&logo=rss&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "substack",
     "name": "Substack",
     "url": "https://img.shields.io/badge/Substack-%23006f5c.svg?style=for-the-badge&logo=substack&logoColor=FF6719",
     "markdown": "![Substack](https://img.shields.io/badge/Substack-%23006f5c.svg?style=for-the-badge&logo=substack&logoColor=FF6719)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "wix",
     "name": "Wix",
     "url": "https://img.shields.io/badge/wix-000?style=for-the-badge&logo=wix&logoColor=white",
     "markdown": "![Wix](https://img.shields.io/badge/wix-000?style=for-the-badge&logo=wix&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "zola",
     "name": "Zola",
     "url": "https://img.shields.io/badge/Zola-black?style=for-the-badge&logo=zola&logoColor=white",
     "markdown": "![Zola](https://img.shields.io/badge/Zola-black?style=for-the-badge&logo=zola&logoColor=white)",
-    "category": "Blog"
+    "categories": [
+      "Blog"
+    ]
   },
   {
     "id": "arc",
     "name": "Arc",
     "url": "https://img.shields.io/badge/Arc-000000?style=for-the-badge&logo=arc&logoColor=white",
     "markdown": "![Arc](https://img.shields.io/badge/Arc-000000?style=for-the-badge&logo=arc&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "brave",
     "name": "Brave",
     "url": "https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white",
     "markdown": "![Brave](https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers",
+      "Search Engines"
+    ]
   },
   {
     "id": "duckduckgo",
     "name": "DuckDuckGo",
     "url": "https://img.shields.io/badge/duckduckgo-de5833?style=for-the-badge&logo=duckduckgo&logoColor=white",
     "markdown": "![DuckDuckGo](https://img.shields.io/badge/duckduckgo-de5833?style=for-the-badge&logo=duckduckgo&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers",
+      "Search Engines"
+    ]
   },
   {
     "id": "edge",
     "name": "Edge",
     "url": "https://img.shields.io/badge/Edge-0078D7?style=for-the-badge&logo=Microsoft-edge&logoColor=white",
     "markdown": "![Edge](https://img.shields.io/badge/Edge-0078D7?style=for-the-badge&logo=Microsoft-edge&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "firefox",
     "name": "Firefox",
     "url": "https://img.shields.io/badge/Firefox-FF7139?style=for-the-badge&logo=Firefox-Browser&logoColor=white",
     "markdown": "![Firefox](https://img.shields.io/badge/Firefox-FF7139?style=for-the-badge&logo=Firefox-Browser&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "google-chrome",
     "name": "Google Chrome",
     "url": "https://img.shields.io/badge/Google%20Chrome-4285F4?style=for-the-badge&logo=GoogleChrome&logoColor=white",
     "markdown": "![Google Chrome](https://img.shields.io/badge/Google%20Chrome-4285F4?style=for-the-badge&logo=GoogleChrome&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "icecat",
     "name": "IceCat",
     "url": "https://img.shields.io/badge/gnuicecat-263A85?style=for-the-badge&logo=gnuicecat&logoColor=white",
     "markdown": "![IceCat](https://img.shields.io/badge/gnuicecat-263A85?style=for-the-badge&logo=gnuicecat&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "ie",
     "name": "IE",
     "url": "https://img.shields.io/badge/Internet%20Explorer-0076D6?style=for-the-badge&logo=Internet%20Explorer&logoColor=white",
     "markdown": "![IE](https://img.shields.io/badge/Internet%20Explorer-0076D6?style=for-the-badge&logo=Internet%20Explorer&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "opera",
     "name": "Opera",
     "url": "https://img.shields.io/badge/Opera-FF1B2D?style=for-the-badge&logo=Opera&logoColor=white",
     "markdown": "![Opera](https://img.shields.io/badge/Opera-FF1B2D?style=for-the-badge&logo=Opera&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "safari",
     "name": "Safari",
     "url": "https://img.shields.io/badge/Safari-000000?style=for-the-badge&logo=Safari&logoColor=white",
     "markdown": "![Safari](https://img.shields.io/badge/Safari-000000?style=for-the-badge&logo=Safari&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "tor",
     "name": "Tor",
     "url": "https://img.shields.io/badge/Tor-7D4698?style=for-the-badge&logo=Tor-Browser&logoColor=white",
     "markdown": "![Tor](https://img.shields.io/badge/Tor-7D4698?style=for-the-badge&logo=Tor-Browser&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers",
+      "Security"
+    ]
   },
   {
     "id": "vivaldi",
     "name": "Vivaldi",
     "url": "https://img.shields.io/badge/Vivaldi-EF3939?style=for-the-badge&logo=Vivaldi&logoColor=white",
     "markdown": "![Vivaldi](https://img.shields.io/badge/Vivaldi-EF3939?style=for-the-badge&logo=Vivaldi&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "zen",
     "name": "Zen",
     "url": "https://img.shields.io/badge/Zen-%23F76F53.svg?style=for-the-badge&logo=zenbrowser&logoColor=white",
     "markdown": "![Zen](https://img.shields.io/badge/Zen-%23F76F53.svg?style=for-the-badge&logo=zenbrowser&logoColor=white)",
-    "category": "Browsers"
+    "categories": [
+      "Browsers"
+    ]
   },
   {
     "id": "altium-designer",
     "name": "Altium Designer",
     "url": "https://img.shields.io/badge/altium_designer-%23A5915F.svg?style=for-the-badge&logo=altiumdesigner&logoColor=white",
     "markdown": "![Altium Designer](https://img.shields.io/badge/altium_designer-%23A5915F.svg?style=for-the-badge&logo=altiumdesigner&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "archicad",
     "name": "Archicad",
     "url": "https://img.shields.io/badge/archicad-%232D50A5.svg?style=for-the-badge&logo=archicad&logoColor=white",
     "markdown": "![Archicad](https://img.shields.io/badge/archicad-%232D50A5.svg?style=for-the-badge&logo=archicad&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "autocad",
     "name": "AutoCAD",
     "url": "https://img.shields.io/badge/autocad-%23E51050.svg?style=for-the-badge&logo=autocad&logoColor=white",
     "markdown": "![AutoCAD](https://img.shields.io/badge/autocad-%23E51050.svg?style=for-the-badge&logo=autocad&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "autodesk",
     "name": "AutoDesk",
     "url": "https://img.shields.io/badge/autodesk-%23000000.svg?style=for-the-badge&logo=autodesk&logoColor=white",
     "markdown": "![AutoDesk](https://img.shields.io/badge/autodesk-%23000000.svg?style=for-the-badge&logo=autodesk&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "autodesk-revit",
     "name": "Autodesk Revit",
     "url": "https://img.shields.io/badge/Autodesk_Revit-%23186BFF.svg?style=for-the-badge&logo=autodeskrevit&logoColor=white",
     "markdown": "![Autodesk Revit](https://img.shields.io/badge/Autodesk_Revit-%23186BFF.svg?style=for-the-badge&logo=autodeskrevit&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "freecad",
     "name": "FreeCAD",
     "url": "https://img.shields.io/badge/freecad-%23418FDE.svg?style=for-the-badge&logo=freecad&logoColor=white",
     "markdown": "![FreeCAD](https://img.shields.io/badge/freecad-%23418FDE.svg?style=for-the-badge&logo=freecad&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "kicad",
     "name": "KiCad",
     "url": "https://img.shields.io/badge/kicad-%23314CB0.svg?style=for-the-badge&logo=kicad&logoColor=white",
     "markdown": "![KiCad](https://img.shields.io/badge/kicad-%23314CB0.svg?style=for-the-badge&logo=kicad&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "microstation",
     "name": "Microstation",
     "url": "https://img.shields.io/badge/microstation-%2362BB47.svg?style=for-the-badge&logo=microstation&logoColor=white",
     "markdown": "![Microstation](https://img.shields.io/badge/microstation-%2362BB47.svg?style=for-the-badge&logo=microstation&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "openscad",
     "name": "OpenSCAD",
     "url": "https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto",
     "markdown": "![OpenSCAD](https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "rhinoceros",
     "name": "Rhinoceros",
     "url": "https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white",
     "markdown": "![Rhinoceros](https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD",
+      "Design"
+    ]
   },
   {
     "id": "sketchup",
     "name": "SketchUp",
     "url": "https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white",
     "markdown": "![SketchUp](https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "tinkercad",
     "name": "Tinkercad",
     "url": "https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white",
     "markdown": "![Tinkercad](https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white)",
-    "category": "CAD"
+    "categories": [
+      "CAD"
+    ]
   },
   {
     "id": "chipperci",
     "name": "ChipperCI",
     "url": "https://img.shields.io/badge/chipperci-1e394e.svg?style=for-the-badge&logo=chipperci&logoColor=white",
     "markdown": "![ChipperCI](https://img.shields.io/badge/chipperci-1e394e.svg?style=for-the-badge&logo=chipperci&logoColor=white)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "circleci",
     "name": "CircleCI",
     "url": "https://img.shields.io/badge/circle%20ci-%23161616.svg?style=for-the-badge&logo=circleci&logoColor=white",
     "markdown": "![CircleCI](https://img.shields.io/badge/circle%20ci-%23161616.svg?style=for-the-badge&logo=circleci&logoColor=white)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "cloudbees",
     "name": "CloudBees",
     "url": "https://img.shields.io/badge/CloudBees-1997B5&?logo=cloudbees&logoColor=white&style=for-the-badge",
     "markdown": "![CloudBees](https://img.shields.io/badge/CloudBees-1997B5&?logo=cloudbees&logoColor=white&style=for-the-badge)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "fastlane",
     "name": "Fastlane",
     "url": "https://img.shields.io/badge/fastlane-%2382bd4e.svg?style=for-the-badge&logo=fastlane&logoColor=black",
     "markdown": "![Fastlane](https://img.shields.io/badge/fastlane-%2382bd4e.svg?style=for-the-badge&logo=fastlane&logoColor=black)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "github-actions",
     "name": "GitHub Actions",
     "url": "https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white",
     "markdown": "![GitHub Actions](https://img.shields.io/badge/github%20actions-%232671E5.svg?style=for-the-badge&logo=githubactions&logoColor=white)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "gitlab-ci",
     "name": "GitLab CI",
     "url": "https://img.shields.io/badge/gitlab%20ci-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white",
     "markdown": "![GitLab CI](https://img.shields.io/badge/gitlab%20ci-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "teamcity",
     "name": "TeamCity",
     "url": "https://img.shields.io/badge/teamcity-000000.svg?style=for-the-badge&logo=teamcity&logoColor=white",
     "markdown": "![TeamCity](https://img.shields.io/badge/teamcity-000000.svg?style=for-the-badge&logo=teamcity&logoColor=white)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "travis-ci",
     "name": "Travis CI",
     "url": "https://img.shields.io/badge/travis%20ci-%232B2F33.svg?style=for-the-badge&logo=travis&logoColor=white",
     "markdown": "![TravisCI](https://img.shields.io/badge/travis%20ci-%232B2F33.svg?style=for-the-badge&logo=travis&logoColor=white)",
-    "category": "CI"
+    "categories": [
+      "CI"
+    ]
   },
   {
     "id": "octopus-deploy",
     "name": "Octopus Deploy",
     "url": "https://img.shields.io/badge/octopus%20deploy-0D80D8?style=for-the-badge&logo=octopusdeploy&logoColor=white",
     "markdown": "![Octopus Deploy](https://img.shields.io/badge/octopus%20deploy-0D80D8?style=for-the-badge&logo=octopusdeploy&logoColor=white)",
-    "category": "CD"
+    "categories": [
+      "CD"
+    ]
   },
   {
     "id": "amazon-s3",
     "name": "Amazon S3",
     "url": "https://img.shields.io/badge/Amazon%20S3-FF9900?style=for-the-badge&logo=amazons3&logoColor=white",
     "markdown": "![Amazon S3](https://img.shields.io/badge/Amazon%20S3-FF9900?style=for-the-badge&logo=amazons3&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "backblaze",
     "name": "Backblaze",
     "url": "https://img.shields.io/badge/Backblaze-%23E21E29.svg?style=for-the-badge&logo=Backblaze&logoColor=white",
     "markdown": "![Backblaze](https://img.shields.io/badge/Backblaze-%23E21E29.svg?style=for-the-badge&logo=Backblaze&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "box",
     "name": "Box",
     "url": "https://img.shields.io/badge/box-%230061D5.svg?style=for-the-badge&logo=box&logoColor=white",
     "markdown": "![Box](https://img.shields.io/badge/box-%230061D5.svg?style=for-the-badge&logo=box&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "dropbox",
     "name": "Dropbox",
     "url": "https://img.shields.io/badge/Dropbox-%233B4D98.svg?style=for-the-badge&logo=Dropbox&logoColor=white",
     "markdown": "![Dropbox](https://img.shields.io/badge/Dropbox-%233B4D98.svg?style=for-the-badge&logo=Dropbox&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "google-drive",
     "name": "Google Drive",
     "url": "https://img.shields.io/badge/Google%20Drive-4285F4?style=for-the-badge&logo=googledrive&logoColor=white",
     "markdown": "![Google Drive](https://img.shields.io/badge/Google%20Drive-4285F4?style=for-the-badge&logo=googledrive&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "icloud",
     "name": "iCloud",
     "url": "https://img.shields.io/badge/icloud-%233693F3.svg?style=for-the-badge&logo=icloud&logoColor=white",
     "markdown": "![iCloud](https://img.shields.io/badge/icloud-%233693F3.svg?style=for-the-badge&logo=icloud&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "mega.nz",
     "name": "Mega.nz",
     "url": "https://img.shields.io/badge/Mega-%23D90007.svg?style=for-the-badge&logo=Mega&logoColor=white",
     "markdown": "![Mega.nz](https://img.shields.io/badge/Mega-%23D90007.svg?style=for-the-badge&logo=Mega&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "microsoft-onedrive",
     "name": "Microsoft OneDrive",
     "url": "https://img.shields.io/badge/OneDrive-white?style=for-the-badge&logo=Microsoft%20OneDrive&logoColor=0078D4",
     "markdown": "![OneDrive](https://img.shields.io/badge/OneDrive-white?style=for-the-badge&logo=Microsoft%20OneDrive&logoColor=0078D4)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "next-cloud",
     "name": "Next Cloud",
     "url": "https://img.shields.io/badge/Next%20Cloud-0B94DE?style=for-the-badge&logo=nextcloud&logoColor=white",
     "markdown": "![Next Cloud](https://img.shields.io/badge/Next%20Cloud-0B94DE?style=for-the-badge&logo=nextcloud&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "onedrive",
     "name": "OneDrive",
     "url": "https://img.shields.io/badge/OneDrive-0078D4.svg?style=for-the-badge&logo=microsoftonedrive&logoColor=white",
     "markdown": "![OneDrive](https://img.shields.io/badge/OneDrive-0078D4.svg?style=for-the-badge&logo=microsoftonedrive&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "proton-drive",
     "name": "Proton Drive",
     "url": "https://img.shields.io/badge/Proton%20Drive-6d4aff?style=for-the-badge&logo=proton%20drive&logoColor=white",
     "markdown": "![Proton Drive](https://img.shields.io/badge/Proton%20Drive-6d4aff?style=for-the-badge&logo=proton%20drive&logoColor=white)",
-    "category": "Cloud Storage"
+    "categories": [
+      "Cloud Storage"
+    ]
   },
   {
     "id": "amp",
     "name": "Amp",
     "url": "https://img.shields.io/badge/Amp-005AF0?style=for-the-badge&logo=amp&logoColor=white",
     "markdown": "![Amp](https://img.shields.io/badge/Amp-005AF0?style=for-the-badge&logo=amp&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "binance",
     "name": "Binance",
     "url": "https://img.shields.io/badge/Binance-FCD535?style=for-the-badge&logo=binance&logoColor=white",
     "markdown": "![Binance](https://img.shields.io/badge/Binance-FCD535?style=for-the-badge&logo=binance&logoColor=white)",
-    "category": "Cryptocurrency"
-  },
-  {
-    "id": "bitcoin-cryptocurrency",
-    "name": "Bitcoin",
-    "url": "https://img.shields.io/badge/Bitcoin-000?style=for-the-badge&logo=bitcoin&logoColor=white",
-    "markdown": "![Bitcoin](https://img.shields.io/badge/Bitcoin-000?style=for-the-badge&logo=bitcoin&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "bitcoin-cash",
     "name": "Bitcoin Cash",
     "url": "https://img.shields.io/badge/Bitcoin%20Cash-0AC18E?style=for-the-badge&logo=Bitcoin%20Cash&logoColor=white",
     "markdown": "![Bitcoin Cash](https://img.shields.io/badge/Bitcoin%20Cash-0AC18E?style=for-the-badge&logo=Bitcoin%20Cash&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "bitcoin-sv",
     "name": "Bitcoin SV",
     "url": "https://img.shields.io/badge/Bitcoin%20SV-EAB300?style=for-the-badge&logo=Bitcoin%20SV&logoColor=white",
     "markdown": "![Bitcoin SV](https://img.shields.io/badge/Bitcoin%20SV-EAB300?style=for-the-badge&logo=Bitcoin%20SV&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "chainlink",
     "name": "Chainlink",
     "url": "https://img.shields.io/badge/Chainlink-375BD2?style=for-the-badge&logo=Chainlink&logoColor=white",
     "markdown": "![Chainlink](https://img.shields.io/badge/Chainlink-375BD2?style=for-the-badge&logo=Chainlink&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "dash",
     "name": "Dash",
     "url": "https://img.shields.io/badge/dash-008DE4?style=for-the-badge&logo=dash&logoColor=white",
     "markdown": "![Dash](https://img.shields.io/badge/dash-008DE4?style=for-the-badge&logo=dash&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "dogecoin",
     "name": "Dogecoin",
     "url": "https://img.shields.io/badge/dogecoin-B59A30?style=for-the-badge&logo=dogecoin&logoColor=white",
     "markdown": "![Dogecoin](https://img.shields.io/badge/dogecoin-B59A30?style=for-the-badge&logo=dogecoin&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "ethereum",
     "name": "Ethereum",
     "url": "https://img.shields.io/badge/Ethereum-3C3C3D?style=for-the-badge&logo=Ethereum&logoColor=white",
     "markdown": "![Ethereum](https://img.shields.io/badge/Ethereum-3C3C3D?style=for-the-badge&logo=Ethereum&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "iota",
     "name": "Iota",
     "url": "https://img.shields.io/badge/iota-29334C?style=for-the-badge&logo=iota&logoColor=white",
     "markdown": "![Iota](https://img.shields.io/badge/iota-29334C?style=for-the-badge&logo=iota&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "litecoin",
     "name": "Litecoin",
     "url": "https://img.shields.io/badge/Litecoin-A6A9AA?style=for-the-badge&logo=Litecoin&logoColor=white",
     "markdown": "![Litecoin](https://img.shields.io/badge/Litecoin-A6A9AA?style=for-the-badge&logo=Litecoin&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "monero",
     "name": "Monero",
     "url": "https://img.shields.io/badge/monero-FF6600?style=for-the-badge&logo=monero&logoColor=white",
     "markdown": "![Monero](https://img.shields.io/badge/monero-FF6600?style=for-the-badge&logo=monero&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "polkadot",
     "name": "Polkadot",
     "url": "https://img.shields.io/badge/polkadot-E6007A?style=for-the-badge&logo=polkadot&logoColor=white",
     "markdown": "![Polkadot](https://img.shields.io/badge/polkadot-E6007A?style=for-the-badge&logo=polkadot&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "rarible",
     "name": "Rarible",
     "url": "https://img.shields.io/badge/rarible-%23FEDA03.svg?style=for-the-badge&logo=rarible&logoColor=black",
     "markdown": "![Rarible](https://img.shields.io/badge/rarible-%23FEDA03.svg?style=for-the-badge&logo=rarible&logoColor=black)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "stellar",
     "name": "Stellar",
     "url": "https://img.shields.io/badge/Stellar-7D00FF?style=for-the-badge&logo=Stellar&logoColor=white",
     "markdown": "![Stellar](https://img.shields.io/badge/Stellar-7D00FF?style=for-the-badge&logo=Stellar&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "tether",
     "name": "Tether",
     "url": "https://img.shields.io/badge/tether-168363?style=for-the-badge&logo=tether&logoColor=white",
     "markdown": "![Tether](https://img.shields.io/badge/tether-168363?style=for-the-badge&logo=tether&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "xrp",
     "name": "Xrp",
     "url": "https://img.shields.io/badge/Xrp-black?style=for-the-badge&logo=xrp&logoColor=white",
     "markdown": "![Xrp](https://img.shields.io/badge/Xrp-black?style=for-the-badge&logo=xrp&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "z-cash",
     "name": "Z Cash",
     "url": "https://img.shields.io/badge/Zcash-F4B728?style=for-the-badge&logo=zcash&logoColor=white",
     "markdown": "![Z Cash](https://img.shields.io/badge/Zcash-F4B728?style=for-the-badge&logo=zcash&logoColor=white)",
-    "category": "Cryptocurrency"
+    "categories": [
+      "Cryptocurrency"
+    ]
   },
   {
     "id": "amazon-dynamodb",
     "name": "Amazon DynamoDB",
     "url": "https://img.shields.io/badge/Amazon%20DynamoDB-4053D6?style=for-the-badge&logo=Amazon%20DynamoDB&logoColor=white",
     "markdown": "![AmazonDynamoDB](https://img.shields.io/badge/Amazon%20DynamoDB-4053D6?style=for-the-badge&logo=Amazon%20DynamoDB&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "appwrite",
     "name": "Appwrite",
     "url": "https://img.shields.io/badge/Appwrite-%23FD366E.svg?style=for-the-badge&logo=appwrite&logoColor=white",
     "markdown": "![Appwrite](https://img.shields.io/badge/Appwrite-%23FD366E.svg?style=for-the-badge&logo=appwrite&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "arangodb",
     "name": "ArangoDB",
     "url": "https://img.shields.io/badge/ArangoDB-DDE072?style=for-the-badge&logo=arangodb&logoColor=white",
     "markdown": "![Arango DB](https://img.shields.io/badge/ArangoDB-DDE072?style=for-the-badge&logo=arangodb&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "cassandra",
     "name": "Cassandra",
     "url": "https://img.shields.io/badge/cassandra-%231287B1.svg?style=for-the-badge&logo=apache-cassandra&logoColor=white",
     "markdown": "![ApacheCassandra](https://img.shields.io/badge/cassandra-%231287B1.svg?style=for-the-badge&logo=apache-cassandra&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "clickhouse",
     "name": "ClickHouse",
     "url": "https://img.shields.io/badge/ClickHouse-FFCC01?style=for-the-badge&logo=clickhouse&logoColor=white",
     "markdown": "![ClickHouse](https://img.shields.io/badge/ClickHouse-FFCC01?style=for-the-badge&logo=clickhouse&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "cockroach-labs",
     "name": "Cockroach Labs",
     "url": "https://img.shields.io/badge/Cockroach%20Labs-6933FF?style=for-the-badge&logo=Cockroach%20Labs&logoColor=white",
     "markdown": "![CockroachLabs](https://img.shields.io/badge/Cockroach%20Labs-6933FF?style=for-the-badge&logo=Cockroach%20Labs&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "couchbase",
     "name": "Couchbase",
     "url": "https://img.shields.io/badge/Couchbase-EA2328?style=for-the-badge&logo=couchbase&logoColor=white",
     "markdown": "![Couchbase](https://img.shields.io/badge/Couchbase-EA2328?style=for-the-badge&logo=couchbase&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "cratedb",
     "name": "CrateDB",
     "url": "https://img.shields.io/badge/CrateDB-009DC7?style=for-the-badge&logo=CrateDB&logoColor=white",
     "markdown": "![CrateDB](https://img.shields.io/badge/CrateDB-009DC7?style=for-the-badge&logo=CrateDB&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "duckdb",
     "name": "DuckDB",
     "url": "https://img.shields.io/badge/duckdb-%23FFF000.svg?style=for-the-badge&logo=duckdb&logoColor=black",
     "markdown": "![Duckdb](https://img.shields.io/badge/duckdb-%23FFF000.svg?style=for-the-badge&logo=duckdb&logoColor=black)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "firebase",
     "name": "Firebase",
     "url": "https://img.shields.io/badge/firebase-a08021?style=for-the-badge&logo=firebase&logoColor=ffcd34",
     "markdown": "![Firebase](https://img.shields.io/badge/firebase-a08021?style=for-the-badge&logo=firebase&logoColor=ffcd34)",
-    "category": "Databases"
+    "categories": [
+      "Databases",
+      "SaaS"
+    ]
   },
   {
     "id": "influxdb",
     "name": "InfluxDB",
     "url": "https://img.shields.io/badge/InfluxDB-22ADF6?style=for-the-badge&logo=InfluxDB&logoColor=white",
     "markdown": "![InfluxDB](https://img.shields.io/badge/InfluxDB-22ADF6?style=for-the-badge&logo=InfluxDB&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "mariadb",
     "name": "MariaDB",
     "url": "https://img.shields.io/badge/MariaDB-003545?style=for-the-badge&logo=mariadb&logoColor=white",
     "markdown": "![MariaDB](https://img.shields.io/badge/MariaDB-003545?style=for-the-badge&logo=mariadb&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "microsoft-sql-server",
     "name": "Microsoft SQL Server",
     "url": "https://img.shields.io/badge/Microsoft%20SQL%20Server-CC2927?style=for-the-badge&logo=microsoft%20sql%20server&logoColor=white",
     "markdown": "![MicrosoftSQLServer](https://img.shields.io/badge/Microsoft%20SQL%20Server-CC2927?style=for-the-badge&logo=microsoft%20sql%20server&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "mongodb",
     "name": "MongoDB",
     "url": "https://img.shields.io/badge/MongoDB-%234ea94b.svg?style=for-the-badge&logo=mongodb&logoColor=white",
     "markdown": "![MongoDB](https://img.shields.io/badge/MongoDB-%234ea94b.svg?style=for-the-badge&logo=mongodb&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "musicbrainz",
     "name": "MusicBrainz",
     "url": "https://img.shields.io/badge/Musicbrainz-EB743B?style=for-the-badge&logo=musicbrainz&logoColor=BA478F",
     "markdown": "![MusicBrainz](https://img.shields.io/badge/Musicbrainz-EB743B?style=for-the-badge&logo=musicbrainz&logoColor=BA478F)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "mysql",
     "name": "MySQL",
     "url": "https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white",
     "markdown": "![MySQL](https://img.shields.io/badge/mysql-4479A1.svg?style=for-the-badge&logo=mysql&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "neo4j",
     "name": "Neo4J",
     "url": "https://img.shields.io/badge/Neo4j-008CC1?style=for-the-badge&logo=neo4j&logoColor=white",
     "markdown": "![Neo4J](https://img.shields.io/badge/Neo4j-008CC1?style=for-the-badge&logo=neo4j&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "planetscale",
     "name": "PlanetScale",
     "url": "https://img.shields.io/badge/planetscale-%23000000.svg?style=for-the-badge&logo=planetscale&logoColor=white",
     "markdown": "![PlanetScale](https://img.shields.io/badge/planetscale-%23000000.svg?style=for-the-badge&logo=planetscale&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "pocketbase",
     "name": "PocketBase",
     "url": "https://img.shields.io/badge/pocketbase-%23b8dbe4.svg?style=for-the-badge&logo=Pocketbase&logoColor=black",
     "markdown": "![PocketBase](https://img.shields.io/badge/pocketbase-%23b8dbe4.svg?style=for-the-badge&logo=Pocketbase&logoColor=black)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "postgres",
     "name": "Postgres",
     "url": "https://img.shields.io/badge/postgres-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white",
     "markdown": "![Postgres](https://img.shields.io/badge/postgres-%23316192.svg?style=for-the-badge&logo=postgresql&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "realm",
     "name": "Realm",
     "url": "https://img.shields.io/badge/Realm-39477F?style=for-the-badge&logo=realm&logoColor=white",
     "markdown": "![Realm](https://img.shields.io/badge/Realm-39477F?style=for-the-badge&logo=realm&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "redis",
     "name": "Redis",
     "url": "https://img.shields.io/badge/redis-%23DD0031.svg?style=for-the-badge&logo=redis&logoColor=white",
     "markdown": "![Redis](https://img.shields.io/badge/redis-%23DD0031.svg?style=for-the-badge&logo=redis&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "single-store",
     "name": "Single Store",
     "url": "https://img.shields.io/badge/Single%20Store-AA00FF?style=for-the-badge&logo=singlestore&logoColor=white",
     "markdown": "![Single Store](https://img.shields.io/badge/Single%20Store-AA00FF?style=for-the-badge&logo=singlestore&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "sqlite",
     "name": "SQLite",
     "url": "https://img.shields.io/badge/sqlite-%2307405e.svg?style=for-the-badge&logo=sqlite&logoColor=white",
     "markdown": "![SQLite](https://img.shields.io/badge/sqlite-%2307405e.svg?style=for-the-badge&logo=sqlite&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "supabase",
     "name": "Supabase",
     "url": "https://img.shields.io/badge/Supabase-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white",
     "markdown": "![Supabase](https://img.shields.io/badge/Supabase-3ECF8E?style=for-the-badge&logo=supabase&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "surrealdb",
     "name": "SurrealDB",
     "url": "https://img.shields.io/badge/SurrealDB-FF00A0?style=for-the-badge&logo=surrealdb&logoColor=white",
     "markdown": "![SurrealDB](https://img.shields.io/badge/SurrealDB-FF00A0?style=for-the-badge&logo=surrealdb&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "teradata",
     "name": "Teradata",
     "url": "https://img.shields.io/badge/Teradata-F37440?style=for-the-badge&logo=teradata&logoColor=white",
     "markdown": "![Teradata](https://img.shields.io/badge/Teradata-F37440?style=for-the-badge&logo=teradata&logoColor=white)",
-    "category": "Databases"
+    "categories": [
+      "Databases"
+    ]
   },
   {
     "id": "adobe",
     "name": "Adobe",
     "url": "https://img.shields.io/badge/adobe-%23FF0000.svg?style=for-the-badge&logo=adobe&logoColor=white",
     "markdown": "![Adobe](https://img.shields.io/badge/adobe-%23FF0000.svg?style=for-the-badge&logo=adobe&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-acrobat-reader",
     "name": "Adobe Acrobat Reader",
     "url": "https://img.shields.io/badge/Adobe%20Acrobat%20Reader-EC1C24.svg?style=for-the-badge&logo=Adobe%20Acrobat%20Reader&logoColor=white",
     "markdown": "![Adobe Acrobat Reader](https://img.shields.io/badge/Adobe%20Acrobat%20Reader-EC1C24.svg?style=for-the-badge&logo=Adobe%20Acrobat%20Reader&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-after-effects",
     "name": "Adobe After Effects",
     "url": "https://img.shields.io/badge/Adobe%20After%20Effects-9999FF.svg?style=for-the-badge&logo=Adobe%20After%20Effects&logoColor=white",
     "markdown": "![Adobe After Effects](https://img.shields.io/badge/Adobe%20After%20Effects-9999FF.svg?style=for-the-badge&logo=Adobe%20After%20Effects&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-audition",
     "name": "Adobe Audition",
     "url": "https://img.shields.io/badge/Adobe%20Audition-9999FF.svg?style=for-the-badge&logo=Adobe%20Audition&logoColor=white",
     "markdown": "![Adobe Audition](https://img.shields.io/badge/Adobe%20Audition-9999FF.svg?style=for-the-badge&logo=Adobe%20Audition&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-creative-cloud",
     "name": "Adobe Creative Cloud",
     "url": "https://img.shields.io/badge/Adobe%20Creative%20Cloud-DA1F26.svg?style=for-the-badge&logo=Adobe%20Creative%20Cloud&logoColor=white",
     "markdown": "![Adobe Creative Cloud](https://img.shields.io/badge/Adobe%20Creative%20Cloud-DA1F26.svg?style=for-the-badge&logo=Adobe%20Creative%20Cloud&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-dreamweaver",
     "name": "Adobe Dreamweaver",
     "url": "https://img.shields.io/badge/Adobe%20Dreamweaver-FF61F6.svg?style=for-the-badge&logo=Adobe%20Dreamweaver&logoColor=white",
     "markdown": "![Adobe Dreamweaver](https://img.shields.io/badge/Adobe%20Dreamweaver-FF61F6.svg?style=for-the-badge&logo=Adobe%20Dreamweaver&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-fonts",
     "name": "Adobe Fonts",
     "url": "https://img.shields.io/badge/Adobe%20Fonts-000B1D.svg?style=for-the-badge&logo=Adobe%20Fonts&logoColor=white",
     "markdown": "![Adobe Fonts](https://img.shields.io/badge/Adobe%20Fonts-000B1D.svg?style=for-the-badge&logo=Adobe%20Fonts&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-illustrator",
     "name": "Adobe Illustrator",
     "url": "https://img.shields.io/badge/adobe%20illustrator-%23FF9A00.svg?style=for-the-badge&logo=adobe%20illustrator&logoColor=white",
     "markdown": "![Adobe Illustrator](https://img.shields.io/badge/adobe%20illustrator-%23FF9A00.svg?style=for-the-badge&logo=adobe%20illustrator&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-indesign",
     "name": "Adobe InDesign",
     "url": "https://img.shields.io/badge/Adobe%20InDesign-49021F?style=for-the-badge&logo=adobeindesign&logoColor=white",
     "markdown": "![Adobe InDesign](https://img.shields.io/badge/Adobe%20InDesign-49021F?style=for-the-badge&logo=adobeindesign&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-lightroom",
     "name": "Adobe Lightroom",
     "url": "https://img.shields.io/badge/Adobe%20Lightroom-31A8FF.svg?style=for-the-badge&logo=Adobe%20Lightroom&logoColor=white",
     "markdown": "![Adobe Lightroom](https://img.shields.io/badge/Adobe%20Lightroom-31A8FF.svg?style=for-the-badge&logo=Adobe%20Lightroom&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-lightroom-classic",
     "name": "Adobe Lightroom Classic",
     "url": "https://img.shields.io/badge/Adobe%20Lightroom%20Classic-31A8FF.svg?style=for-the-badge&logo=Adobe%20Lightroom%20Classic&logoColor=white",
     "markdown": "![Adobe Lightroom Classic](https://img.shields.io/badge/Adobe%20Lightroom%20Classic-31A8FF.svg?style=for-the-badge&logo=Adobe%20Lightroom%20Classic&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-photoshop",
     "name": "Adobe Photoshop",
     "url": "https://img.shields.io/badge/adobe%20photoshop-%2331A8FF.svg?style=for-the-badge&logo=adobe%20photoshop&logoColor=white",
     "markdown": "![Adobe Photoshop](https://img.shields.io/badge/adobe%20photoshop-%2331A8FF.svg?style=for-the-badge&logo=adobe%20photoshop&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-premiere-pro",
     "name": "Adobe Premiere Pro",
     "url": "https://img.shields.io/badge/Adobe%20Premiere%20Pro-9999FF.svg?style=for-the-badge&logo=Adobe%20Premiere%20Pro&logoColor=white",
     "markdown": "![Adobe Premiere Pro](https://img.shields.io/badge/Adobe%20Premiere%20Pro-9999FF.svg?style=for-the-badge&logo=Adobe%20Premiere%20Pro&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "adobe-xd",
     "name": "Adobe XD",
     "url": "https://img.shields.io/badge/Adobe%20XD-470137?style=for-the-badge&logo=Adobe%20XD&logoColor=#FF61F6",
     "markdown": "![Adobe XD](https://img.shields.io/badge/Adobe%20XD-470137?style=for-the-badge&logo=Adobe%20XD&logoColor=#FF61F6)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "affinity-designer",
     "name": "Affinity Designer",
     "url": "https://img.shields.io/badge/affinity%20desginer-%231B72BE.svg?style=for-the-badge&logo=affinity-designer&logoColor=white",
     "markdown": "![Affinity Designer](https://img.shields.io/badge/affinity%20desginer-%231B72BE.svg?style=for-the-badge&logo=affinity-designer&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "affinity-photo",
     "name": "Affinity Photo",
     "url": "https://img.shields.io/badge/affinityphoto-%237E4DD2.svg?style=for-the-badge&logo=affinity-photo&logoColor=white",
     "markdown": "![Affinity Photo](https://img.shields.io/badge/affinityphoto-%237E4DD2.svg?style=for-the-badge&logo=affinity-photo&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "aseprite",
     "name": "Aseprite",
     "url": "https://img.shields.io/badge/Aseprite-FFFFFF?style=for-the-badge&logo=Aseprite&logoColor=#7D929E",
     "markdown": "![Aseprite](https://img.shields.io/badge/Aseprite-FFFFFF?style=for-the-badge&logo=Aseprite&logoColor=#7D929E)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "blender",
     "name": "Blender",
     "url": "https://img.shields.io/badge/blender-%23F5792A.svg?style=for-the-badge&logo=blender&logoColor=white",
     "markdown": "![Blender](https://img.shields.io/badge/blender-%23F5792A.svg?style=for-the-badge&logo=blender&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "canva",
     "name": "Canva",
     "url": "https://img.shields.io/badge/Canva-%2300C4CC.svg?style=for-the-badge&logo=Canva&logoColor=white",
     "markdown": "![Canva](https://img.shields.io/badge/Canva-%2300C4CC.svg?style=for-the-badge&logo=Canva&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "clip-studio-paint",
     "name": "Clip Studio Paint",
     "url": "https://img.shields.io/badge/ClipStudioPaint-%23CFD3D3.svg?style=for-the-badge&logo=ClipStudioPaint&logoColor=white",
     "markdown": "![Clip Studio Paint](https://img.shields.io/badge/ClipStudioPaint-%23CFD3D3.svg?style=for-the-badge&logo=ClipStudioPaint&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "davinci-resolve",
     "name": "DaVinci Resolve",
     "url": "https://img.shields.io/badge/davinci_resolve-%23233A51.svg?style=for-the-badge&logo=davinciresolve&logoColor=white",
     "markdown": "![DaVinci Resolve](https://img.shields.io/badge/davinci_resolve-%23233A51.svg?style=for-the-badge&logo=davinciresolve&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "drawio",
     "name": "Drawio",
     "url": "https://img.shields.io/badge/drawio-%23F08705?style=for-the-badge&logo=diagrams.net&logoColor=white",
     "markdown": "![Drawio](https://img.shields.io/badge/drawio-%23F08705?style=for-the-badge&logo=diagrams.net&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "dribbble",
     "name": "Dribbble",
     "url": "https://img.shields.io/badge/Dribbble-EA4C89?style=for-the-badge&logo=dribbble&logoColor=white",
     "markdown": "![Dribbble](https://img.shields.io/badge/Dribbble-EA4C89?style=for-the-badge&logo=dribbble&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "figma",
     "name": "Figma",
     "url": "https://img.shields.io/badge/figma-%23F24E1E.svg?style=for-the-badge&logo=figma&logoColor=white",
     "markdown": "![Figma](https://img.shields.io/badge/figma-%23F24E1E.svg?style=for-the-badge&logo=figma&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "framer",
     "name": "Framer",
     "url": "https://img.shields.io/badge/Framer-black?style=for-the-badge&logo=framer&logoColor=blue",
     "markdown": "![Framer](https://img.shields.io/badge/Framer-black?style=for-the-badge&logo=framer&logoColor=blue)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "gimp",
     "name": "Gimp",
     "url": "https://img.shields.io/badge/Gimp-657D8B?style=for-the-badge&logo=gimp&logoColor=FFFFFF",
     "markdown": "![Gimp Gnu Image Manipulation Program](https://img.shields.io/badge/Gimp-657D8B?style=for-the-badge&logo=gimp&logoColor=FFFFFF)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "inkscape",
     "name": "Inkscape",
     "url": "https://img.shields.io/badge/Inkscape-e0e0e0?style=for-the-badge&logo=inkscape&logoColor=080A13",
     "markdown": "![Inkscape](https://img.shields.io/badge/Inkscape-e0e0e0?style=for-the-badge&logo=inkscape&logoColor=080A13)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "invision",
     "name": "Invision",
     "url": "https://img.shields.io/badge/invision-FF3366?style=for-the-badge&logo=invision&logoColor=white",
     "markdown": "![Invision](https://img.shields.io/badge/invision-FF3366?style=for-the-badge&logo=invision&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "krita",
     "name": "Krita",
     "url": "https://img.shields.io/badge/Krita-203759?style=for-the-badge&logo=krita&logoColor=EEF37B",
     "markdown": "![Krita](https://img.shields.io/badge/Krita-203759?style=for-the-badge&logo=krita&logoColor=EEF37B)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "penpot",
     "name": "Penpot",
     "url": "https://img.shields.io/badge/penpot-%23FFFFFF.svg?style=for-the-badge&logo=penpot&logoColor=black",
     "markdown": "![Penpot](https://img.shields.io/badge/penpot-%23FFFFFF.svg?style=for-the-badge&logo=penpot&logoColor=black)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "proto.io",
     "name": "Proto.io",
     "url": "https://img.shields.io/badge/Proto.io-161637?style=for-the-badge&logo=proto.io&logoColor=00e5ff",
     "markdown": "![Proto.io](https://img.shields.io/badge/Proto.io-161637?style=for-the-badge&logo=proto.io&logoColor=00e5ff)",
-    "category": "Design"
-  },
-  {
-    "id": "rhinoceros-design",
-    "name": "Rhinoceros",
-    "url": "https://img.shields.io/badge/Rhinoceros-801010?style=for-the-badge&logo=rhinoceros&logoColor=white",
-    "markdown": "![Rhinoceros](https://img.shields.io/badge/Rhinoceros-801010?style=for-the-badge&logo=rhinoceros&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "sketch",
     "name": "Sketch",
     "url": "https://img.shields.io/badge/Sketch-FFB387?style=for-the-badge&logo=sketch&logoColor=black",
     "markdown": "![Sketch](https://img.shields.io/badge/Sketch-FFB387?style=for-the-badge&logo=sketch&logoColor=black)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "sketch-up",
     "name": "Sketch Up",
     "url": "https://img.shields.io/badge/SketchUp-005F9E?style=for-the-badge&logo=sketchup&logoColor=white",
     "markdown": "![Sketch Up](https://img.shields.io/badge/SketchUp-005F9E?style=for-the-badge&logo=sketchup&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "storybook",
     "name": "Storybook",
     "url": "https://img.shields.io/badge/-Storybook-FF4785?style=for-the-badge&logo=storybook&logoColor=white",
     "markdown": "![Storybook](https://img.shields.io/badge/-Storybook-FF4785?style=for-the-badge&logo=storybook&logoColor=white)",
-    "category": "Design"
+    "categories": [
+      "Design"
+    ]
   },
   {
     "id": "backstage",
     "name": "Backstage",
     "url": "https://img.shields.io/badge/Backstage-%237A3CF8.svg?style=for-the-badge&logo=backstage&logoColor=white",
     "markdown": "![Backstage](https://img.shields.io/badge/Backstage-%237A3CF8.svg?style=for-the-badge&logo=backstage&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "codechef",
     "name": "CodeChef",
     "url": "https://img.shields.io/badge/CodeChef-%23964B00.svg?style=for-the-badge&logo=CodeChef&logoColor=white",
     "markdown": "![CodeChef](https://img.shields.io/badge/CodeChef-%23964B00.svg?style=for-the-badge&logo=CodeChef&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "codeforces",
     "name": "Codeforces",
     "url": "https://img.shields.io/badge/Codeforces-445f9d?style=for-the-badge&logo=Codeforces&logoColor=white",
     "markdown": "![Codeforces](https://img.shields.io/badge/Codeforces-445f9d?style=for-the-badge&logo=Codeforces&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "codepen",
     "name": "CodePen",
     "url": "https://img.shields.io/badge/Codepen-000000?style=for-the-badge&logo=codepen&logoColor=white",
     "markdown": "![CodePen](https://img.shields.io/badge/Codepen-000000?style=for-the-badge&logo=codepen&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums",
+      "IDEs"
+    ]
   },
   {
     "id": "frontend-mentor",
     "name": "Frontend Mentor",
     "url": "https://img.shields.io/badge/Frontend_Mentor-%233F54A3.svg?style=for-the-badge&logo=frontendmentor&logoColor=white",
     "markdown": "![Frontend Mentor](https://img.shields.io/badge/Frontend_Mentor-%233F54A3.svg?style=for-the-badge&logo=frontendmentor&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "hackerearth",
     "name": "Hackerearth",
     "url": "https://img.shields.io/badge/HackerEarth-%232C3454.svg?&style=for-the-badge&logo=HackerEarth&logoColor=Blue",
     "markdown": "![Hackerearth](https://img.shields.io/badge/HackerEarth-%232C3454.svg?&style=for-the-badge&logo=HackerEarth&logoColor=Blue)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "hackerrank",
     "name": "Hackerrank",
     "url": "https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white",
     "markdown": "![Hackerrank](https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums",
+      "Jobs"
+    ]
   },
   {
     "id": "kaggle",
     "name": "Kaggle",
     "url": "https://img.shields.io/badge/Kaggle-035a7d?style=for-the-badge&logo=kaggle&logoColor=white",
     "markdown": "![Kaggle](https://img.shields.io/badge/Kaggle-035a7d?style=for-the-badge&logo=kaggle&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "leetcode",
     "name": "LeetCode",
     "url": "https://img.shields.io/badge/LeetCode-000000?style=for-the-badge&logo=LeetCode&logoColor=#d16c06",
     "markdown": "![LeetCode](https://img.shields.io/badge/LeetCode-000000?style=for-the-badge&logo=LeetCode&logoColor=#d16c06)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "oneplus-forums",
     "name": "OnePlus Forums",
     "url": "https://img.shields.io/badge/OnePlusForums-%23EB0028.svg?style=for-the-badge&logo=OnePlus&logoColor=white",
     "markdown": "![OnePlus Forums](https://img.shields.io/badge/OnePlusForums-%23EB0028.svg?style=for-the-badge&logo=OnePlus&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "quora",
     "name": "Quora",
     "url": "https://img.shields.io/badge/Quora-%23B92B27.svg?style=for-the-badge&logo=Quora&logoColor=white",
     "markdown": "![Quora](https://img.shields.io/badge/Quora-%23B92B27.svg?style=for-the-badge&logo=Quora&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "reddit",
     "name": "Reddit",
     "url": "https://img.shields.io/badge/Reddit-%23FF4500.svg?style=for-the-badge&logo=Reddit&logoColor=white",
     "markdown": "![Reddit](https://img.shields.io/badge/Reddit-%23FF4500.svg?style=for-the-badge&logo=Reddit&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums",
+      "Social"
+    ]
   },
   {
     "id": "researchgate",
     "name": "ResearchGate",
     "url": "https://img.shields.io/badge/ResearchGate-00CCBB?style=for-the-badge&logo=ResearchGate&logoColor=white",
     "markdown": "![ResearchGate](https://img.shields.io/badge/ResearchGate-00CCBB?style=for-the-badge&logo=ResearchGate&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "stack-exchange",
     "name": "Stack Exchange",
     "url": "https://img.shields.io/badge/StackExchange-%23ffffff.svg?style=for-the-badge&logo=StackExchange",
     "markdown": "![Stack Exchange](https://img.shields.io/badge/StackExchange-%23ffffff.svg?style=for-the-badge&logo=StackExchange)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "stack-overflow",
     "name": "Stack Overflow",
     "url": "https://img.shields.io/badge/-Stackoverflow-FE7A16?style=for-the-badge&logo=stack-overflow&logoColor=white",
     "markdown": "![Stack Overflow](https://img.shields.io/badge/-Stackoverflow-FE7A16?style=for-the-badge&logo=stack-overflow&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "xda-developers",
     "name": "XDA-Developers",
     "url": "https://img.shields.io/badge/XDA--Developers-%23AC6E2F.svg?style=for-the-badge&logo=XDA-Developers&logoColor=white",
     "markdown": "![XDA-Developers](https://img.shields.io/badge/XDA--Developers-%23AC6E2F.svg?style=for-the-badge&logo=XDA-Developers&logoColor=white)",
-    "category": "Forums"
+    "categories": [
+      "Forums"
+    ]
   },
   {
     "id": "bookstack",
     "name": "Bookstack",
     "url": "https://img.shields.io/badge/Bookstack-%230288D1.svg?style=for-the-badge&logo=bookstack&logoColor=white",
     "markdown": "![Bookstack](https://img.shields.io/badge/Bookstack-%230288D1.svg?style=for-the-badge&logo=bookstack&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "coda",
     "name": "Coda",
     "url": "https://img.shields.io/badge/coda-%23F46A54.svg?style=for-the-badge&logo=coda&logoColor=white",
     "markdown": "![Coda](https://img.shields.io/badge/coda-%23F46A54.svg?style=for-the-badge&logo=coda&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "confluence",
     "name": "Confluence",
     "url": "https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white",
     "markdown": "![Confluence](https://img.shields.io/badge/confluence-%23172BF4.svg?style=for-the-badge&logo=confluence&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "docsify",
     "name": "Docsify",
     "url": "https://img.shields.io/badge/docsify-%232ECE53.svg?style=for-the-badge&logo=docsify&logoColor=white",
     "markdown": "![Docsify](https://img.shields.io/badge/docsify-%232ECE53.svg?style=for-the-badge&logo=docsify&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "docusaurus",
     "name": "Docusaurus",
     "url": "https://img.shields.io/badge/docusaurus-%233ECC5F.svg?style=for-the-badge&logo=docusaurus&logoColor=white",
     "markdown": "![Docusaurus](https://img.shields.io/badge/docusaurus-%233ECC5F.svg?style=for-the-badge&logo=docusaurus&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "gitbook",
     "name": "GitBook",
     "url": "https://img.shields.io/badge/GitBook-%23000000.svg?style=for-the-badge&logo=gitbook&logoColor=white",
     "markdown": "![GitBook](https://img.shields.io/badge/GitBook-%23000000.svg?style=for-the-badge&logo=gitbook&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "quip",
     "name": "Quip",
     "url": "https://img.shields.io/badge/quip-%23F27557.svg?style=for-the-badge&logo=quip&logoColor=white",
     "markdown": "![Quip](https://img.shields.io/badge/quip-%23F27557.svg?style=for-the-badge&logo=quip&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "read-the-docs",
     "name": "Read the Docs",
     "url": "https://img.shields.io/badge/Read%20the%20Docs-%23000000?style=for-the-badge&logo=readthedocs&logoColor=white",
     "markdown": "![Read the Docs](https://img.shields.io/badge/Read%20the%20Docs-%23000000?style=for-the-badge&logo=readthedocs&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "swagger",
     "name": "Swagger",
     "url": "https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white",
     "markdown": "![Swagger](https://img.shields.io/badge/-Swagger-%23Clojure?style=for-the-badge&logo=swagger&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "tiddlywiki",
     "name": "TiddlyWiki",
     "url": "https://img.shields.io/badge/tiddlywiki-%23111111.svg?style=for-the-badge&logo=tiddlywiki&logoColor=white",
     "markdown": "![TiddlyWiki](https://img.shields.io/badge/tiddlywiki-%23111111.svg?style=for-the-badge&logo=tiddlywiki&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "wiki.js",
     "name": "Wiki.js",
     "url": "https://img.shields.io/badge/wiki.js-%231976D2.svg?style=for-the-badge&logo=wikidotjs&logoColor=white",
     "markdown": "![Wiki.js](https://img.shields.io/badge/wiki.js-%231976D2.svg?style=for-the-badge&logo=wikidotjs&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "wikipedia",
     "name": "Wikipedia",
     "url": "https://img.shields.io/badge/Wikipedia-%23000000.svg?style=for-the-badge&logo=wikipedia&logoColor=white",
     "markdown": "![Wikipedia](https://img.shields.io/badge/Wikipedia-%23000000.svg?style=for-the-badge&logo=wikipedia&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "zettlr",
     "name": "Zettlr",
     "url": "https://img.shields.io/badge/zettlr-%231CB27E.svg?style=for-the-badge&logo=zettlr&logoColor=white",
     "markdown": "![Zettlr](https://img.shields.io/badge/zettlr-%231CB27E.svg?style=for-the-badge&logo=zettlr&logoColor=white)",
-    "category": "Documentation Platforms"
+    "categories": [
+      "Documentation Platforms"
+    ]
   },
   {
     "id": "42",
     "name": "42",
     "url": "https://img.shields.io/badge/-42-black?style=for-the-badge&logo=42&logoColor=white",
     "markdown": "![42](https://img.shields.io/badge/-42-black?style=for-the-badge&logo=42&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "codecademy",
     "name": "Codecademy",
     "url": "https://img.shields.io/badge/Codecademy-FFF0E5?style=for-the-badge&logo=codecademy&logoColor=1F243A",
     "markdown": "![Codecademy](https://img.shields.io/badge/Codecademy-FFF0E5?style=for-the-badge&logo=codecademy&logoColor=1F243A)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "codewars",
     "name": "Codewars",
     "url": "https://img.shields.io/badge/Codewars-B1361E?style=for-the-badge&logo=codewars&logoColor=grey",
     "markdown": "![Codewars](https://img.shields.io/badge/Codewars-B1361E?style=for-the-badge&logo=codewars&logoColor=grey)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "codingninjas",
     "name": "Codingninjas",
     "url": "https://img.shields.io/badge/coding%20ninjas-DD6620?style=for-the-badge&logo=codingninjas&logoColor=white",
     "markdown": "![codingninjas](https://img.shields.io/badge/coding%20ninjas-DD6620?style=for-the-badge&logo=codingninjas&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "coursera",
     "name": "Coursera",
     "url": "https://img.shields.io/badge/Coursera-%230056D2.svg?style=for-the-badge&logo=Coursera&logoColor=white",
     "markdown": "![Coursera](https://img.shields.io/badge/Coursera-%230056D2.svg?style=for-the-badge&logo=Coursera&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "datacamp",
     "name": "Datacamp",
     "url": "https://img.shields.io/badge/Datacamp-05192D?style=for-the-badge&logo=datacamp&logoColor=03E860",
     "markdown": "![Datacamp](https://img.shields.io/badge/Datacamp-05192D?style=for-the-badge&logo=datacamp&logoColor=03E860)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "duolingo",
     "name": "Duolingo",
     "url": "https://img.shields.io/badge/Duolingo-%234DC730.svg?style=for-the-badge&logo=Duolingo&logoColor=white",
     "markdown": "![Duolingo](https://img.shields.io/badge/Duolingo-%234DC730.svg?style=for-the-badge&logo=Duolingo&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "edx",
     "name": "edX",
     "url": "https://img.shields.io/badge/edX-%2302262B.svg?style=for-the-badge&logo=edX&logoColor=white",
     "markdown": "![edX](https://img.shields.io/badge/edX-%2302262B.svg?style=for-the-badge&logo=edX&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "exercism",
     "name": "Exercism",
     "url": "https://img.shields.io/badge/Exercism-009CAB?style=for-the-badge&logo=exercism&logoColor=white",
     "markdown": "![Exercism](https://img.shields.io/badge/Exercism-009CAB?style=for-the-badge&logo=exercism&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "freecodecamp",
     "name": "FreeCodeCamp",
     "url": "https://img.shields.io/badge/Freecodecamp-%23123.svg?&style=for-the-badge&logo=freecodecamp&logoColor=green",
     "markdown": "![FreeCodeCamp](https://img.shields.io/badge/Freecodecamp-%23123.svg?&style=for-the-badge&logo=freecodecamp&logoColor=green)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "future-learn",
     "name": "Future Learn",
     "url": "https://img.shields.io/badge/future%20learn-DE00A5?style=for-the-badge&logo=futurelearn&logoColor=white",
     "markdown": "![Future Learn](https://img.shields.io/badge/future%20learn-DE00A5?style=for-the-badge&logo=futurelearn&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "geeksforgeeks",
     "name": "GeeksforGeeks",
     "url": "https://img.shields.io/badge/GeeksforGeeks-gray?style=for-the-badge&logo=geeksforgeeks&logoColor=35914c",
     "markdown": "![GeeksForGeeks](https://img.shields.io/badge/GeeksforGeeks-gray?style=for-the-badge&logo=geeksforgeeks&logoColor=35914c)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "google-scholar",
     "name": "Google Scholar",
     "url": "https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&logo=google-scholar&logoColor=white",
     "markdown": "![Google Scholar](https://img.shields.io/badge/Google%20Scholar-4285F4?style=for-the-badge&logo=google-scholar&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "khan-academy",
     "name": "Khan Academy",
     "url": "https://img.shields.io/badge/KhanAcademy-%2314BF96.svg?style=for-the-badge&logo=KhanAcademy&logoColor=white",
     "markdown": "![Khan Academy](https://img.shields.io/badge/KhanAcademy-%2314BF96.svg?style=for-the-badge&logo=KhanAcademy&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "mdn-web-docs",
     "name": "MDN Web Docs",
     "url": "https://img.shields.io/badge/MDN_Web_Docs-black?style=for-the-badge&logo=mdnwebdocs&logoColor=white",
     "markdown": "![MDN Web Docs](https://img.shields.io/badge/MDN_Web_Docs-black?style=for-the-badge&logo=mdnwebdocs&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "microsoft-learn",
     "name": "Microsoft Learn",
     "url": "https://img.shields.io/badge/Microsoft_Learn-258ffa?style=for-the-badge&logo=microsoft&logoColor=white",
     "markdown": "![Microsoft Learn](https://img.shields.io/badge/Microsoft_Learn-258ffa?style=for-the-badge&logo=microsoft&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "o'reilly",
     "name": "O'Reilly",
     "url": "https://img.shields.io/badge/O'Reilly-%23D30000.svg?style=for-the-badge&logo=o%27reilly&logoColor=F1F1F1",
     "markdown": "![O'Reilly](https://img.shields.io/badge/O'Reilly-%23D30000.svg?style=for-the-badge&logo=o%27reilly&logoColor=F1F1F1)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "pluralsight",
     "name": "Pluralsight",
     "url": "https://img.shields.io/badge/Pluralsight-EE3057?style=for-the-badge&logo=pluralsight&logoColor=white",
     "markdown": "![Pluralsight](https://img.shields.io/badge/Pluralsight-EE3057?style=for-the-badge&logo=pluralsight&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "scrimba",
     "name": "Scrimba",
     "url": "https://img.shields.io/badge/scrimba-2B283A?style=for-the-badge&logo=scrimba&logoColor=white",
     "markdown": "![Scrimba](https://img.shields.io/badge/scrimba-2B283A?style=for-the-badge&logo=scrimba&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "skill-share",
     "name": "Skill Share",
     "url": "https://img.shields.io/badge/Skill%20share-002333?style=for-the-badge&logo=skillshare&logoColor=00FF84",
     "markdown": "![Skill Share](https://img.shields.io/badge/Skill%20share-002333?style=for-the-badge&logo=skillshare&logoColor=00FF84)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "sololearn",
     "name": "Sololearn",
     "url": "https://img.shields.io/badge/Sololearn-149EF2?style=for-the-badge&logo=sololearn&logoColor=white",
     "markdown": "![Sololearn](https://img.shields.io/badge/Sololearn-149EF2?style=for-the-badge&logo=sololearn&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "the-odin-project",
     "name": "The Odin Project",
     "url": "https://img.shields.io/badge/the_odin_project-%23A9792B.svg?style=for-the-badge&logo=theodinproject&logoColor=white",
     "markdown": "![The Odin Project](https://img.shields.io/badge/the_odin_project-%23A9792B.svg?style=for-the-badge&logo=theodinproject&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "udacity",
     "name": "Udacity",
     "url": "https://img.shields.io/badge/Udacity-grey?style=for-the-badge&logo=udacity&logoColor=15B8E6",
     "markdown": "![Udacity](https://img.shields.io/badge/Udacity-grey?style=for-the-badge&logo=udacity&logoColor=15B8E6)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "udemy",
     "name": "Udemy",
     "url": "https://img.shields.io/badge/Udemy-A435F0?style=for-the-badge&logo=Udemy&logoColor=white",
     "markdown": "![Udemy](https://img.shields.io/badge/Udemy-A435F0?style=for-the-badge&logo=Udemy&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "w3-schools",
     "name": "W3 Schools",
     "url": "https://img.shields.io/badge/W3%20Schools-04AA6D?style=for-the-badge&logo=w3schools&logoColor=white",
     "markdown": "![W3 Schools](https://img.shields.io/badge/W3%20Schools-04AA6D?style=for-the-badge&logo=w3schools&logoColor=white)",
-    "category": "Education"
+    "categories": [
+      "Education"
+    ]
   },
   {
     "id": "amazon-pay",
     "name": "Amazon Pay",
     "url": "https://img.shields.io/badge/AmazonPay-ff9900.svg?style=for-the-badge&logo=Amazon-Pay&logoColor=white",
     "markdown": "![Amazon Pay](https://img.shields.io/badge/AmazonPay-ff9900.svg?style=for-the-badge&logo=Amazon-Pay&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "apple-pay",
     "name": "Apple Pay",
     "url": "https://img.shields.io/badge/ApplePay-000000.svg?style=for-the-badge&logo=Apple-Pay&logoColor=white",
     "markdown": "![Apple Pay](https://img.shields.io/badge/ApplePay-000000.svg?style=for-the-badge&logo=Apple-Pay&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "buy-me-a-coffee",
     "name": "Buy Me a Coffee",
     "url": "https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black",
     "markdown": "![BuyMeACoffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)",
-    "category": "Funding"
+    "categories": [
+      "Funding",
+      "Social"
+    ]
   },
   {
     "id": "github-sponsors",
     "name": "Github Sponsors",
     "url": "https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA",
     "markdown": "![Github-sponsors](https://img.shields.io/badge/sponsor-30363D?style=for-the-badge&logo=GitHub-Sponsors&logoColor=#EA4AAA)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "google-pay",
     "name": "Google Pay",
     "url": "https://img.shields.io/badge/GooglePay-%233780F1.svg?style=for-the-badge&logo=Google-Pay&logoColor=white",
     "markdown": "![Google Pay](https://img.shields.io/badge/GooglePay-%233780F1.svg?style=for-the-badge&logo=Google-Pay&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "ko-fi",
     "name": "Ko-Fi",
     "url": "https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white",
     "markdown": "![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "liberapay",
     "name": "LiberaPay",
     "url": "https://img.shields.io/badge/Liberapay-F6C915?style=for-the-badge&logo=liberapay&logoColor=black",
     "markdown": "![LiberaPay](https://img.shields.io/badge/Liberapay-F6C915?style=for-the-badge&logo=liberapay&logoColor=black)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "patreon",
     "name": "Patreon",
     "url": "https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white",
     "markdown": "![Patreon](https://img.shields.io/badge/Patreon-F96854?style=for-the-badge&logo=patreon&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "paypal",
     "name": "PayPal",
     "url": "https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white",
     "markdown": "![PayPal](https://img.shields.io/badge/PayPal-00457C?style=for-the-badge&logo=paypal&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "paytm",
     "name": "Paytm",
     "url": "https://img.shields.io/badge/Paytm-1C2C94?style=for-the-badge&logo=paytm&logoColor=05BAF3",
     "markdown": "![Paytm](https://img.shields.io/badge/Paytm-1C2C94?style=for-the-badge&logo=paytm&logoColor=05BAF3)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "phonepe",
     "name": "Phonepe",
     "url": "https://img.shields.io/badge/Phonepe-54039A?style=for-the-badge&logo=phonepe&logoColor=white",
     "markdown": "![Phonepe](https://img.shields.io/badge/Phonepe-54039A?style=for-the-badge&logo=phonepe&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "samsung-pay",
     "name": "Samsung Pay",
     "url": "https://img.shields.io/badge/SamsungPay-1428A0.svg?style=for-the-badge&logo=Samsung-Pay&logoColor=white",
     "markdown": "![Samsung Pay](https://img.shields.io/badge/SamsungPay-1428A0.svg?style=for-the-badge&logo=Samsung-Pay&logoColor=white)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "stripe",
     "name": "Stripe",
     "url": "https://img.shields.io/badge/Stripe-5469d4?style=for-the-badge&logo=stripe&logoColor=ffffff",
     "markdown": "![Stripe](https://img.shields.io/badge/Stripe-5469d4?style=for-the-badge&logo=stripe&logoColor=ffffff)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": "wise",
     "name": "Wise",
     "url": "https://img.shields.io/badge/Wise-394e79?style=for-the-badge&logo=wise&logoColor=00B9FF",
     "markdown": "![Wise](https://img.shields.io/badge/Wise-394e79?style=for-the-badge&logo=wise&logoColor=00B9FF)",
-    "category": "Funding"
+    "categories": [
+      "Funding"
+    ]
   },
   {
     "id": ".net",
     "name": ".NET",
     "url": "https://img.shields.io/badge/.NET-5C2D91?style=for-the-badge&logo=.net&logoColor=white",
     "markdown": "![.Net](https://img.shields.io/badge/.NET-5C2D91?style=for-the-badge&logo=.net&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "adonisjs",
     "name": "AdonisJS",
     "url": "https://img.shields.io/badge/adonisjs-%23220052.svg?style=for-the-badge&logo=adonisjs&logoColor=white",
     "markdown": "![AdonisJS](https://img.shields.io/badge/adonisjs-%23220052.svg?style=for-the-badge&logo=adonisjs&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "ajv",
     "name": "Ajv",
     "url": "https://img.shields.io/badge/ajv-%23C21325.svg?style=for-the-badge&logo=ajv&logoColor=white",
     "markdown": "![Ajv](https://img.shields.io/badge/ajv-%23C21325.svg?style=for-the-badge&logo=ajv&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "alpine.js",
     "name": "Alpine.js",
     "url": "https://img.shields.io/badge/alpinejs-white.svg?style=for-the-badge&logo=alpinedotjs&logoColor=%238BC0D0",
     "markdown": "![Alpine.js](https://img.shields.io/badge/alpinejs-white.svg?style=for-the-badge&logo=alpinedotjs&logoColor=%238BC0D0)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "amd",
     "name": "AMD",
     "url": "https://img.shields.io/badge/amd-%23ED1C24.svg?style=for-the-badge&logo=amd&logoColor=white",
     "markdown": "![AMD](https://img.shields.io/badge/amd-%23ED1C24.svg?style=for-the-badge&logo=amd&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "Gaming"
+    ]
   },
   {
     "id": "anaconda",
     "name": "Anaconda",
     "url": "https://img.shields.io/badge/Anaconda-%2344A833.svg?style=for-the-badge&logo=anaconda&logoColor=white",
     "markdown": "![Anaconda](https://img.shields.io/badge/Anaconda-%2344A833.svg?style=for-the-badge&logo=anaconda&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "angular.js",
     "name": "Angular.js",
     "url": "https://img.shields.io/badge/angular.js-%23E23237.svg?style=for-the-badge&logo=angularjs&logoColor=white",
     "markdown": "![Angular.js](https://img.shields.io/badge/angular.js-%23E23237.svg?style=for-the-badge&logo=angularjs&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "apache-hadoop",
     "name": "Apache Hadoop",
     "url": "https://img.shields.io/badge/Apache%20Hadoop-66CCFF?style=for-the-badge&logo=apachehadoop&logoColor=black",
     "markdown": "![Apache Hadoop](https://img.shields.io/badge/Apache%20Hadoop-66CCFF?style=for-the-badge&logo=apachehadoop&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "apache-hive",
     "name": "Apache Hive",
     "url": "https://img.shields.io/badge/Apache%20Hive-FDEE21?style=for-the-badge&logo=apachehive&logoColor=black",
     "markdown": "![Apache Hive](https://img.shields.io/badge/Apache%20Hive-FDEE21?style=for-the-badge&logo=apachehive&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "apache-kafka",
     "name": "Apache Kafka",
     "url": "https://img.shields.io/badge/Apache%20Kafka-000?style=for-the-badge&logo=apachekafka",
     "markdown": "![Apache Kafka](https://img.shields.io/badge/Apache%20Kafka-000?style=for-the-badge&logo=apachekafka)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "apache-spark",
     "name": "Apache Spark",
     "url": "https://img.shields.io/badge/Apache%20Spark-FDEE21?style=flat-square&logo=apachespark&logoColor=black",
     "markdown": "![Apache Spark](https://img.shields.io/badge/Apache%20Spark-FDEE21?style=flat-square&logo=apachespark&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "apollo-graphql",
     "name": "Apollo GraphQL",
     "url": "https://img.shields.io/badge/-ApolloGraphQL-311C87?style=for-the-badge&logo=apollo-graphql",
     "markdown": "![Apollo-GraphQL](https://img.shields.io/badge/-ApolloGraphQL-311C87?style=for-the-badge&logo=apollo-graphql)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "arm",
     "name": "Arm",
     "url": "https://img.shields.io/badge/arm-%230091BD.svg?style=for-the-badge&logo=arm&logoColor=white",
     "markdown": "![Arm](https://img.shields.io/badge/arm-%230091BD.svg?style=for-the-badge&logo=arm&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "aurelia",
     "name": "Aurelia",
     "url": "https://img.shields.io/badge/aurelia-%23ED2B88.svg?style=for-the-badge&logo=aurelia&logoColor=fff",
     "markdown": "![Aurelia](https://img.shields.io/badge/aurelia-%23ED2B88.svg?style=for-the-badge&logo=aurelia&logoColor=fff)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "biome",
     "name": "Biome",
     "url": "https://img.shields.io/badge/biome-%2360A5FA.svg?style=for-the-badge&logo=biome&logoColor=white",
     "markdown": "![Biome](https://img.shields.io/badge/biome-%2360A5FA.svg?style=for-the-badge&logo=biome&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "black",
     "name": "Black",
     "url": "https://img.shields.io/badge/black-%23000000.svg?style=for-the-badge&logo=black&logoColor=white",
     "markdown": "![Black](https://img.shields.io/badge/black-%23000000.svg?style=for-the-badge&logo=black&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "blazor",
     "name": "Blazor",
     "url": "https://img.shields.io/badge/blazor-%235C2D91.svg?style=for-the-badge&logo=blazor&logoColor=white",
     "markdown": "![Blazor](https://img.shields.io/badge/blazor-%235C2D91.svg?style=for-the-badge&logo=blazor&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "buefy",
     "name": "Buefy",
     "url": "https://img.shields.io/badge/Buefy-7957D5?style=for-the-badge&logo=buefy&logoColor=48289E",
     "markdown": "![Buefy](https://img.shields.io/badge/Buefy-7957D5?style=for-the-badge&logo=buefy&logoColor=48289E)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "celery",
     "name": "Celery",
     "url": "https://img.shields.io/badge/celery-%23a9cc54.svg?style=for-the-badge&logo=celery&logoColor=ddf4a4",
     "markdown": "![Celery](https://img.shields.io/badge/celery-%23a9cc54.svg?style=for-the-badge&logo=celery&logoColor=ddf4a4)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "chakra-ui",
     "name": "Chakra UI",
     "url": "https://img.shields.io/badge/chakra-%234ED1C5.svg?style=for-the-badge&logo=chakraui&logoColor=white",
     "markdown": "![Chakra](https://img.shields.io/badge/chakra-%234ED1C5.svg?style=for-the-badge&logo=chakraui&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "chart.js",
     "name": "Chart.js",
     "url": "https://img.shields.io/badge/chart.js-F5788D.svg?style=for-the-badge&logo=chart.js&logoColor=white",
     "markdown": "![Chart.js](https://img.shields.io/badge/chart.js-F5788D.svg?style=for-the-badge&logo=chart.js&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "code-igniter",
     "name": "Code Igniter",
     "url": "https://img.shields.io/badge/CodeIgniter-%23EF4223.svg?style=for-the-badge&logo=codeIgniter&logoColor=white",
     "markdown": "![Code-Igniter](https://img.shields.io/badge/CodeIgniter-%23EF4223.svg?style=for-the-badge&logo=codeIgniter&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "composer",
     "name": "Composer",
     "url": "https://img.shields.io/badge/composer-%23885630.svg?style=for-the-badge&logo=composer&logoColor=white",
     "markdown": "![Composer](https://img.shields.io/badge/composer-%23885630.svg?style=for-the-badge&logo=composer&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "conan",
     "name": "Conan",
     "url": "https://img.shields.io/badge/conan-%236699CB.svg?style=for-the-badge&logo=conan&logoColor=white",
     "markdown": "![Conan](https://img.shields.io/badge/conan-%236699CB.svg?style=for-the-badge&logo=conan&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "context-api",
     "name": "Context API",
     "url": "https://img.shields.io/badge/Context--Api-000000?style=for-the-badge&logo=react",
     "markdown": "![Context-API](https://img.shields.io/badge/Context--Api-000000?style=for-the-badge&logo=react)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "cuda",
     "name": "CUDA",
     "url": "https://img.shields.io/badge/cuda-000000.svg?style=for-the-badge&logo=nVIDIA&logoColor=green",
     "markdown": "![nVIDIA](https://img.shields.io/badge/cuda-000000.svg?style=for-the-badge&logo=nVIDIA&logoColor=green)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "d3.js",
     "name": "D3.js",
     "url": "https://img.shields.io/badge/D3.JS-%23000000?style=for-the-badge&logo=D3&logoColor=#ff823e",
     "markdown": "![D3.js](https://img.shields.io/badge/D3.JS-%23000000?style=for-the-badge&logo=D3&logoColor=#ff823e)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "daisyui",
     "name": "DaisyUI",
     "url": "https://img.shields.io/badge/daisyui-5A0EF8?style=for-the-badge&logo=daisyui&logoColor=white",
     "markdown": "![DaisyUI](https://img.shields.io/badge/daisyui-5A0EF8?style=for-the-badge&logo=daisyui&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "deno-js",
     "name": "Deno JS",
     "url": "https://img.shields.io/badge/deno%20js-000000?style=for-the-badge&logo=deno&logoColor=white",
     "markdown": "![Deno JS](https://img.shields.io/badge/deno%20js-000000?style=for-the-badge&logo=deno&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "directus",
     "name": "Directus",
     "url": "https://img.shields.io/badge/directus-%2364f.svg?style=for-the-badge&logo=directus&logoColor=white",
     "markdown": "![Directus](https://img.shields.io/badge/directus-%2364f.svg?style=for-the-badge&logo=directus&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "djangorest",
     "name": "DjangoREST",
     "url": "https://img.shields.io/badge/DJANGO-REST-ff1709?style=for-the-badge&logo=django&logoColor=white&color=ff1709&labelColor=gray",
     "markdown": "![DjangoREST](https://img.shields.io/badge/DJANGO-REST-ff1709?style=for-the-badge&logo=django&logoColor=white&color=ff1709&labelColor=gray)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "drupal",
     "name": "Drupal",
     "url": "https://img.shields.io/badge/drupal-%230678BE.svg?style=for-the-badge&logo=drupal&logoColor=white",
     "markdown": "![Drupal](https://img.shields.io/badge/drupal-%230678BE.svg?style=for-the-badge&logo=drupal&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "ejs",
     "name": "EJS",
     "url": "https://img.shields.io/badge/ejs-%23B4CA65.svg?style=for-the-badge&logo=ejs&logoColor=black",
     "markdown": "![EJS](https://img.shields.io/badge/ejs-%23B4CA65.svg?style=for-the-badge&logo=ejs&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "elasticsearch",
     "name": "Elasticsearch",
     "url": "https://img.shields.io/badge/elasticsearch-%230377CC.svg?style=for-the-badge&logo=elasticsearch&logoColor=white",
     "markdown": "![Elasticsearch](https://img.shields.io/badge/elasticsearch-%230377CC.svg?style=for-the-badge&logo=elasticsearch&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "Other"
+    ]
   },
   {
     "id": "electron.js",
     "name": "Electron.js",
     "url": "https://img.shields.io/badge/Electron-191970?style=for-the-badge&logo=Electron&logoColor=white",
     "markdown": "![Electron.js](https://img.shields.io/badge/Electron-191970?style=for-the-badge&logo=Electron&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "ember",
     "name": "Ember",
     "url": "https://img.shields.io/badge/ember-1C1E24?style=for-the-badge&logo=ember.js&logoColor=#D04A37",
     "markdown": "![Ember](https://img.shields.io/badge/ember-1C1E24?style=for-the-badge&logo=ember.js&logoColor=#D04A37)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "fastify",
     "name": "Fastify",
     "url": "https://img.shields.io/badge/fastify-%23000000.svg?style=for-the-badge&logo=fastify&logoColor=white",
     "markdown": "![Fastify](https://img.shields.io/badge/fastify-%23000000.svg?style=for-the-badge&logo=fastify&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "filament",
     "name": "Filament",
     "url": "https://img.shields.io/badge/filament-%23FDAE4B.svg?style=for-the-badge&logo=filament&logoColor=black&logoSize=auto",
     "markdown": "![Filament](https://img.shields.io/badge/filament-%23FDAE4B.svg?style=for-the-badge&logo=filament&logoColor=black&logoSize=auto)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "flatpak",
     "name": "Flatpak",
     "url": "https://img.shields.io/badge/flatpak-%234A90D9.svg?style=for-the-badge&logo=flatpak&logoColor=white",
     "markdown": "![Flatpak](https://img.shields.io/badge/flatpak-%234A90D9.svg?style=for-the-badge&logo=flatpak&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "font-awesome",
     "name": "Font Awesome",
     "url": "https://img.shields.io/badge/Font_Awesome-%23538DD7.svg?style=for-the-badge&logo=fontawesome&logoColor=white",
     "markdown": "![Font Awesome](https://img.shields.io/badge/Font_Awesome-%23538DD7.svg?style=for-the-badge&logo=fontawesome&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "framework7",
     "name": "Framework7",
     "url": "https://img.shields.io/badge/framework7-%23EE350F.svg?style=for-the-badge&logo=framework7&logoColor=white",
     "markdown": "![Framework7](https://img.shields.io/badge/framework7-%23EE350F.svg?style=for-the-badge&logo=framework7&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "gatsby.js",
     "name": "Gatsby.js",
     "url": "https://img.shields.io/badge/Gatsby-%23663399.svg?style=for-the-badge&logo=gatsby&logoColor=white",
     "markdown": "![Gatsby](https://img.shields.io/badge/Gatsby-%23663399.svg?style=for-the-badge&logo=gatsby&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "grav",
     "name": "Grav",
     "url": "https://img.shields.io/badge/grav-%23FFFFFF.svg?style=for-the-badge&logo=grav&logoColor=221E1F",
     "markdown": "![Grav](https://img.shields.io/badge/grav-%23FFFFFF.svg?style=for-the-badge&logo=grav&logoColor=221E1F)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "green-sock",
     "name": "Green Sock",
     "url": "https://img.shields.io/badge/green%20sock-88CE02?style=for-the-badge&logo=greensock&logoColor=black",
     "markdown": "![Green Sock](https://img.shields.io/badge/green%20sock-88CE02?style=for-the-badge&logo=greensock&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "gsap",
     "name": "GSAP",
     "url": "https://img.shields.io/badge/GSAP-%2388CE02.svg?style=for-the-badge&logo=greensock&logoColor=black",
     "markdown": "![GSAP](https://img.shields.io/badge/GSAP-%2388CE02.svg?style=for-the-badge&logo=greensock&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "gutenberg",
     "name": "Gutenberg",
     "url": "https://img.shields.io/badge/gutenberg-%23077CB2.svg?style=for-the-badge&logo=gutenberg&logoColor=white",
     "markdown": "![Gutenberg](https://img.shields.io/badge/gutenberg-%23077CB2.svg?style=for-the-badge&logo=gutenberg&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "handlebars",
     "name": "Handlebars",
     "url": "https://img.shields.io/badge/Handlebars-%23000000?style=for-the-badge&logo=Handlebars.js&logoColor=white",
     "markdown": "![Handlebars](https://img.shields.io/badge/Handlebars-%23000000?style=for-the-badge&logo=Handlebars.js&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "helm",
     "name": "Helm",
     "url": "https://img.shields.io/badge/helm-%230F1689.svg?style=for-the-badge&logo=helm&logoColor=white",
     "markdown": "![Helm](https://img.shields.io/badge/helm-%230F1689.svg?style=for-the-badge&logo=helm&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "homebrew",
     "name": "Homebrew",
     "url": "https://img.shields.io/badge/homebrew-%23FBB040.svg?style=for-the-badge&logo=homebrew&logoColor=black",
     "markdown": "![Homebrew](https://img.shields.io/badge/homebrew-%23FBB040.svg?style=for-the-badge&logo=homebrew&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "hono",
     "name": "Hono",
     "url": "https://img.shields.io/badge/hono-%23E36002.svg?style=for-the-badge&logo=hono&logoColor=white",
     "markdown": "![Hono](https://img.shields.io/badge/hono-%23E36002.svg?style=for-the-badge&logo=hono&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "htmx",
     "name": "htmx",
     "url": "https://img.shields.io/badge/htmx-%233366CC.svg?style=for-the-badge&logo=htmx&logoColor=white",
     "markdown": "![htmx](https://img.shields.io/badge/htmx-%233366CC.svg?style=for-the-badge&logo=htmx&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "hugo",
     "name": "Hugo",
     "url": "https://img.shields.io/badge/Hugo-black.svg?style=for-the-badge&logo=Hugo",
     "markdown": "![Hugo](https://img.shields.io/badge/Hugo-black.svg?style=for-the-badge&logo=Hugo)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "insomnia",
     "name": "Insomnia",
     "url": "https://img.shields.io/badge/Insomnia-black?style=for-the-badge&logo=insomnia&logoColor=5849BE",
     "markdown": "![Insomnia](https://img.shields.io/badge/Insomnia-black?style=for-the-badge&logo=insomnia&logoColor=5849BE)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "jamstack",
     "name": "Jamstack",
     "url": "https://img.shields.io/badge/jamstack-%23F0047F.svg?style=for-the-badge&logo=jamstack&logoColor=white",
     "markdown": "![Jamstack](https://img.shields.io/badge/jamstack-%23F0047F.svg?style=for-the-badge&logo=jamstack&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "jasmine",
     "name": "Jasmine",
     "url": "https://img.shields.io/badge/jasmine-%238A4182.svg?style=for-the-badge&logo=jasmine&logoColor=white",
     "markdown": "![Jasmine](https://img.shields.io/badge/jasmine-%238A4182.svg?style=for-the-badge&logo=jasmine&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "Testing"
+    ]
   },
   {
     "id": "javafx",
     "name": "JavaFx",
     "url": "https://img.shields.io/badge/javafx-%23FF0000.svg?style=for-the-badge&logo=javafx&logoColor=white",
     "markdown": "![JavaFX](https://img.shields.io/badge/javafx-%23FF0000.svg?style=for-the-badge&logo=javafx&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "jinja",
     "name": "Jinja",
     "url": "https://img.shields.io/badge/jinja-white.svg?style=for-the-badge&logo=jinja&logoColor=black",
     "markdown": "![Jinja](https://img.shields.io/badge/jinja-white.svg?style=for-the-badge&logo=jinja&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "joomla",
     "name": "Joomla",
     "url": "https://img.shields.io/badge/joomla-%235091CD.svg?style=for-the-badge&logo=joomla&logoColor=white",
     "markdown": "![Joomla](https://img.shields.io/badge/joomla-%235091CD.svg?style=for-the-badge&logo=joomla&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "jquery",
     "name": "jQuery",
     "url": "https://img.shields.io/badge/jquery-%230769AD.svg?style=for-the-badge&logo=jquery&logoColor=white",
     "markdown": "![jQuery](https://img.shields.io/badge/jquery-%230769AD.svg?style=for-the-badge&logo=jquery&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "junit5",
     "name": "JUnit5",
     "url": "https://img.shields.io/badge/JUnit5-f5f5f5?style=for-the-badge&logo=junit5&logoColor=dc524a",
     "markdown": "![JUnit5](https://img.shields.io/badge/JUnit5-f5f5f5?style=for-the-badge&logo=junit5&logoColor=dc524a)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "jwt/json-web-token",
     "name": "JWT/JSON Web Token",
     "url": "https://img.shields.io/badge/JWT-black?style=for-the-badge&logo=JSON%20web%20tokens",
     "markdown": "![JWT](https://img.shields.io/badge/JWT-black?style=for-the-badge&logo=JSON%20web%20tokens)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "ktor",
     "name": "Ktor",
     "url": "https://img.shields.io/badge/Ktor-%23087CFA.svg?style=for-the-badge&logo=Ktor&logoColor=white",
     "markdown": "![Ktor](https://img.shields.io/badge/Ktor-%23087CFA.svg?style=for-the-badge&logo=Ktor&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "less",
     "name": "Less",
     "url": "https://img.shields.io/badge/less-2B4C80?style=for-the-badge&logo=less&logoColor=white",
     "markdown": "![Less](https://img.shields.io/badge/less-2B4C80?style=for-the-badge&logo=less&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "lit",
     "name": "Lit",
     "url": "https://img.shields.io/badge/lit-%23324FFF.svg?style=for-the-badge&logo=lit&logoColor=white",
     "markdown": "![Lit](https://img.shields.io/badge/lit-%23324FFF.svg?style=for-the-badge&logo=lit&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "livewire",
     "name": "Livewire",
     "url": "https://img.shields.io/badge/livewire-%234e56a6.svg?style=for-the-badge&logo=livewire&logoColor=white",
     "markdown": "![Livewire](https://img.shields.io/badge/livewire-%234e56a6.svg?style=for-the-badge&logo=livewire&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "maven",
     "name": "Maven",
     "url": "https://img.shields.io/badge/apachemaven-C71A36.svg?style=for-the-badge&logo=apachemaven&logoColor=white",
     "markdown": "![Maven](https://img.shields.io/badge/apachemaven-C71A36.svg?style=for-the-badge&logo=apachemaven&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "maxcompute",
     "name": "MaxCompute",
     "url": "https://img.shields.io/badge/MaxCompute-%23FF6701?style=for-the-badge&logo=alibabacloud&logoColor=white",
     "markdown": "![MaxCompute](https://img.shields.io/badge/MaxCompute-%23FF6701?style=for-the-badge&logo=alibabacloud&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "nativescript",
     "name": "NativeScript",
     "url": "https://img.shields.io/badge/NativeScript-%2365ADF1?style=for-the-badge&logo=nativescript&logoColor=white",
     "markdown": "![NativeScript](https://img.shields.io/badge/NativeScript-%2365ADF1?style=for-the-badge&logo=nativescript&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "node-red",
     "name": "Node-RED",
     "url": "https://img.shields.io/badge/Node--RED-%238F0000.svg?style=for-the-badge&logo=node-red&logoColor=white",
     "markdown": "![Node-RED](https://img.shields.io/badge/Node--RED-%238F0000.svg?style=for-the-badge&logo=node-red&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "nodemon",
     "name": "Nodemon",
     "url": "https://img.shields.io/badge/NODEMON-%23323330.svg?style=for-the-badge&logo=nodemon&logoColor=%BBDEAD",
     "markdown": "![Nodemon](https://img.shields.io/badge/NODEMON-%23323330.svg?style=for-the-badge&logo=nodemon&logoColor=%BBDEAD)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "npm",
     "name": "NPM",
     "url": "https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white",
     "markdown": "![NPM](https://img.shields.io/badge/NPM-%23CB3837.svg?style=for-the-badge&logo=npm&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "nuget",
     "name": "NuGet",
     "url": "https://img.shields.io/badge/nuget-%23004880.svg?style=for-the-badge&logo=nuget&logoColor=white",
     "markdown": "![NuGet](https://img.shields.io/badge/nuget-%23004880.svg?style=for-the-badge&logo=nuget&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "opengl",
     "name": "OpenGL",
     "url": "https://img.shields.io/badge/OpenGL-%23FFFFFF.svg?style=for-the-badge&logo=opengl",
     "markdown": "![OpenGL](https://img.shields.io/badge/OpenGL-%23FFFFFF.svg?style=for-the-badge&logo=opengl)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "Gaming"
+    ]
   },
   {
     "id": "oxc",
     "name": "Oxc",
     "url": "https://img.shields.io/badge/oxc-%233451b2.svg?style=for-the-badge&logo=oxc&logoColor=white&logoSize=auto",
     "markdown": "![Oxc](https://img.shields.io/badge/oxc-%233451b2.svg?style=for-the-badge&logo=oxc&logoColor=white&logoSize=auto)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "p5js",
     "name": "P5js",
     "url": "https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF",
     "markdown": "![p5js](https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "IDEs"
+    ]
   },
   {
     "id": "pantheon",
     "name": "Pantheon",
     "url": "https://img.shields.io/badge/pantheon-%23FFDC28.svg?style=for-the-badge&logo=pantheon&logoColor=black",
     "markdown": "![Pantheon](https://img.shields.io/badge/pantheon-%23FFDC28.svg?style=for-the-badge&logo=pantheon&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "phoenix-framework",
     "name": "Phoenix Framework",
     "url": "https://img.shields.io/badge/phoenixframework-%23FD4F00.svg?style=for-the-badge&logo=phoenixframework&logoColor=black",
     "markdown": "![Phoenix Framework](https://img.shields.io/badge/phoenixframework-%23FD4F00.svg?style=for-the-badge&logo=phoenixframework&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "photon",
     "name": "Photon",
     "url": "https://img.shields.io/badge/photon-%23004480.svg?style=for-the-badge&logo=photon&logoColor=white",
     "markdown": "![Photon](https://img.shields.io/badge/photon-%23004480.svg?style=for-the-badge&logo=photon&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "pipx",
     "name": "pipx",
     "url": "https://img.shields.io/badge/pipx-%232CFFAA.svg?style=for-the-badge&logo=pipx&logoColor=black",
     "markdown": "![pipx](https://img.shields.io/badge/pipx-%232CFFAA.svg?style=for-the-badge&logo=pipx&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "pkgsrc",
     "name": "pkgsrc",
     "url": "https://img.shields.io/badge/pkgsrc-%23FF6600.svg?style=for-the-badge&logo=pkgsrc&logoColor=white",
     "markdown": "![pkgsrc](https://img.shields.io/badge/pkgsrc-%23FF6600.svg?style=for-the-badge&logo=pkgsrc&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "platformio",
     "name": "PlatformIO",
     "url": "https://img.shields.io/badge/platformio-%23000.svg?style=for-the-badge&logo=platformio&logoColor=F5822A",
     "markdown": "![PlatformIO](https://img.shields.io/badge/platformio-%23000.svg?style=for-the-badge&logo=platformio&logoColor=F5822A)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "Build Toolchains"
+    ]
   },
   {
     "id": "plotly-dash",
     "name": "Plotly Dash",
     "url": "https://img.shields.io/badge/plotly-3F4F75.svg?style=for-the-badge&logo=plotly&logoColor=white",
     "markdown": "![Plotly Dash](https://img.shields.io/badge/plotly-3F4F75.svg?style=for-the-badge&logo=plotly&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "pnpm",
     "name": "PNPM",
     "url": "https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220",
     "markdown": "![PNPM](https://img.shields.io/badge/pnpm-%234a4a4a.svg?style=for-the-badge&logo=pnpm&logoColor=f69220)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "poetry",
     "name": "Poetry",
     "url": "https://img.shields.io/badge/Poetry-%233B82F6.svg?style=for-the-badge&logo=poetry&logoColor=0B3D8D",
     "markdown": "![Poetry](https://img.shields.io/badge/Poetry-%233B82F6.svg?style=for-the-badge&logo=poetry&logoColor=0B3D8D)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "postcss",
     "name": "PostCSS",
     "url": "https://img.shields.io/badge/PostCSS-%23DD3A0A.svg?style=for-the-badge&logo=postcss&logoColor=white",
     "markdown": "![PostCSS](https://img.shields.io/badge/PostCSS-%23DD3A0A.svg?style=for-the-badge&logo=postcss&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "prefect",
     "name": "Prefect",
     "url": "https://img.shields.io/badge/Prefect-%23ffffff.svg?style=for-the-badge&logo=prefect&logoColor=white",
     "markdown": "![Prefect](https://img.shields.io/badge/Prefect-%23ffffff.svg?style=for-the-badge&logo=prefect&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "prettier",
     "name": "Prettier",
     "url": "https://img.shields.io/badge/prettier-%23192a32?style=for-the-badge&logo=prettier&logoColor=dc524a",
     "markdown": "![Prettier](https://img.shields.io/badge/prettier-%23192a32?style=for-the-badge&logo=prettier&logoColor=dc524a)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks",
+      "Other"
+    ]
   },
   {
     "id": "primefaces",
     "name": "PrimeFaces",
     "url": "https://img.shields.io/badge/primefaces-%23263238.svg?style=for-the-badge&logo=for-the-badge&logoColor=white",
     "markdown": "![PrimeFaces](https://img.shields.io/badge/primefaces-%23263238.svg?style=for-the-badge&logo=for-the-badge&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "pug",
     "name": "Pug",
     "url": "https://img.shields.io/badge/Pug-FFF?style=for-the-badge&logo=pug&logoColor=A86454",
     "markdown": "![Pug](https://img.shields.io/badge/Pug-FFF?style=for-the-badge&logo=pug&logoColor=A86454)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "pydantic",
     "name": "Pydantic",
     "url": "https://img.shields.io/badge/pydantic-%23E92063.svg?style=for-the-badge&logo=pydantic&logoColor=white",
     "markdown": "![Pydantic](https://img.shields.io/badge/pydantic-%23E92063.svg?style=for-the-badge&logo=pydantic&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "qt",
     "name": "Qt",
     "url": "https://img.shields.io/badge/Qt-%23217346.svg?style=for-the-badge&logo=Qt&logoColor=white",
     "markdown": "![Qt](https://img.shields.io/badge/Qt-%23217346.svg?style=for-the-badge&logo=Qt&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "quarkus",
     "name": "Quarkus",
     "url": "https://img.shields.io/badge/quarkus-%234794EB.svg?style=for-the-badge&logo=quarkus&logoColor=white",
     "markdown": "![Quarkus](https://img.shields.io/badge/quarkus-%234794EB.svg?style=for-the-badge&logo=quarkus&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "quasar",
     "name": "Quasar",
     "url": "https://img.shields.io/badge/Quasar-16B7FB?style=for-the-badge&logo=quasar&logoColor=black",
     "markdown": "![Quasar](https://img.shields.io/badge/Quasar-16B7FB?style=for-the-badge&logo=quasar&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "qwik",
     "name": "Qwik",
     "url": "https://img.shields.io/badge/qwik-%23AC7EF4.svg?style=for-the-badge&logo=qwik&logoColor=white",
     "markdown": "![Qwik](https://img.shields.io/badge/qwik-%23AC7EF4.svg?style=for-the-badge&logo=qwik&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "rabbitmq",
     "name": "RabbitMQ",
     "url": "https://img.shields.io/badge/Rabbitmq-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white",
     "markdown": "![RabbitMQ](https://img.shields.io/badge/Rabbitmq-FF6600?style=for-the-badge&logo=rabbitmq&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "radix-ui",
     "name": "Radix UI",
     "url": "https://img.shields.io/badge/radix%20ui-161618.svg?style=for-the-badge&logo=radix-ui&logoColor=white",
     "markdown": "![Radix UI](https://img.shields.io/badge/radix%20ui-161618.svg?style=for-the-badge&logo=radix-ui&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "raylib",
     "name": "RayLib",
     "url": "https://img.shields.io/badge/RAYLIB-FFFFFF?style=for-the-badge&logo=raylib&logoColor=black",
     "markdown": "![RayLib](https://img.shields.io/badge/RAYLIB-FFFFFF?style=for-the-badge&logo=raylib&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "react-hook-form",
     "name": "React Hook Form",
     "url": "https://img.shields.io/badge/React%20Hook%20Form-%23EC5990.svg?style=for-the-badge&logo=reacthookform&logoColor=white",
     "markdown": "![React Hook Form](https://img.shields.io/badge/React%20Hook%20Form-%23EC5990.svg?style=for-the-badge&logo=reacthookform&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "react-query",
     "name": "React Query",
     "url": "https://img.shields.io/badge/-React%20Query-FF4154?style=for-the-badge&logo=react%20query&logoColor=white",
     "markdown": "![React Query](https://img.shields.io/badge/-React%20Query-FF4154?style=for-the-badge&logo=react%20query&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "react-router",
     "name": "React Router",
     "url": "https://img.shields.io/badge/React_Router-CA4245?style=for-the-badge&logo=react-router&logoColor=white",
     "markdown": "![React Router](https://img.shields.io/badge/React_Router-CA4245?style=for-the-badge&logo=react-router&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "redux",
     "name": "Redux",
     "url": "https://img.shields.io/badge/redux-%23593d88.svg?style=for-the-badge&logo=redux&logoColor=white",
     "markdown": "![Redux](https://img.shields.io/badge/redux-%23593d88.svg?style=for-the-badge&logo=redux&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "remix",
     "name": "Remix",
     "url": "https://img.shields.io/badge/remix-%23000.svg?style=for-the-badge&logo=remix&logoColor=white",
     "markdown": "![Remix](https://img.shields.io/badge/remix-%23000.svg?style=for-the-badge&logo=remix&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "risc-v",
     "name": "RISC-V",
     "url": "https://img.shields.io/badge/riscv-%23283272.svg?style=for-the-badge&logo=riscv&logoColor=white",
     "markdown": "![RISC-V](https://img.shields.io/badge/riscv-%23283272.svg?style=for-the-badge&logo=riscv&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "ros",
     "name": "ROS",
     "url": "https://img.shields.io/badge/ros-%230A0FF9.svg?style=for-the-badge&logo=ros&logoColor=white",
     "markdown": "![ROS](https://img.shields.io/badge/ros-%230A0FF9.svg?style=for-the-badge&logo=ros&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "rxdb",
     "name": "RxDB",
     "url": "https://img.shields.io/badge/rxjs-%23B7178C.svg?style=for-the-badge&logo=reactivex&logoColor=white",
     "markdown": "![RxDB](https://img.shields.io/badge/rxjs-%23B7178C.svg?style=for-the-badge&logo=reactivex&logoColor=white)",
-    "category": "Frameworks"
-  },
-  {
-    "id": "rxjs",
-    "name": "RxJS",
-    "url": "https://img.shields.io/badge/rxjs-%23B7178C.svg?style=for-the-badge&logo=reactivex&logoColor=white",
-    "markdown": "![RxJS](https://img.shields.io/badge/rxjs-%23B7178C.svg?style=for-the-badge&logo=reactivex&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "sap-commerce-cloud",
     "name": "SAP Commerce Cloud",
     "url": "https://img.shields.io/badge/SAP%20Commerce%20Cloud-%230057D2.svg?style=for-the-badge&logo=sap&logoColor=white",
     "markdown": "![SAP Commerce Cloud](https://img.shields.io/badge/SAP%20Commerce%20Cloud-%230057D2.svg?style=for-the-badge&logo=sap&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "sass",
     "name": "SASS",
     "url": "https://img.shields.io/badge/SASS-hotpink.svg?style=for-the-badge&logo=SASS&logoColor=white",
     "markdown": "![SASS](https://img.shields.io/badge/SASS-hotpink.svg?style=for-the-badge&logo=SASS&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "scrapy",
     "name": "Scrapy",
     "url": "https://img.shields.io/badge/scrapy-%2360a839.svg?style=for-the-badge&logo=scrapy&logoColor=d1d2d3",
     "markdown": "![Scrapy](https://img.shields.io/badge/scrapy-%2360a839.svg?style=for-the-badge&logo=scrapy&logoColor=d1d2d3)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "semantic-ui-react",
     "name": "Semantic UI React",
     "url": "https://img.shields.io/badge/Semantic%20UI%20React-%2335BDB2.svg?style=for-the-badge&logo=SemanticUIReact&logoColor=white",
     "markdown": "![Semantic UI React](https://img.shields.io/badge/Semantic%20UI%20React-%2335BDB2.svg?style=for-the-badge&logo=SemanticUIReact&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "snowflake",
     "name": "Snowflake",
     "url": "https://img.shields.io/badge/snowflake-%2329B5E8.svg?style=for-the-badge&logo=snowflake&logoColor=white",
     "markdown": "![Snowflake](https://img.shields.io/badge/snowflake-%2329B5E8.svg?style=for-the-badge&logo=snowflake&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "socket.io",
     "name": "Socket.io",
     "url": "https://img.shields.io/badge/Socket.io-black?style=for-the-badge&logo=socket.io&badgeColor=010101",
     "markdown": "![Socket.io](https://img.shields.io/badge/Socket.io-black?style=for-the-badge&logo=socket.io&badgeColor=010101)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "solidjs",
     "name": "SolidJS",
     "url": "https://img.shields.io/badge/SolidJS-2c4f7c?style=for-the-badge&logo=solid&logoColor=c8c9cb",
     "markdown": "![SolidJS](https://img.shields.io/badge/SolidJS-2c4f7c?style=for-the-badge&logo=solid&logoColor=c8c9cb)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "strapi",
     "name": "Strapi",
     "url": "https://img.shields.io/badge/strapi-%232E7EEA.svg?style=for-the-badge&logo=strapi&logoColor=white",
     "markdown": "![Strapi](https://img.shields.io/badge/strapi-%232E7EEA.svg?style=for-the-badge&logo=strapi&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "streamlit",
     "name": "Streamlit",
     "url": "https://img.shields.io/badge/Streamlit-%23FE4B4B.svg?style=for-the-badge&logo=streamlit&logoColor=white",
     "markdown": "![Streamlit](https://img.shields.io/badge/Streamlit-%23FE4B4B.svg?style=for-the-badge&logo=streamlit&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "styled-components",
     "name": "Styled Components",
     "url": "https://img.shields.io/badge/styled--components-DB7093?style=for-the-badge&logo=styled-components&logoColor=white",
     "markdown": "![Styled Components](https://img.shields.io/badge/styled--components-DB7093?style=for-the-badge&logo=styled-components&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "stylus",
     "name": "Stylus",
     "url": "https://img.shields.io/badge/stylus-%23ff6347.svg?style=for-the-badge&logo=stylus&logoColor=white",
     "markdown": "![Stylus](https://img.shields.io/badge/stylus-%23ff6347.svg?style=for-the-badge&logo=stylus&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "sveltekit",
     "name": "SvelteKit",
     "url": "https://img.shields.io/badge/sveltekit-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white",
     "markdown": "![Svelte](https://img.shields.io/badge/sveltekit-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "symfony",
     "name": "Symfony",
     "url": "https://img.shields.io/badge/symfony-%23000000.svg?style=for-the-badge&logo=symfony&logoColor=white",
     "markdown": "![Symfony](https://img.shields.io/badge/symfony-%23000000.svg?style=for-the-badge&logo=symfony&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "three.js",
     "name": "Three.js",
     "url": "https://img.shields.io/badge/threejs-black?style=for-the-badge&logo=three.js&logoColor=white",
     "markdown": "![Threejs](https://img.shields.io/badge/threejs-black?style=for-the-badge&logo=three.js&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "thymeleaf",
     "name": "Thymeleaf",
     "url": "https://img.shields.io/badge/Thymeleaf-%23005C0F.svg?style=for-the-badge&logo=Thymeleaf&logoColor=white",
     "markdown": "![Thymeleaf](https://img.shields.io/badge/Thymeleaf-%23005C0F.svg?style=for-the-badge&logo=Thymeleaf&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "trpc",
     "name": "tRPC",
     "url": "https://img.shields.io/badge/tRPC-%232596BE.svg?style=for-the-badge&logo=tRPC&logoColor=white",
     "markdown": "![tRPC](https://img.shields.io/badge/tRPC-%232596BE.svg?style=for-the-badge&logo=tRPC&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "turborepo",
     "name": "Turborepo",
     "url": "https://img.shields.io/badge/turborepo-%23EF4444.svg?style=for-the-badge&logo=turborepo&logoColor=white",
     "markdown": "![Turborepo](https://img.shields.io/badge/turborepo-%23EF4444.svg?style=for-the-badge&logo=turborepo&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "typegraphql",
     "name": "TypeGraphQL",
     "url": "https://img.shields.io/badge/-TypeGraphQL-%23C04392?style=for-the-badge",
     "markdown": "![Type-graphql](https://img.shields.io/badge/-TypeGraphQL-%23C04392?style=for-the-badge)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "uikit",
     "name": "UIkit",
     "url": "https://img.shields.io/badge/UIkit-%232396F3?style=for-the-badge&logo=uikit&logoColor=white",
     "markdown": "![UIkit](https://img.shields.io/badge/UIkit-%232396F3?style=for-the-badge&logo=uikit&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "unjs",
     "name": "UnJS",
     "url": "https://img.shields.io/badge/-UnJs-%23ECDC5A?style=for-the-badge&logo=UnJs&logoColor=black",
     "markdown": "![UnJs](https://img.shields.io/badge/-UnJs-%23ECDC5A?style=for-the-badge&logo=UnJs&logoColor=black)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "unocss",
     "name": "UnoCSS",
     "url": "https://img.shields.io/badge/unocss-333333.svg?style=for-the-badge&logo=unocss&logoColor=white",
     "markdown": "![UnoCSS](https://img.shields.io/badge/unocss-333333.svg?style=for-the-badge&logo=unocss&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "unpkg",
     "name": "unpkg",
     "url": "https://img.shields.io/badge/unpkg-%23000000.svg?style=for-the-badge&logo=unpkg&logoColor=white",
     "markdown": "![unpkg](https://img.shields.io/badge/unpkg-%23000000.svg?style=for-the-badge&logo=unpkg&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "uv",
     "name": "uv",
     "url": "https://img.shields.io/badge/uv-%23DE5FE9.svg?style=for-the-badge&logo=uv&logoColor=white",
     "markdown": "![uv](https://img.shields.io/badge/uv-%23DE5FE9.svg?style=for-the-badge&logo=uv&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "vulkan",
     "name": "Vulkan",
     "url": "https://img.shields.io/badge/Vulkan-AC162C.svg?style=for-the-badge&logo=vulkan&logoColor=white&logoSize=auto",
     "markdown": "![Vulkan API](https://img.shields.io/badge/Vulkan-AC162C.svg?style=for-the-badge&logo=vulkan&logoColor=white&logoSize=auto)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "web3.js",
     "name": "Web3.js",
     "url": "https://img.shields.io/badge/web3.js-F16822?style=for-the-badge&logo=web3.js&logoColor=white",
     "markdown": "![Web3.js](https://img.shields.io/badge/web3.js-F16822?style=for-the-badge&logo=web3.js&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "webflow",
     "name": "Webflow",
     "url": "https://img.shields.io/badge/webflow-%23146EF5.svg?style=for-the-badge&logo=webflow&logoColor=white",
     "markdown": "![Webflow](https://img.shields.io/badge/webflow-%23146EF5.svg?style=for-the-badge&logo=webflow&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "webgl",
     "name": "WebGL",
     "url": "https://img.shields.io/badge/WebGL-990000?logo=webgl&logoColor=white&style=for-the-badge",
     "markdown": "![WebGL](https://img.shields.io/badge/WebGL-990000?logo=webgl&logoColor=white&style=for-the-badge)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "windicss",
     "name": "WindiCSS",
     "url": "https://img.shields.io/badge/windicss-48B0F1.svg?style=for-the-badge&logo=windi-css&logoColor=white",
     "markdown": "![Windicss](https://img.shields.io/badge/windicss-48B0F1.svg?style=for-the-badge&logo=windi-css&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "wordpress",
     "name": "WordPress",
     "url": "https://img.shields.io/badge/WordPress-%23117AC9.svg?style=for-the-badge&logo=WordPress&logoColor=white",
     "markdown": "![WordPress](https://img.shields.io/badge/WordPress-%23117AC9.svg?style=for-the-badge&logo=WordPress&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "xamarin",
     "name": "Xamarin",
     "url": "https://img.shields.io/badge/Xamarin-3199DC?style=for-the-badge&logo=xamarin&logoColor=white",
     "markdown": "![Xamarin](https://img.shields.io/badge/Xamarin-3199DC?style=for-the-badge&logo=xamarin&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "yarn",
     "name": "Yarn",
     "url": "https://img.shields.io/badge/yarn-%232C8EBB.svg?style=for-the-badge&logo=yarn&logoColor=white",
     "markdown": "![Yarn](https://img.shields.io/badge/yarn-%232C8EBB.svg?style=for-the-badge&logo=yarn&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "zod",
     "name": "Zod",
     "url": "https://img.shields.io/badge/zod-%233068b7.svg?style=for-the-badge&logo=zod&logoColor=white",
     "markdown": "![Zod](https://img.shields.io/badge/zod-%233068b7.svg?style=for-the-badge&logo=zod&logoColor=white)",
-    "category": "Frameworks"
+    "categories": [
+      "Frameworks"
+    ]
   },
   {
     "id": "angular",
     "name": "Angular",
     "url": "https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white",
     "markdown": "![Angular](https://img.shields.io/badge/angular-%23DD0031.svg?style=for-the-badge&logo=angular&logoColor=white)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "astro",
     "name": "Astro",
     "url": "https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white",
     "markdown": "![Astro](https://img.shields.io/badge/astro-%232C2052.svg?style=for-the-badge&logo=astro&logoColor=white)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "next-js",
     "name": "Next JS",
     "url": "https://img.shields.io/badge/Next-black.svg?style=for-the-badge&logo=next.js&logoColor=white",
     "markdown": "![Next JS](https://img.shields.io/badge/Next-black.svg?style=for-the-badge&logo=next.js&logoColor=white)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "nuxt-js",
     "name": "Nuxt JS",
     "url": "https://img.shields.io/badge/Nuxt-002E3B.svg?style=for-the-badge&logo=nuxt&logoColor=#00DC82",
     "markdown": "![Nuxt JS](https://img.shields.io/badge/Nuxt-002E3B.svg?style=for-the-badge&logo=nuxt&logoColor=#00DC82)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "react",
     "name": "React",
     "url": "https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB",
     "markdown": "![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "svelte",
     "name": "Svelte",
     "url": "https://img.shields.io/badge/svelte-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white",
     "markdown": "![Svelte](https://img.shields.io/badge/svelte-%23f1413d.svg?style=for-the-badge&logo=svelte&logoColor=white)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "vue.js",
     "name": "Vue.js",
     "url": "https://img.shields.io/badge/vue.js-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D",
     "markdown": "![Vue.js](https://img.shields.io/badge/vue.js-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D)",
-    "category": "Frontend"
+    "categories": [
+      "Frontend"
+    ]
   },
   {
     "id": "ant-design",
     "name": "Ant Design",
     "url": "https://img.shields.io/badge/-AntDesign-%230170FE.svg?style=for-the-badge&logo=ant-design&logoColor=white",
     "markdown": "![Ant-Design](https://img.shields.io/badge/-AntDesign-%230170FE.svg?style=for-the-badge&logo=ant-design&logoColor=white)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "bootstrap",
     "name": "Bootstrap",
     "url": "https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white",
     "markdown": "![Bootstrap](https://img.shields.io/badge/bootstrap-%238511FA.svg?style=for-the-badge&logo=bootstrap&logoColor=white)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "bulma",
     "name": "Bulma",
     "url": "https://img.shields.io/badge/bulma-00D0B1.svg?style=for-the-badge&logo=bulma&logoColor=white",
     "markdown": "![Bulma](https://img.shields.io/badge/bulma-00D0B1.svg?style=for-the-badge&logo=bulma&logoColor=white)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "mantine",
     "name": "Mantine",
     "url": "https://img.shields.io/badge/Mantine-ffffff.svg?style=for-the-badge&logo=Mantine&logoColor=339af0",
     "markdown": "![Mantine](https://img.shields.io/badge/Mantine-ffffff.svg?style=for-the-badge&logo=Mantine&logoColor=339af0)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "material-ui",
     "name": "Material UI",
     "url": "https://img.shields.io/badge/Material%20UI-%23FFFFFF.svg?style=for-the-badge&logo=MUI&logoColor=#007FFF",
     "markdown": "![MaterialUI](https://img.shields.io/badge/Material%20UI-%23FFFFFF.svg?style=for-the-badge&logo=MUI&logoColor=#007FFF)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "shadcn/ui",
     "name": "Shadcn/UI",
     "url": "https://img.shields.io/badge/shadcn/ui-%23000000.svg?style=for-the-badge&logo=shadcnui&logoColor=white",
     "markdown": "![Shadcn/ui](https://img.shields.io/badge/shadcn/ui-%23000000.svg?style=for-the-badge&logo=shadcnui&logoColor=white)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "tailwindcss",
     "name": "TailwindCSS",
     "url": "https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white",
     "markdown": "![TailwindCSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "vuetify",
     "name": "Vuetify",
     "url": "https://img.shields.io/badge/Vuetify-1867C0.svg?style=for-the-badge&logo=vuetify&logoColor=AEDDFF",
     "markdown": "![Vuetify](https://img.shields.io/badge/Vuetify-1867C0.svg?style=for-the-badge&logo=vuetify&logoColor=AEDDFF)",
-    "category": "CSS Frameworks"
+    "categories": [
+      "CSS Frameworks"
+    ]
   },
   {
     "id": "django",
     "name": "Django",
     "url": "https://img.shields.io/badge/django-%23092E20.svg?style=for-the-badge&logo=django&logoColor=white",
     "markdown": "![Django](https://img.shields.io/badge/django-%23092E20.svg?style=for-the-badge&logo=django&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "express.js",
     "name": "Express.js",
     "url": "https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB",
     "markdown": "![Express.js](https://img.shields.io/badge/express.js-%23404d59.svg?style=for-the-badge&logo=express&logoColor=%2361DAFB)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "fastapi",
     "name": "FastAPI",
     "url": "https://img.shields.io/badge/FastAPI-005571.svg?style=for-the-badge&logo=fastapi",
     "markdown": "![FastAPI](https://img.shields.io/badge/FastAPI-005571.svg?style=for-the-badge&logo=fastapi)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "flask",
     "name": "Flask",
     "url": "https://img.shields.io/badge/flask-%23000.svg?style=for-the-badge&logo=flask&logoColor=white",
     "markdown": "![Flask](https://img.shields.io/badge/flask-%23000.svg?style=for-the-badge&logo=flask&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "laravel",
     "name": "Laravel",
     "url": "https://img.shields.io/badge/laravel-%23FF2D20.svg?style=for-the-badge&logo=laravel&logoColor=white",
     "markdown": "![Laravel](https://img.shields.io/badge/laravel-%23FF2D20.svg?style=for-the-badge&logo=laravel&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "nestjs",
     "name": "NestJS",
     "url": "https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white",
     "markdown": "![NestJS](https://img.shields.io/badge/nestjs-%23E0234E.svg?style=for-the-badge&logo=nestjs&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "node.js",
     "name": "Node.js",
     "url": "https://img.shields.io/badge/node.js-6DA55F.svg?style=for-the-badge&logo=node.js&logoColor=white",
     "markdown": "![NodeJS](https://img.shields.io/badge/node.js-6DA55F.svg?style=for-the-badge&logo=node.js&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "rails",
     "name": "Rails",
     "url": "https://img.shields.io/badge/rails-%23CC0000.svg?style=for-the-badge&logo=ruby-on-rails&logoColor=white",
     "markdown": "![Rails](https://img.shields.io/badge/rails-%23CC0000.svg?style=for-the-badge&logo=ruby-on-rails&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "spring",
     "name": "Spring",
     "url": "https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white",
     "markdown": "![Spring](https://img.shields.io/badge/spring-%236DB33F.svg?style=for-the-badge&logo=spring&logoColor=white)",
-    "category": "Backend"
+    "categories": [
+      "Backend"
+    ]
   },
   {
     "id": "expo",
     "name": "Expo",
     "url": "https://img.shields.io/badge/expo-1C1E24.svg?style=for-the-badge&logo=expo&logoColor=#D04A37",
     "markdown": "![Expo](https://img.shields.io/badge/expo-1C1E24.svg?style=for-the-badge&logo=expo&logoColor=#D04A37)",
-    "category": "Mobile"
+    "categories": [
+      "Mobile"
+    ]
   },
   {
     "id": "flutter",
     "name": "Flutter",
     "url": "https://img.shields.io/badge/Flutter-%2302569B.svg?style=for-the-badge&logo=Flutter&logoColor=white",
     "markdown": "![Flutter](https://img.shields.io/badge/Flutter-%2302569B.svg?style=for-the-badge&logo=Flutter&logoColor=white)",
-    "category": "Mobile"
+    "categories": [
+      "Mobile"
+    ]
   },
   {
     "id": "ionic",
     "name": "Ionic",
     "url": "https://img.shields.io/badge/Ionic-%233880FF.svg?style=for-the-badge&logo=Ionic&logoColor=white",
     "markdown": "![Ionic](https://img.shields.io/badge/Ionic-%233880FF.svg?style=for-the-badge&logo=Ionic&logoColor=white)",
-    "category": "Mobile"
+    "categories": [
+      "Mobile"
+    ]
   },
   {
     "id": "react-native",
     "name": "React Native",
     "url": "https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB",
     "markdown": "![React Native](https://img.shields.io/badge/react_native-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
-    "category": "Mobile"
+    "categories": [
+      "Mobile"
+    ]
   },
   {
     "id": "tauri",
     "name": "Tauri",
     "url": "https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF",
     "markdown": "![Tauri](https://img.shields.io/badge/tauri-%2324C8DB.svg?style=for-the-badge&logo=tauri&logoColor=%23FFFFFF)",
-    "category": "Mobile"
+    "categories": [
+      "Mobile"
+    ]
   },
   {
     "id": "keras",
     "name": "Keras",
     "url": "https://img.shields.io/badge/Keras-D00000.svg?style=for-the-badge&logo=keras&logoColor=white",
     "markdown": "![Keras](https://img.shields.io/badge/Keras-D00000.svg?style=for-the-badge&logo=keras&logoColor=white)",
-    "category": "ML/AI"
+    "categories": [
+      "ML/AI",
+      "ML/DL"
+    ]
   },
   {
     "id": "numpy",
     "name": "NumPy",
     "url": "https://img.shields.io/badge/NumPy-013243.svg?style=for-the-badge&logo=numpy&logoColor=white",
     "markdown": "![NumPy](https://img.shields.io/badge/NumPy-013243.svg?style=for-the-badge&logo=numpy&logoColor=white)",
-    "category": "ML/AI"
+    "categories": [
+      "ML/AI",
+      "ML/DL"
+    ]
   },
   {
     "id": "opencv",
     "name": "OpenCV",
     "url": "https://img.shields.io/badge/opencv-%23white.svg?style=for-the-badge&logo=opencv&logoColor=white",
     "markdown": "![OpenCV](https://img.shields.io/badge/opencv-%23white.svg?style=for-the-badge&logo=opencv&logoColor=white)",
-    "category": "ML/AI"
+    "categories": [
+      "ML/AI"
+    ]
   },
   {
     "id": "pandas",
     "name": "Pandas",
     "url": "https://img.shields.io/badge/Pandas-150458.svg?style=for-the-badge&logo=pandas&logoColor=white",
     "markdown": "![Pandas](https://img.shields.io/badge/Pandas-150458.svg?style=for-the-badge&logo=pandas&logoColor=white)",
-    "category": "ML/AI"
+    "categories": [
+      "ML/AI",
+      "ML/DL"
+    ]
   },
   {
     "id": "pytorch",
     "name": "PyTorch",
     "url": "https://img.shields.io/badge/PyTorch-EE4C2C.svg?style=for-the-badge&logo=pytorch&logoColor=white",
     "markdown": "![PyTorch](https://img.shields.io/badge/PyTorch-EE4C2C.svg?style=for-the-badge&logo=pytorch&logoColor=white)",
-    "category": "ML/AI"
+    "categories": [
+      "ML/AI",
+      "ML/DL"
+    ]
   },
   {
     "id": "tensorflow",
     "name": "TensorFlow",
     "url": "https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=tensorflow&logoColor=white",
     "markdown": "![TensorFlow](https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=tensorflow&logoColor=white)",
-    "category": "ML/AI"
+    "categories": [
+      "ML/AI",
+      "ML/DL"
+    ]
   },
   {
     "id": "bun",
     "name": "Bun",
     "url": "https://img.shields.io/badge/Bun-%23000000.svg?style=for-the-badge&logo=bun&logoColor=white",
     "markdown": "![Bun](https://img.shields.io/badge/Bun-%23000000.svg?style=for-the-badge&logo=bun&logoColor=white)",
-    "category": "Build Tools"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "esbuild",
     "name": "ESBuild",
     "url": "https://img.shields.io/badge/esbuild-%23FFCF00.svg?style=for-the-badge&logo=esbuild&logoColor=black",
     "markdown": "![Esbuild](https://img.shields.io/badge/esbuild-%23FFCF00.svg?style=for-the-badge&logo=esbuild&logoColor=black)",
-    "category": "Build Tools"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "gulp",
     "name": "Gulp",
     "url": "https://img.shields.io/badge/GULP-%23CF4647.svg?style=for-the-badge&logo=gulp&logoColor=white",
     "markdown": "![Gulp](https://img.shields.io/badge/GULP-%23CF4647.svg?style=for-the-badge&logo=gulp&logoColor=white)",
-    "category": "Build Tools"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "nx",
     "name": "Nx",
     "url": "https://img.shields.io/badge/nx-143055.svg?style=for-the-badge&logo=nx&logoColor=white",
     "markdown": "![Nx](https://img.shields.io/badge/nx-143055.svg?style=for-the-badge&logo=nx&logoColor=white)",
-    "category": "Build Tools"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "rollupjs",
     "name": "RollupJS",
     "url": "https://img.shields.io/badge/RollupJS-ef3335.svg?style=for-the-badge&logo=rollup.js&logoColor=white",
     "markdown": "![RollupJS](https://img.shields.io/badge/RollupJS-ef3335.svg?style=for-the-badge&logo=rollup.js&logoColor=white)",
-    "category": "Build Tools"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "vite",
     "name": "Vite",
     "url": "https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white",
     "markdown": "![Vite](https://img.shields.io/badge/vite-%23646CFF.svg?style=for-the-badge&logo=vite&logoColor=white)",
-    "category": "Build Tools"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "webpack",
     "name": "Webpack",
     "url": "https://img.shields.io/badge/webpack-%238DD6F9.svg?style=for-the-badge&logo=webpack&logoColor=black",
     "markdown": "![Webpack](https://img.shields.io/badge/webpack-%238DD6F9.svg?style=for-the-badge&logo=webpack&logoColor=black)",
-    "category": "Build Tools"
-  },
-  {
-    "id": "amd-gaming",
-    "name": "AMD",
-    "url": "https://img.shields.io/badge/AMD-%23000000.svg?style=for-the-badge&logo=amd&logoColor=white",
-    "markdown": "![AMD](https://img.shields.io/badge/AMD-%23000000.svg?style=for-the-badge&logo=amd&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Build Tools"
+    ]
   },
   {
     "id": "analogue",
     "name": "Analogue",
     "url": "https://img.shields.io/badge/Analogue-1A1A1A?style=for-the-badge&logo=Analogue&logoColor=white",
     "markdown": "![Analogue](https://img.shields.io/badge/Analogue-1A1A1A?style=for-the-badge&logo=Analogue&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "battle.net",
     "name": "Battle.net",
     "url": "https://img.shields.io/badge/battle.net-%2300AEFF.svg?style=for-the-badge&logo=battle.net&logoColor=white",
     "markdown": "![Battle.net](https://img.shields.io/badge/battle.net-%2300AEFF.svg?style=for-the-badge&logo=battle.net&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "bevy",
     "name": "Bevy",
     "url": "https://img.shields.io/badge/bevy-%23232326.svg?style=for-the-badge&logo=bevy&logoColor=white",
     "markdown": "![Bevy](https://img.shields.io/badge/bevy-%23232326.svg?style=for-the-badge&logo=bevy&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "ea",
     "name": "EA",
     "url": "https://img.shields.io/badge/ea-%23000000.svg?style=for-the-badge&logo=ea&logoColor=white",
     "markdown": "![EA](https://img.shields.io/badge/ea-%23000000.svg?style=for-the-badge&logo=ea&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "epic-games",
     "name": "Epic Games",
     "url": "https://img.shields.io/badge/epicgames-%23313131.svg?style=for-the-badge&logo=epicgames&logoColor=white",
     "markdown": "![Epic Games](https://img.shields.io/badge/epicgames-%23313131.svg?style=for-the-badge&logo=epicgames&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "godot-engine",
     "name": "Godot Engine",
     "url": "https://img.shields.io/badge/GODOT-%23FFFFFF.svg?style=for-the-badge&logo=godot-engine",
     "markdown": "![Godot Engine](https://img.shields.io/badge/GODOT-%23FFFFFF.svg?style=for-the-badge&logo=godot-engine)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "hearthstone-collection",
     "name": "Hearthstone Collection",
     "url": "https://img.shields.io/badge/Hearthstone-%23FA830D.svg?style=for-the-badge&logo=hearthstone-collection&logoColor=white",
     "markdown": "![Hearthstone Collection](https://img.shields.io/badge/Hearthstone-%23FA830D.svg?style=for-the-badge&logo=hearthstone-collection&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "humble-bundle",
     "name": "Humble Bundle",
     "url": "https://img.shields.io/badge/HumbleBundle-%23494F5C.svg?style=for-the-badge&logo=HumbleBundle&logoColor=white",
     "markdown": "![Humble Bundle](https://img.shields.io/badge/HumbleBundle-%23494F5C.svg?style=for-the-badge&logo=HumbleBundle&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "intel",
     "name": "Intel",
     "url": "https://img.shields.io/badge/intel-%230068B5%20.svg?style=for-the-badge&logo=intel&logoColor=white",
     "markdown": "![Intel](https://img.shields.io/badge/intel-%230068B5%20.svg?style=for-the-badge&logo=intel&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "itch.io",
     "name": "Itch.io",
     "url": "https://img.shields.io/badge/Itch-%23FF0B34.svg?style=for-the-badge&logo=Itch.io&logoColor=white",
     "markdown": "![Itch.io](https://img.shields.io/badge/Itch-%23FF0B34.svg?style=for-the-badge&logo=Itch.io&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "nvidia",
     "name": "nVIDIA",
     "url": "https://img.shields.io/badge/nVIDIA-%2376B900.svg?style=for-the-badge&logo=nVIDIA&logoColor=white",
     "markdown": "![nVIDIA](https://img.shields.io/badge/nVIDIA-%2376B900.svg?style=for-the-badge&logo=nVIDIA&logoColor=white)",
-    "category": "Gaming"
-  },
-  {
-    "id": "opengl-gaming",
-    "name": "OpenGL",
-    "url": "https://img.shields.io/badge/OpenGL-white?logo=OpenGL&style=for-the-badge",
-    "markdown": "![OpenGL](https://img.shields.io/badge/OpenGL-white?logo=OpenGL&style=for-the-badge)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "playstation-network",
     "name": "PlayStation Network",
     "url": "https://img.shields.io/badge/PSN-%230070D1.svg?style=for-the-badge&logo=Playstation&logoColor=white",
     "markdown": "![PlayStation Network](https://img.shields.io/badge/PSN-%230070D1.svg?style=for-the-badge&logo=Playstation&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "riot-games",
     "name": "Riot Games",
     "url": "https://img.shields.io/badge/riotgames-D32936.svg?style=for-the-badge&logo=riotgames&logoColor=white",
     "markdown": "![Riot Games](https://img.shields.io/badge/riotgames-D32936.svg?style=for-the-badge&logo=riotgames&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "roblox",
     "name": "Roblox",
     "url": "https://img.shields.io/badge/Roblox-%230a0b0b.svg?style=for-the-badge&logo=Roblox&logoColor=white",
     "markdown": "![Roblox](https://img.shields.io/badge/Roblox-%230a0b0b.svg?style=for-the-badge&logo=Roblox&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "sidequest",
     "name": "Sidequest",
     "url": "https://img.shields.io/badge/sidequest-%23101227.svg?style=for-the-badge&logo=sidequest&logoColor=white",
     "markdown": "![Sidequest](https://img.shields.io/badge/sidequest-%23101227.svg?style=for-the-badge&logo=sidequest&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "square-enix",
     "name": "Square Enix",
     "url": "https://img.shields.io/badge/SquareEnix-%23ED1C24.svg?style=for-the-badge&logo=SquareEnix&logoColor=white",
     "markdown": "![Square Enix](https://img.shields.io/badge/SquareEnix-%23ED1C24.svg?style=for-the-badge&logo=SquareEnix&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "steam",
     "name": "Steam",
     "url": "https://img.shields.io/badge/steam-%23000000.svg?style=for-the-badge&logo=steam&logoColor=white",
     "markdown": "![Steam](https://img.shields.io/badge/steam-%23000000.svg?style=for-the-badge&logo=steam&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "ubisoft",
     "name": "Ubisoft",
     "url": "https://img.shields.io/badge/Ubisoft-%23F5F5F5.svg?style=for-the-badge&logo=Ubisoft&logoColor=black",
     "markdown": "![Ubisoft](https://img.shields.io/badge/Ubisoft-%23F5F5F5.svg?style=for-the-badge&logo=Ubisoft&logoColor=black)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "unity",
     "name": "Unity",
     "url": "https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white",
     "markdown": "![Unity](https://img.shields.io/badge/unity-%23000000.svg?style=for-the-badge&logo=unity&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "unreal-engine",
     "name": "Unreal Engine",
     "url": "https://img.shields.io/badge/unrealengine-%23313131.svg?style=for-the-badge&logo=unrealengine&logoColor=white",
     "markdown": "![Unreal Engine](https://img.shields.io/badge/unrealengine-%23313131.svg?style=for-the-badge&logo=unrealengine&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming"
+    ]
   },
   {
     "id": "xbox",
     "name": "Xbox",
     "url": "https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white",
     "markdown": "![Xbox](https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white)",
-    "category": "Gaming"
+    "categories": [
+      "Gaming",
+      "Game Consoles",
+      "Social"
+    ]
   },
   {
     "id": "google-earth-engine",
     "name": "Google Earth Engine",
     "url": "https://img.shields.io/badge/google%20earth%20engine-%234285F4?style=for-the-badge&logo=googleearthengine&logoColor=white",
     "markdown": "![GoogleEarthEngine](https://img.shields.io/badge/google%20earth%20engine-%234285F4?style=for-the-badge&logo=googleearthengine&logoColor=white)",
-    "category": "Geospatial"
+    "categories": [
+      "Geospatial"
+    ]
   },
   {
     "id": "qgis",
     "name": "QGIS",
     "url": "https://img.shields.io/badge/qgis-%2393b023?&style=for-the-badge&logo=qgis&logoColor=white",
     "markdown": "![QGIS](https://img.shields.io/badge/qgis-%2393b023?&style=for-the-badge&logo=qgis&logoColor=white)",
-    "category": "Geospatial"
+    "categories": [
+      "Geospatial"
+    ]
   },
   {
     "id": "3ds",
     "name": "3DS",
     "url": "https://img.shields.io/badge/3DS-D12228?style=for-the-badge&logo=nintendo-3ds&logoColor=white",
     "markdown": "![3DS](https://img.shields.io/badge/3DS-D12228?style=for-the-badge&logo=nintendo-3ds&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "gamecube",
     "name": "Gamecube",
     "url": "https://img.shields.io/badge/Gamecube-6A5FBB?style=for-the-badge&logo=nintendo-gamecube&logoColor=white",
     "markdown": "![Gamecube](https://img.shields.io/badge/Gamecube-6A5FBB?style=for-the-badge&logo=nintendo-gamecube&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "playstation",
     "name": "Playstation",
     "url": "https://img.shields.io/badge/Playstation-003791?style=for-the-badge&logo=playstation&logoColor=white",
     "markdown": "![Playstation](https://img.shields.io/badge/Playstation-003791?style=for-the-badge&logo=playstation&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "playstation-2",
     "name": "Playstation 2",
     "url": "https://img.shields.io/badge/Playstation%202-003791?style=for-the-badge&logo=playstation-2&logoColor=white",
     "markdown": "![Playstation 2](https://img.shields.io/badge/Playstation%202-003791?style=for-the-badge&logo=playstation-2&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "playstation-3",
     "name": "Playstation 3",
     "url": "https://img.shields.io/badge/Playstation%203-003791?style=for-the-badge&logo=playstation-3&logoColor=white",
     "markdown": "![Playstation 3](https://img.shields.io/badge/Playstation%203-003791?style=for-the-badge&logo=playstation-3&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "playstation-4",
     "name": "Playstation 4",
     "url": "https://img.shields.io/badge/Playstation%204-003791?style=for-the-badge&logo=playstation-4&logoColor=white",
     "markdown": "![Playstation 4](https://img.shields.io/badge/Playstation%204-003791?style=for-the-badge&logo=playstation-4&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "playstation-5",
     "name": "Playstation 5",
     "url": "https://img.shields.io/badge/Playstation%205-003791?style=for-the-badge&logo=playstation-5&logoColor=white",
     "markdown": "![Playstation 5](https://img.shields.io/badge/Playstation%205-003791?style=for-the-badge&logo=playstation-5&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "playstation-vita",
     "name": "Playstation Vita",
     "url": "https://img.shields.io/badge/Playstation%20Vita-003791?style=for-the-badge&logo=playstation-vita&logoColor=white",
     "markdown": "![Playstation Vita](https://img.shields.io/badge/Playstation%20Vita-003791?style=for-the-badge&logo=playstation-vita&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "switch",
     "name": "Switch",
     "url": "https://img.shields.io/badge/Switch-E60012?style=for-the-badge&logo=nintendo-switch&logoColor=white",
     "markdown": "![Switch](https://img.shields.io/badge/Switch-E60012?style=for-the-badge&logo=nintendo-switch&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "wii",
     "name": "Wii",
     "url": "https://img.shields.io/badge/Wii-8B8B8B?style=for-the-badge&logo=wii&logoColor=white",
     "markdown": "![Wii](https://img.shields.io/badge/Wii-8B8B8B?style=for-the-badge&logo=wii&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "wii-u",
     "name": "Wii U",
     "url": "https://img.shields.io/badge/Wii%20U-8B8B8B?style=for-the-badge&logo=wiiu&logoColor=white",
     "markdown": "![Wii U](https://img.shields.io/badge/Wii%20U-8B8B8B?style=for-the-badge&logo=wiiu&logoColor=white)",
-    "category": "Game Consoles"
-  },
-  {
-    "id": "xbox-game-consoles",
-    "name": "Xbox",
-    "url": "https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white",
-    "markdown": "![Xbox](https://img.shields.io/badge/xbox-%23107C10.svg?style=for-the-badge&logo=xbox&logoColor=white)",
-    "category": "Game Consoles"
+    "categories": [
+      "Game Consoles"
+    ]
   },
   {
     "id": "adafruit",
     "name": "Adafruit",
     "url": "https://img.shields.io/badge/Adafruit-%23000000.svg?style=for-the-badge&logo=adafruit&logoColor=white",
     "markdown": "![Adafruit](https://img.shields.io/badge/Adafruit-%23000000.svg?style=for-the-badge&logo=adafruit&logoColor=white)",
-    "category": "Hardware"
+    "categories": [
+      "Hardware"
+    ]
   },
   {
     "id": "alienware",
     "name": "Alienware",
     "url": "https://img.shields.io/badge/Alienware-%23541BAE.svg?style=for-the-badge&logo=alienware&logoColor=white",
     "markdown": "![Alienware](https://img.shields.io/badge/Alienware-%23541BAE.svg?style=for-the-badge&logo=alienware&logoColor=white)",
-    "category": "Hardware"
+    "categories": [
+      "Hardware"
+    ]
   },
   {
     "id": "msi",
     "name": "MSI",
     "url": "https://img.shields.io/badge/msi-%23000000.svg?style=for-the-badge&logo=msi&logoColor=%23FF0000",
     "markdown": "![MSI](https://img.shields.io/badge/msi-%23000000.svg?style=for-the-badge&logo=msi&logoColor=%23FF0000)",
-    "category": "Hardware"
+    "categories": [
+      "Hardware"
+    ]
   },
   {
     "id": "alibaba-cloud",
     "name": "Alibaba Cloud",
     "url": "https://img.shields.io/badge/AlibabaCloud-%23FF6701.svg?style=for-the-badge&logo=alibabacloud&logoColor=white",
     "markdown": "![Alibaba Cloud](https://img.shields.io/badge/AlibabaCloud-%23FF6701.svg?style=for-the-badge&logo=alibabacloud&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "asana",
     "name": "Asana",
     "url": "https://img.shields.io/badge/asana-F06A6A.svg?style=for-the-badge&logo=asana&logoColor=white",
     "markdown": "![Asana](https://img.shields.io/badge/asana-F06A6A.svg?style=for-the-badge&logo=asana&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "aws",
     "name": "AWS",
     "url": "https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white",
     "markdown": "![AWS](https://img.shields.io/badge/AWS-%23FF9900.svg?style=for-the-badge&logo=amazon-aws&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "azure",
     "name": "Azure",
     "url": "https://img.shields.io/badge/azure-%230072C6.svg?style=for-the-badge&logo=microsoftazure&logoColor=white",
     "markdown": "![Azure](https://img.shields.io/badge/azure-%230072C6.svg?style=for-the-badge&logo=microsoftazure&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "clickup",
     "name": "Clickup",
     "url": "https://img.shields.io/badge/clickup-7B68EE.svg?style=for-the-badge&logo=clickup&logoColor=white",
     "markdown": "![ClickUp](https://img.shields.io/badge/clickup-7B68EE.svg?style=for-the-badge&logo=clickup&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "cloudflare",
     "name": "Cloudflare",
     "url": "https://img.shields.io/badge/Cloudflare-F38020?style=for-the-badge&logo=Cloudflare&logoColor=white",
     "markdown": "![Cloudflare](https://img.shields.io/badge/Cloudflare-F38020?style=for-the-badge&logo=Cloudflare&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "codeberg",
     "name": "Codeberg",
     "url": "https://img.shields.io/badge/Codeberg-2185D0?style=for-the-badge&logo=Codeberg&logoColor=white",
     "markdown": "![Codeberg](https://img.shields.io/badge/Codeberg-2185D0?style=for-the-badge&logo=Codeberg&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "datadog",
     "name": "Datadog",
     "url": "https://img.shields.io/badge/datadog-%23632CA6.svg?style=for-the-badge&logo=datadog&logoColor=white",
     "markdown": "![Datadog](https://img.shields.io/badge/datadog-%23632CA6.svg?style=for-the-badge&logo=datadog&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "digitalocean",
     "name": "DigitalOcean",
     "url": "https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white",
     "markdown": "![DigitalOcean](https://img.shields.io/badge/DigitalOcean-%230167ff.svg?style=for-the-badge&logo=digitalOcean&logoColor=white)",
-    "category": "SaaS"
-  },
-  {
-    "id": "firebase-saas",
-    "name": "Firebase",
-    "url": "https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase",
-    "markdown": "![Firebase](https://img.shields.io/badge/firebase-%23039BE5.svg?style=for-the-badge&logo=firebase)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "github-pages",
     "name": "Github Pages",
     "url": "https://img.shields.io/badge/github%20pages-121013?style=for-the-badge&logo=github&logoColor=white",
     "markdown": "![Github Pages](https://img.shields.io/badge/github%20pages-121013?style=for-the-badge&logo=github&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "glitch",
     "name": "Glitch",
     "url": "https://img.shields.io/badge/glitch-%233333FF.svg?style=for-the-badge&logo=glitch&logoColor=white",
     "markdown": "![Glitch](https://img.shields.io/badge/glitch-%233333FF.svg?style=for-the-badge&logo=glitch&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "google-cloud",
     "name": "Google Cloud",
     "url": "https://img.shields.io/badge/GoogleCloud-%234285F4.svg?style=for-the-badge&logo=google-cloud&logoColor=white",
     "markdown": "![Google Cloud](https://img.shields.io/badge/GoogleCloud-%234285F4.svg?style=for-the-badge&logo=google-cloud&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "heroku",
     "name": "Heroku",
     "url": "https://img.shields.io/badge/heroku-%23430098.svg?style=for-the-badge&logo=heroku&logoColor=white",
     "markdown": "![Heroku](https://img.shields.io/badge/heroku-%23430098.svg?style=for-the-badge&logo=heroku&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "hostinger",
     "name": "Hostinger",
     "url": "https://img.shields.io/badge/hostinger-%23673DE6.svg?style=for-the-badge&logo=hostinger&logoColor=white",
     "markdown": "![Hostinger](https://img.shields.io/badge/hostinger-%23673DE6.svg?style=for-the-badge&logo=hostinger&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "infomaniak",
     "name": "Infomaniak",
     "url": "https://img.shields.io/badge/infomaniak-%230098FF?style=for-the-badge&logo=infomaniak&logoColor=white",
     "markdown": "![Infomaniak](https://img.shields.io/badge/infomaniak-%230098FF?style=for-the-badge&logo=infomaniak&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "linear",
     "name": "Linear",
     "url": "https://img.shields.io/badge/linear-5E6AD2.svg?style=for-the-badge&logo=linear&logoColor=white",
     "markdown": "![Linear](https://img.shields.io/badge/linear-5E6AD2.svg?style=for-the-badge&logo=linear&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "linode",
     "name": "Linode",
     "url": "https://img.shields.io/badge/linode-00A95C?style=for-the-badge&logo=linode&logoColor=white",
     "markdown": "![Linode](https://img.shields.io/badge/linode-00A95C?style=for-the-badge&logo=linode&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "netlify",
     "name": "Netlify",
     "url": "https://img.shields.io/badge/netlify-%23000000.svg?style=for-the-badge&logo=netlify&logoColor=#00C7B7",
     "markdown": "![Netlify](https://img.shields.io/badge/netlify-%23000000.svg?style=for-the-badge&logo=netlify&logoColor=#00C7B7)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "openstack",
     "name": "OpenStack",
     "url": "https://img.shields.io/badge/Openstack-%23f01742.svg?style=for-the-badge&logo=openstack&logoColor=white",
     "markdown": "![OpenStack](https://img.shields.io/badge/Openstack-%23f01742.svg?style=for-the-badge&logo=openstack&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "oracle",
     "name": "Oracle",
     "url": "https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white",
     "markdown": "![Oracle](https://img.shields.io/badge/Oracle-F80000?style=for-the-badge&logo=oracle&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "ovh",
     "name": "OVH",
     "url": "https://img.shields.io/badge/ovh-%23123F6D.svg?style=for-the-badge&logo=ovh&logoColor=#123F6D",
     "markdown": "![OVH](https://img.shields.io/badge/ovh-%23123F6D.svg?style=for-the-badge&logo=ovh&logoColor=#123F6D)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "proxmox",
     "name": "Proxmox",
     "url": "https://img.shields.io/badge/proxmox-proxmox?style=for-the-badge&logo=proxmox&logoColor=%23E57000&labelColor=%232b2a33&color=%232b2a33",
     "markdown": "![Proxmox](https://img.shields.io/badge/proxmox-proxmox?style=for-the-badge&logo=proxmox&logoColor=%23E57000&labelColor=%232b2a33&color=%232b2a33)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "pythonanywhere",
     "name": "PythonAnywhere",
     "url": "https://img.shields.io/badge/pythonanywhere-%232F9FD7.svg?style=for-the-badge&logo=pythonanywhere&logoColor=151515",
     "markdown": "![PythonAnywhere](https://img.shields.io/badge/pythonanywhere-%232F9FD7.svg?style=for-the-badge&logo=pythonanywhere&logoColor=151515)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "render",
     "name": "Render",
     "url": "https://img.shields.io/badge/Render-%46E3B7.svg?style=for-the-badge&logo=render&logoColor=white",
     "markdown": "![Render](https://img.shields.io/badge/Render-%46E3B7.svg?style=for-the-badge&logo=render&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "scaleway",
     "name": "Scaleway",
     "url": "https://img.shields.io/badge/SCALEWAY-%234f0599.svg?style=for-the-badge&logo=scaleway&logoColor=white",
     "markdown": "![Scaleway](https://img.shields.io/badge/SCALEWAY-%234f0599.svg?style=for-the-badge&logo=scaleway&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "vercel",
     "name": "Vercel",
     "url": "https://img.shields.io/badge/vercel-%23000000.svg?style=for-the-badge&logo=vercel&logoColor=white",
     "markdown": "![Vercel](https://img.shields.io/badge/vercel-%23000000.svg?style=for-the-badge&logo=vercel&logoColor=white)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "vultr",
     "name": "Vultr",
     "url": "https://img.shields.io/badge/Vultr-007BFC.svg?style=for-the-badge&logo=vultr",
     "markdown": "![Vultr](https://img.shields.io/badge/Vultr-007BFC.svg?style=for-the-badge&logo=vultr)",
-    "category": "SaaS"
+    "categories": [
+      "SaaS"
+    ]
   },
   {
     "id": "android-studio",
     "name": "Android Studio",
     "url": "https://img.shields.io/badge/Android%20Studio-3DDC84.svg?style=for-the-badge&logo=android-studio&logoColor=white",
     "markdown": "![Android Studio](https://img.shields.io/badge/Android%20Studio-3DDC84.svg?style=for-the-badge&logo=android-studio&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "arduino-ide",
     "name": "Arduino IDE",
     "url": "https://img.shields.io/badge/Arduino%20IDE-%2300979D.svg?style=for-the-badge&logo=Arduino&logoColor=white",
     "markdown": "![Arduino IDE](https://img.shields.io/badge/Arduino%20IDE-%2300979D.svg?style=for-the-badge&logo=Arduino&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "atom",
     "name": "Atom",
     "url": "https://img.shields.io/badge/Atom-%2366595C.svg?style=for-the-badge&logo=atom&logoColor=white",
     "markdown": "![Atom](https://img.shields.io/badge/Atom-%2366595C.svg?style=for-the-badge&logo=atom&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "clion",
     "name": "CLion",
     "url": "https://img.shields.io/badge/CLion-black?style=for-the-badge&logo=clion&logoColor=white",
     "markdown": "![CLion](https://img.shields.io/badge/CLion-black?style=for-the-badge&logo=clion&logoColor=white)",
-    "category": "IDEs"
-  },
-  {
-    "id": "codepen-ides",
-    "name": "CodePen",
-    "url": "https://img.shields.io/badge/CodePen-white?style=for-the-badge&logo=codepen&logoColor=black",
-    "markdown": "![CodePen](https://img.shields.io/badge/CodePen-white?style=for-the-badge&logo=codepen&logoColor=black)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "codesandbox",
     "name": "CodeSandbox",
     "url": "https://img.shields.io/badge/Codesandbox-040404?style=for-the-badge&logo=codesandbox&logoColor=DBDBDB",
     "markdown": "![CodeSandbox](https://img.shields.io/badge/Codesandbox-040404?style=for-the-badge&logo=codesandbox&logoColor=DBDBDB)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "cursor",
     "name": "Cursor",
     "url": "https://img.shields.io/badge/Cursor-%23000000?style=for-the-badge&logo=Cursor&logoColor=white",
     "markdown": "![Cursor](https://img.shields.io/badge/Cursor-%23000000?style=for-the-badge&logo=Cursor&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "datagrip",
     "name": "Datagrip",
     "url": "https://img.shields.io/badge/DataGrip-%23000000.svg?style=for-the-badge&logo=DataGrip&logoColor=white",
     "markdown": "![Datagrip](https://img.shields.io/badge/DataGrip-%23000000.svg?style=for-the-badge&logo=DataGrip&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "doxygen",
     "name": "Doxygen",
     "url": "https://img.shields.io/badge/doxygen-2C4AA8?style=for-the-badge&logo=doxygen&logoColor=white",
     "markdown": "![Doxygen](https://img.shields.io/badge/doxygen-2C4AA8?style=for-the-badge&logo=doxygen&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "eclipse",
     "name": "Eclipse",
     "url": "https://img.shields.io/badge/Eclipse-FE7A16.svg?style=for-the-badge&logo=Eclipse&logoColor=white",
     "markdown": "![Eclipse](https://img.shields.io/badge/Eclipse-FE7A16.svg?style=for-the-badge&logo=Eclipse&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "emacs",
     "name": "Emacs",
     "url": "https://img.shields.io/badge/Emacs-%237F5AB6.svg?&style=for-the-badge&logo=gnu-emacs&logoColor=white",
     "markdown": "![Emacs](https://img.shields.io/badge/Emacs-%237F5AB6.svg?&style=for-the-badge&logo=gnu-emacs&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "goland",
     "name": "GoLand",
     "url": "https://img.shields.io/badge/GoLand-0f0f0f?&style=for-the-badge&logo=goland&logoColor=white",
     "markdown": "![GoLand](https://img.shields.io/badge/GoLand-0f0f0f?&style=for-the-badge&logo=goland&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "google-colab",
     "name": "Google Colab",
     "url": "https://img.shields.io/badge/Google%20Colab-%23F9A825.svg?style=for-the-badge&logo=googlecolab&logoColor=white",
     "markdown": "![Google Colab](https://img.shields.io/badge/Google%20Colab-%23F9A825.svg?style=for-the-badge&logo=googlecolab&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "helix",
     "name": "Helix",
     "url": "https://img.shields.io/badge/Helix-%2328153e.svg?style=for-the-badge&logo=helix&logoColor=white",
     "markdown": "![Helix](https://img.shields.io/badge/Helix-%2328153e.svg?style=for-the-badge&logo=helix&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "intellij-idea",
     "name": "IntelliJ IDEA",
     "url": "https://img.shields.io/badge/IntelliJIDEA-000000.svg?style=for-the-badge&logo=intellij-idea&logoColor=white",
     "markdown": "![IntelliJ IDEA](https://img.shields.io/badge/IntelliJIDEA-000000.svg?style=for-the-badge&logo=intellij-idea&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "jetbrains",
     "name": "JetBrains",
     "url": "https://img.shields.io/badge/jetbrains-%23000000.svg?style=for-the-badge&logo=jetbrains&logoColor=white",
     "markdown": "![JetBrains](https://img.shields.io/badge/jetbrains-%23000000.svg?style=for-the-badge&logo=jetbrains&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "jupyter-notebook",
     "name": "Jupyter Notebook",
     "url": "https://img.shields.io/badge/jupyter-%23FA0F00.svg?style=for-the-badge&logo=jupyter&logoColor=white",
     "markdown": "![Jupyter Notebook](https://img.shields.io/badge/jupyter-%23FA0F00.svg?style=for-the-badge&logo=jupyter&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "neovim",
     "name": "Neovim",
     "url": "https://img.shields.io/badge/NeoVim-%2357A143.svg?&style=for-the-badge&logo=neovim&logoColor=white",
     "markdown": "![Neovim](https://img.shields.io/badge/NeoVim-%2357A143.svg?&style=for-the-badge&logo=neovim&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "netbeans-ide",
     "name": "NetBeans IDE",
     "url": "https://img.shields.io/badge/NetBeansIDE-1B6AC6.svg?style=for-the-badge&logo=apache-netbeans-ide&logoColor=white",
     "markdown": "![NetBeans IDE](https://img.shields.io/badge/NetBeansIDE-1B6AC6.svg?style=for-the-badge&logo=apache-netbeans-ide&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "notepad++",
     "name": "Notepad++",
     "url": "https://img.shields.io/badge/Notepad++-90E59A.svg?style=for-the-badge&logo=notepad%2b%2b&logoColor=black",
     "markdown": "![Notepad++](https://img.shields.io/badge/Notepad++-90E59A.svg?style=for-the-badge&logo=notepad%2b%2b&logoColor=black)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "obsidian",
     "name": "Obsidian",
     "url": "https://img.shields.io/badge/Obsidian-%23483699.svg?style=for-the-badge&logo=obsidian&logoColor=white",
     "markdown": "![Obsidian](https://img.shields.io/badge/Obsidian-%23483699.svg?style=for-the-badge&logo=obsidian&logoColor=white)",
-    "category": "IDEs"
-  },
-  {
-    "id": "p5js-editor",
-    "name": "P5js Editor",
-    "url": "https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF",
-    "markdown": "![p5js Editor](https://img.shields.io/badge/p5.js-ED225D?style=for-the-badge&logo=p5.js&logoColor=FFFFFF)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "phpstorm",
     "name": "PhpStorm",
     "url": "https://img.shields.io/badge/phpstorm-143?style=for-the-badge&logo=phpstorm&logoColor=black&color=black&labelColor=darkorchid",
     "markdown": "![PhpStorm](https://img.shields.io/badge/phpstorm-143?style=for-the-badge&logo=phpstorm&logoColor=black&color=black&labelColor=darkorchid)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "pycharm",
     "name": "PyCharm",
     "url": "https://img.shields.io/badge/pycharm-143?style=for-the-badge&logo=pycharm&logoColor=black&color=black&labelColor=green",
     "markdown": "![PyCharm](https://img.shields.io/badge/pycharm-143?style=for-the-badge&logo=pycharm&logoColor=black&color=black&labelColor=green)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "replit",
     "name": "Replit",
     "url": "https://img.shields.io/badge/Replit-DD1200?style=for-the-badge&logo=Replit&logoColor=white",
     "markdown": "![Replit](https://img.shields.io/badge/Replit-DD1200?style=for-the-badge&logo=Replit&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "resharper",
     "name": "ReSharper",
     "url": "https://img.shields.io/badge/ReSharper-%23000000.svg?style=for-the-badge&logo=ReSharper&logoColor=white",
     "markdown": "![ReSharper](https://img.shields.io/badge/ReSharper-%23000000.svg?style=for-the-badge&logo=ReSharper&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "rider",
     "name": "Rider",
     "url": "https://img.shields.io/badge/Rider-000000.svg?style=for-the-badge&logo=Rider&logoColor=white&color=black&labelColor=crimson",
     "markdown": "![Rider](https://img.shields.io/badge/Rider-000000.svg?style=for-the-badge&logo=Rider&logoColor=white&color=black&labelColor=crimson)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "rstudio",
     "name": "RStudio",
     "url": "https://img.shields.io/badge/RStudio-4285F4?style=for-the-badge&logo=rstudio&logoColor=white",
     "markdown": "![RStudio](https://img.shields.io/badge/RStudio-4285F4?style=for-the-badge&logo=rstudio&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "rubymine",
     "name": "RubyMine",
     "url": "https://img.shields.io/badge/RubyMine-%23000000.svg?style=for-the-badge&logo=RubyMine&logoColor=white",
     "markdown": "![RubyMine](https://img.shields.io/badge/RubyMine-%23000000.svg?style=for-the-badge&logo=RubyMine&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "spyder",
     "name": "Spyder",
     "url": "https://img.shields.io/badge/Spyder-838485?style=for-the-badge&logo=spyder%20ide&logoColor=maroon",
     "markdown": "![Spyder](https://img.shields.io/badge/Spyder-838485?style=for-the-badge&logo=spyder%20ide&logoColor=maroon)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "sublime-text",
     "name": "Sublime Text",
     "url": "https://img.shields.io/badge/sublime_text-%23575757.svg?style=for-the-badge&logo=sublime-text&logoColor=important",
     "markdown": "![Sublime Text](https://img.shields.io/badge/sublime_text-%23575757.svg?style=for-the-badge&logo=sublime-text&logoColor=important)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "vim",
     "name": "Vim",
     "url": "https://img.shields.io/badge/VIM-%2311AB00.svg?style=for-the-badge&logo=vim&logoColor=white",
     "markdown": "![Vim](https://img.shields.io/badge/VIM-%2311AB00.svg?style=for-the-badge&logo=vim&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "visual-studio",
     "name": "Visual Studio",
     "url": "https://img.shields.io/badge/Visual%20Studio-5C2D91.svg?style=for-the-badge&logo=visual-studio&logoColor=white",
     "markdown": "![Visual Studio](https://img.shields.io/badge/Visual%20Studio-5C2D91.svg?style=for-the-badge&logo=visual-studio&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "visual-studio-code",
     "name": "Visual Studio Code",
     "url": "https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white",
     "markdown": "![Visual Studio Code](https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "vs-code-insiders",
     "name": "VS Code Insiders",
     "url": "https://img.shields.io/badge/VS%20Code%20Insiders-35b393.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white",
     "markdown": "![VS Code Insiders](https://img.shields.io/badge/VS%20Code%20Insiders-35b393.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "webstorm",
     "name": "WebStorm",
     "url": "https://img.shields.io/badge/webstorm-143?style=for-the-badge&logo=webstorm&logoColor=white&color=black",
     "markdown": "![WebStorm](https://img.shields.io/badge/webstorm-143?style=for-the-badge&logo=webstorm&logoColor=white&color=black)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "xcode",
     "name": "Xcode",
     "url": "https://img.shields.io/badge/Xcode-007ACC?style=for-the-badge&logo=Xcode&logoColor=white",
     "markdown": "![Xcode](https://img.shields.io/badge/Xcode-007ACC?style=for-the-badge&logo=Xcode&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "zed",
     "name": "Zed",
     "url": "https://img.shields.io/badge/zedindustries-084CCF.svg?style=for-the-badge&logo=zedindustries&logoColor=white",
     "markdown": "![Zed](https://img.shields.io/badge/zedindustries-084CCF.svg?style=for-the-badge&logo=zedindustries&logoColor=white)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "zend",
     "name": "Zend",
     "url": "https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA",
     "markdown": "![Zend](https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA)",
-    "category": "IDEs"
+    "categories": [
+      "IDEs"
+    ]
   },
   {
     "id": "apache-groovy",
     "name": "Apache Groovy",
     "url": "https://img.shields.io/badge/Apache%20Groovy-4298B8.svg?style=for-the-badge&logo=Apache+Groovy&logoColor=white",
     "markdown": "![Apache Groovy](https://img.shields.io/badge/Apache%20Groovy-4298B8.svg?style=for-the-badge&logo=Apache+Groovy&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "assembly-script",
     "name": "Assembly Script",
     "url": "https://img.shields.io/badge/assembly%20script-%23000000.svg?style=for-the-badge&logo=assemblyscript&logoColor=white",
     "markdown": "![AssemblyScript](https://img.shields.io/badge/assembly%20script-%23000000.svg?style=for-the-badge&logo=assemblyscript&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "bash-script",
     "name": "Bash Script",
     "url": "https://img.shields.io/badge/bash_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white",
     "markdown": "![Bash Script](https://img.shields.io/badge/bash_script-%23121011.svg?style=for-the-badge&logo=gnu-bash&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "c",
     "name": "C",
     "url": "https://img.shields.io/badge/c-%2300599C.svg?style=for-the-badge&logo=c&logoColor=white",
     "markdown": "![C](https://img.shields.io/badge/c-%2300599C.svg?style=for-the-badge&logo=c&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "c%23",
     "name": "C#",
     "url": "https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white",
     "markdown": "![C#](https://img.shields.io/badge/c%23-%23239120.svg?style=for-the-badge&logo=csharp&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "c++",
     "name": "C++",
     "url": "https://img.shields.io/badge/c++-%2300599C.svg?style=for-the-badge&logo=c%2B%2B&logoColor=white",
     "markdown": "![C++](https://img.shields.io/badge/c++-%2300599C.svg?style=for-the-badge&logo=c%2B%2B&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "clojure",
     "name": "Clojure",
     "url": "https://img.shields.io/badge/Clojure-%23Clojure.svg?style=for-the-badge&logo=Clojure&logoColor=Clojure",
     "markdown": "![Clojure](https://img.shields.io/badge/Clojure-%23Clojure.svg?style=for-the-badge&logo=Clojure&logoColor=Clojure)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "coffeescript",
     "name": "CoffeeScript",
     "url": "https://img.shields.io/badge/CoffeeScript-%232F2625.svg?style=for-the-badge&logo=CoffeeScript&logoColor=white",
     "markdown": "![CoffeeScript](https://img.shields.io/badge/CoffeeScript-%232F2625.svg?style=for-the-badge&logo=CoffeeScript&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "crystal",
     "name": "Crystal",
     "url": "https://img.shields.io/badge/crystal-%23000000.svg?style=for-the-badge&logo=crystal&logoColor=white",
     "markdown": "![Crystal](https://img.shields.io/badge/crystal-%23000000.svg?style=for-the-badge&logo=crystal&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "css",
     "name": "CSS",
     "url": "https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white",
     "markdown": "![CSS](https://img.shields.io/badge/css-%23663399.svg?style=for-the-badge&logo=css&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "css3",
     "name": "CSS3",
     "url": "https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white",
     "markdown": "![CSS3](https://img.shields.io/badge/css3-%231572B6.svg?style=for-the-badge&logo=css3&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "dart",
     "name": "Dart",
     "url": "https://img.shields.io/badge/dart-%230175C2.svg?style=for-the-badge&logo=dart&logoColor=white",
     "markdown": "![Dart](https://img.shields.io/badge/dart-%230175C2.svg?style=for-the-badge&logo=dart&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "delphi",
     "name": "Delphi",
     "url": "https://img.shields.io/badge/delphi-%23B21F24?style=for-the-badge&logo=delphi&logoColor=white",
     "markdown": "![Delphi](https://img.shields.io/badge/delphi-%23B21F24?style=for-the-badge&logo=delphi&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "dgraph",
     "name": "Dgraph",
     "url": "https://img.shields.io/badge/dgraph-%23E50695.svg?style=for-the-badge&logo=dgraph&logoColor=white",
     "markdown": "![Dgraph](https://img.shields.io/badge/dgraph-%23E50695.svg?style=for-the-badge&logo=dgraph&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "elixir",
     "name": "Elixir",
     "url": "https://img.shields.io/badge/elixir-%234B275F.svg?style=for-the-badge&logo=elixir&logoColor=white",
     "markdown": "![Elixir](https://img.shields.io/badge/elixir-%234B275F.svg?style=for-the-badge&logo=elixir&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "elm",
     "name": "Elm",
     "url": "https://img.shields.io/badge/Elm-60B5CC?style=for-the-badge&logo=elm&logoColor=white",
     "markdown": "![Elm](https://img.shields.io/badge/Elm-60B5CC?style=for-the-badge&logo=elm&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "erlang",
     "name": "Erlang",
     "url": "https://img.shields.io/badge/Erlang-white.svg?style=for-the-badge&logo=erlang&logoColor=a90533",
     "markdown": "![Erlang](https://img.shields.io/badge/Erlang-white.svg?style=for-the-badge&logo=erlang&logoColor=a90533)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "fortran",
     "name": "Fortran",
     "url": "https://img.shields.io/badge/Fortran-%23734F96.svg?style=for-the-badge&logo=fortran&logoColor=white",
     "markdown": "![Fortran](https://img.shields.io/badge/Fortran-%23734F96.svg?style=for-the-badge&logo=fortran&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "gdscript",
     "name": "GDScript",
     "url": "https://img.shields.io/badge/GDScript-%2374267B.svg?style=for-the-badge&logo=godotengine&logoColor=white",
     "markdown": "![GDScript](https://img.shields.io/badge/GDScript-%2374267B.svg?style=for-the-badge&logo=godotengine&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "gleam",
     "name": "Gleam",
     "url": "https://img.shields.io/badge/gleam-%23FFAFF3.svg?style=for-the-badge&logo=gleam&logoColor=white",
     "markdown": "![gleam](https://img.shields.io/badge/gleam-%23FFAFF3.svg?style=for-the-badge&logo=gleam&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "go/golang",
     "name": "Go/Golang",
     "url": "https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white",
     "markdown": "![Go](https://img.shields.io/badge/go-%2300ADD8.svg?style=for-the-badge&logo=go&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "graphql",
     "name": "GraphQL",
     "url": "https://img.shields.io/badge/-GraphQL-E10098?style=for-the-badge&logo=graphql&logoColor=white",
     "markdown": "![GraphQL](https://img.shields.io/badge/-GraphQL-E10098?style=for-the-badge&logo=graphql&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "haskell",
     "name": "Haskell",
     "url": "https://img.shields.io/badge/Haskell-5e5086?style=for-the-badge&logo=haskell&logoColor=white",
     "markdown": "![Haskell](https://img.shields.io/badge/Haskell-5e5086?style=for-the-badge&logo=haskell&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "html5",
     "name": "HTML5",
     "url": "https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white",
     "markdown": "![HTML5](https://img.shields.io/badge/html5-%23E34F26.svg?style=for-the-badge&logo=html5&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "java",
     "name": "Java",
     "url": "https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white",
     "markdown": "![Java](https://img.shields.io/badge/java-%23ED8B00.svg?style=for-the-badge&logo=openjdk&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "javascript",
     "name": "JavaScript",
     "url": "https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E",
     "markdown": "![JavaScript](https://img.shields.io/badge/javascript-%23323330.svg?style=for-the-badge&logo=javascript&logoColor=%23F7DF1E)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "julia",
     "name": "Julia",
     "url": "https://img.shields.io/badge/-Julia-9558B2?style=for-the-badge&logo=julia&logoColor=white",
     "markdown": "![Julia](https://img.shields.io/badge/-Julia-9558B2?style=for-the-badge&logo=julia&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "kotlin",
     "name": "Kotlin",
     "url": "https://img.shields.io/badge/kotlin-%237F52FF.svg?style=for-the-badge&logo=kotlin&logoColor=white",
     "markdown": "![Kotlin](https://img.shields.io/badge/kotlin-%237F52FF.svg?style=for-the-badge&logo=kotlin&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "labview",
     "name": "LabView",
     "url": "https://img.shields.io/badge/labview-%23FFDB00.svg?style=for-the-badge&logo=labview&logoColor=black",
     "markdown": "![LabVIEW](https://img.shields.io/badge/labview-%23FFDB00.svg?style=for-the-badge&logo=labview&logoColor=black)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "latex",
     "name": "LaTeX",
     "url": "https://img.shields.io/badge/latex-%23008080.svg?style=for-the-badge&logo=latex&logoColor=white",
     "markdown": "![LaTeX](https://img.shields.io/badge/latex-%23008080.svg?style=for-the-badge&logo=latex&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "lua",
     "name": "Lua",
     "url": "https://img.shields.io/badge/lua-%232C2D72.svg?style=for-the-badge&logo=lua&logoColor=white",
     "markdown": "![Lua](https://img.shields.io/badge/lua-%232C2D72.svg?style=for-the-badge&logo=lua&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "markdown",
     "name": "Markdown",
     "url": "https://img.shields.io/badge/markdown-%23000000.svg?style=for-the-badge&logo=markdown&logoColor=white",
     "markdown": "![Markdown](https://img.shields.io/badge/markdown-%23000000.svg?style=for-the-badge&logo=markdown&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "micropython",
     "name": "MicroPython",
     "url": "https://img.shields.io/badge/micropython-%232B2728.svg?style=for-the-badge&logo=micropython&logoColor=white",
     "markdown": "![MicroPython](https://img.shields.io/badge/micropython-%232B2728.svg?style=for-the-badge&logo=micropython&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "nim",
     "name": "Nim",
     "url": "https://img.shields.io/badge/nim-%23FFE953.svg?style=for-the-badge&logo=nim&logoColor=white",
     "markdown": "![Nim](https://img.shields.io/badge/nim-%23FFE953.svg?style=for-the-badge&logo=nim&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "nix",
     "name": "Nix",
     "url": "https://img.shields.io/badge/NIX-5277C3.svg?style=for-the-badge&logo=NixOS&logoColor=white",
     "markdown": "![Nix](https://img.shields.io/badge/NIX-5277C3.svg?style=for-the-badge&logo=NixOS&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "objective-c",
     "name": "Objective-C",
     "url": "https://img.shields.io/badge/OBJECTIVE--C-%233A95E3.svg?style=for-the-badge&logo=apple&logoColor=white",
     "markdown": "![Objective-C](https://img.shields.io/badge/OBJECTIVE--C-%233A95E3.svg?style=for-the-badge&logo=apple&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "ocaml",
     "name": "OCaml",
     "url": "https://img.shields.io/badge/OCaml-%23E98407.svg?style=for-the-badge&logo=ocaml&logoColor=white",
     "markdown": "![OCaml](https://img.shields.io/badge/OCaml-%23E98407.svg?style=for-the-badge&logo=ocaml&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "octave",
     "name": "Octave",
     "url": "https://img.shields.io/badge/OCTAVE-darkblue?style=for-the-badge&logo=octave&logoColor=fcd683",
     "markdown": "![Octave](https://img.shields.io/badge/OCTAVE-darkblue?style=for-the-badge&logo=octave&logoColor=fcd683)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "org-mode",
     "name": "Org Mode",
     "url": "https://img.shields.io/badge/orgmode-%2377AA99.svg?style=for-the-badge&logo=org&logoColor=white",
     "markdown": "![Org Mode](https://img.shields.io/badge/orgmode-%2377AA99.svg?style=for-the-badge&logo=org&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "pascal",
     "name": "Pascal",
     "url": "https://img.shields.io/badge/pascal-%230288d1?style=for-the-badge&logo=lazarus&logoColor=white",
     "markdown": "![Pascal](https://img.shields.io/badge/pascal-%230288d1?style=for-the-badge&logo=lazarus&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "perl",
     "name": "Perl",
     "url": "https://img.shields.io/badge/perl-%2339457E.svg?style=for-the-badge&logo=perl&logoColor=white",
     "markdown": "![Perl](https://img.shields.io/badge/perl-%2339457E.svg?style=for-the-badge&logo=perl&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "php",
     "name": "PHP",
     "url": "https://img.shields.io/badge/php-%23777BB4.svg?style=for-the-badge&logo=php&logoColor=white",
     "markdown": "![PHP](https://img.shields.io/badge/php-%23777BB4.svg?style=for-the-badge&logo=php&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "powershell",
     "name": "PowerShell",
     "url": "https://img.shields.io/badge/PowerShell-%235391FE.svg?style=for-the-badge&logo=powershell&logoColor=white",
     "markdown": "![PowerShell](https://img.shields.io/badge/PowerShell-%235391FE.svg?style=for-the-badge&logo=powershell&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "python",
     "name": "Python",
     "url": "https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54",
     "markdown": "![Python](https://img.shields.io/badge/python-3670A0?style=for-the-badge&logo=python&logoColor=ffdd54)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "r",
     "name": "R",
     "url": "https://img.shields.io/badge/r-%23276DC3.svg?style=for-the-badge&logo=r&logoColor=white",
     "markdown": "![R](https://img.shields.io/badge/r-%23276DC3.svg?style=for-the-badge&logo=r&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "racket",
     "name": "Racket",
     "url": "https://img.shields.io/badge/Racket-%239F1D20.svg?style=for-the-badge&logo=racket&logoColor=white",
     "markdown": "![Racket](https://img.shields.io/badge/Racket-%239F1D20.svg?style=for-the-badge&logo=racket&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "rescript",
     "name": "ReScript",
     "url": "https://img.shields.io/badge/rescript-%2314162c?style=for-the-badge&logo=rescript&logoColor=e34c4c",
     "markdown": "![ReScript](https://img.shields.io/badge/rescript-%2314162c?style=for-the-badge&logo=rescript&logoColor=e34c4c)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "ruby",
     "name": "Ruby",
     "url": "https://img.shields.io/badge/ruby-%23CC342D.svg?style=for-the-badge&logo=ruby&logoColor=white",
     "markdown": "![Ruby](https://img.shields.io/badge/ruby-%23CC342D.svg?style=for-the-badge&logo=ruby&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "rust",
     "name": "Rust",
     "url": "https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white",
     "markdown": "![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=for-the-badge&logo=rust&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "scala",
     "name": "Scala",
     "url": "https://img.shields.io/badge/scala-%23DC322F.svg?style=for-the-badge&logo=scala&logoColor=white",
     "markdown": "![Scala](https://img.shields.io/badge/scala-%23DC322F.svg?style=for-the-badge&logo=scala&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "scratch",
     "name": "Scratch",
     "url": "https://img.shields.io/badge/Scratch-%23FF6600.svg?style=for-the-badge&logo=scratch&logoColor=white",
     "markdown": "![Scratch](https://img.shields.io/badge/Scratch-%23FF6600.svg?style=for-the-badge&logo=scratch&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "solidity",
     "name": "Solidity",
     "url": "https://img.shields.io/badge/Solidity-%23363636.svg?style=for-the-badge&logo=solidity&logoColor=white",
     "markdown": "![Solidity](https://img.shields.io/badge/Solidity-%23363636.svg?style=for-the-badge&logo=solidity&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "swift",
     "name": "Swift",
     "url": "https://img.shields.io/badge/swift-F54A2A?style=for-the-badge&logo=swift&logoColor=white",
     "markdown": "![Swift](https://img.shields.io/badge/swift-F54A2A?style=for-the-badge&logo=swift&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "typescript",
     "name": "TypeScript",
     "url": "https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white",
     "markdown": "![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "typst",
     "name": "Typst",
     "url": "https://img.shields.io/badge/typst-239DAD.svg?style=for-the-badge&logo=typst&logoColor=white",
     "markdown": "![Typst](https://img.shields.io/badge/typst-239DAD.svg?style=for-the-badge&logo=typst&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "webassembly",
     "name": "WebAssembly",
     "url": "https://img.shields.io/badge/webassembly-%23654FF0.svg?style=for-the-badge&logo=webassembly&logoColor=white",
     "markdown": "![WebAssembly](https://img.shields.io/badge/webassembly-%23654FF0.svg?style=for-the-badge&logo=webassembly&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "windows-terminal",
     "name": "Windows Terminal",
     "url": "https://img.shields.io/badge/Windows%20Terminal-%234D4D4D.svg?style=for-the-badge&logo=windows-terminal&logoColor=white",
     "markdown": "![Windows Terminal](https://img.shields.io/badge/Windows%20Terminal-%234D4D4D.svg?style=for-the-badge&logo=windows-terminal&logoColor=white)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "yaml",
     "name": "YAML",
     "url": "https://img.shields.io/badge/yaml-%23ffffff.svg?style=for-the-badge&logo=yaml&logoColor=151515",
     "markdown": "![YAML](https://img.shields.io/badge/yaml-%23ffffff.svg?style=for-the-badge&logo=yaml&logoColor=151515)",
-    "category": "Languages"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "zig",
     "name": "Zig",
     "url": "https://img.shields.io/badge/Zig-%23F7A41D.svg?style=for-the-badge&logo=zig&logoColor=white",
     "markdown": "![Zig](https://img.shields.io/badge/Zig-%23F7A41D.svg?style=for-the-badge&logo=zig&logoColor=white)",
-    "category": "Languages"
-  },
-  {
-    "id": "keras-ml-dl",
-    "name": "Keras",
-    "url": "https://img.shields.io/badge/Keras-%23D00000.svg?style=for-the-badge&logo=Keras&logoColor=white",
-    "markdown": "![Keras](https://img.shields.io/badge/Keras-%23D00000.svg?style=for-the-badge&logo=Keras&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "Languages"
+    ]
   },
   {
     "id": "matplotlib",
     "name": "Matplotlib",
     "url": "https://img.shields.io/badge/Matplotlib-%23ffffff.svg?style=for-the-badge&logo=Matplotlib&logoColor=black",
     "markdown": "![Matplotlib](https://img.shields.io/badge/Matplotlib-%23ffffff.svg?style=for-the-badge&logo=Matplotlib&logoColor=black)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "mlflow",
     "name": "mlflow",
     "url": "https://img.shields.io/badge/mlflow-%23d9ead3.svg?style=for-the-badge&logo=numpy&logoColor=blue",
     "markdown": "![mlflow](https://img.shields.io/badge/mlflow-%23d9ead3.svg?style=for-the-badge&logo=numpy&logoColor=blue)",
-    "category": "ML/DL"
-  },
-  {
-    "id": "numpy-ml-dl",
-    "name": "NumPy",
-    "url": "https://img.shields.io/badge/numpy-%23013243.svg?style=for-the-badge&logo=numpy&logoColor=white",
-    "markdown": "![NumPy](https://img.shields.io/badge/numpy-%23013243.svg?style=for-the-badge&logo=numpy&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "onnx",
     "name": "ONNX",
     "url": "https://img.shields.io/badge/onnx-%23ffffff.svg?style=for-the-badge&logo=onnx&logoColor=black",
     "markdown": "![ONNX](https://img.shields.io/badge/onnx-%23ffffff.svg?style=for-the-badge&logo=onnx&logoColor=black)",
-    "category": "ML/DL"
-  },
-  {
-    "id": "pandas-ml-dl",
-    "name": "Pandas",
-    "url": "https://img.shields.io/badge/pandas-%23150458.svg?style=for-the-badge&logo=pandas&logoColor=white",
-    "markdown": "![Pandas](https://img.shields.io/badge/pandas-%23150458.svg?style=for-the-badge&logo=pandas&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "plotly",
     "name": "Plotly",
     "url": "https://img.shields.io/badge/Plotly-%233F4F75.svg?style=for-the-badge&logo=plotly&logoColor=white",
     "markdown": "![Plotly](https://img.shields.io/badge/Plotly-%233F4F75.svg?style=for-the-badge&logo=plotly&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "polars",
     "name": "Polars",
     "url": "https://img.shields.io/badge/polars-0075ff?style=for-the-badge&logo=polars&logoColor=white",
     "markdown": "![Polars](https://img.shields.io/badge/polars-0075ff?style=for-the-badge&logo=polars&logoColor=white)",
-    "category": "ML/DL"
-  },
-  {
-    "id": "pytorch-ml-dl",
-    "name": "PyTorch",
-    "url": "https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=for-the-badge&logo=PyTorch&logoColor=white",
-    "markdown": "![PyTorch](https://img.shields.io/badge/PyTorch-%23EE4C2C.svg?style=for-the-badge&logo=PyTorch&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "pytorch-geometric",
     "name": "PyTorch Geometric",
     "url": "https://img.shields.io/badge/PyTorch%20Geometric-%233C2179.svg?style=for-the-badge&logo=pyg&logoColor=white",
     "markdown": "![PyTorch Geometric](https://img.shields.io/badge/PyTorch%20Geometric-%233C2179.svg?style=for-the-badge&logo=pyg&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "roboflow",
     "name": "Roboflow",
     "url": "https://img.shields.io/badge/roboflow-%23EE4C2C.svg?style=for-the-badge&logo=roboflow&logoColor=white",
     "markdown": "![Roboflow](https://img.shields.io/badge/roboflow-%23EE4C2C.svg?style=for-the-badge&logo=roboflow&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "scikit-learn",
     "name": "scikit-learn",
     "url": "https://img.shields.io/badge/scikit--learn-%23F7931E.svg?style=for-the-badge&logo=scikit-learn&logoColor=white",
     "markdown": "![scikit-learn](https://img.shields.io/badge/scikit--learn-%23F7931E.svg?style=for-the-badge&logo=scikit-learn&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "scipy",
     "name": "SciPy",
     "url": "https://img.shields.io/badge/SciPy-%230C55A5.svg?style=for-the-badge&logo=scipy&logoColor=%white",
     "markdown": "![SciPy](https://img.shields.io/badge/SciPy-%230C55A5.svg?style=for-the-badge&logo=scipy&logoColor=%white)",
-    "category": "ML/DL"
-  },
-  {
-    "id": "tensorflow-ml-dl",
-    "name": "TensorFlow",
-    "url": "https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=TensorFlow&logoColor=white",
-    "markdown": "![TensorFlow](https://img.shields.io/badge/TensorFlow-%23FF6F00.svg?style=for-the-badge&logo=TensorFlow&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "ultralytics",
     "name": "Ultralytics",
     "url": "https://img.shields.io/badge/ultralytics-%23111F68.svg?style=for-the-badge&logo=ultralytics&logoColor=white",
     "markdown": "![Ultralytics](https://img.shields.io/badge/ultralytics-%23111F68.svg?style=for-the-badge&logo=ultralytics&logoColor=white)",
-    "category": "ML/DL"
+    "categories": [
+      "ML/DL"
+    ]
   },
   {
     "id": "apple-music",
     "name": "Apple Music",
     "url": "https://img.shields.io/badge/Apple_Music-9933CC?style=for-the-badge&logo=apple-music&logoColor=white",
     "markdown": "![Apple Music](https://img.shields.io/badge/Apple_Music-9933CC?style=for-the-badge&logo=apple-music&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "audacity",
     "name": "Audacity",
     "url": "https://img.shields.io/badge/Audacity-0000CC?style=for-the-badge&logo=audacity&logoColor=white",
     "markdown": "![Audacity](https://img.shields.io/badge/Audacity-0000CC?style=for-the-badge&logo=audacity&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "deezer",
     "name": "Deezer",
     "url": "https://img.shields.io/badge/Deezer-FEAA2D?style=for-the-badge&logo=deezer&logoColor=white",
     "markdown": "![Deezer](https://img.shields.io/badge/Deezer-FEAA2D?style=for-the-badge&logo=deezer&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "last.fm",
     "name": "Last.fm",
     "url": "https://img.shields.io/badge/last.fm-D51007?style=for-the-badge&logo=last.fm&logoColor=white",
     "markdown": "![Last.fm](https://img.shields.io/badge/last.fm-D51007?style=for-the-badge&logo=last.fm&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "musixmatch",
     "name": "Musixmatch",
     "url": "https://img.shields.io/badge/Musixmatch-%23FF5353.svg?style=for-the-badge&logo=Musixmatch&logoColor=white",
     "markdown": "![Musixmatch](https://img.shields.io/badge/Musixmatch-%23FF5353.svg?style=for-the-badge&logo=Musixmatch&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "shazam",
     "name": "Shazam",
     "url": "https://img.shields.io/badge/shazam-1476FE?style=for-the-badge&logo=shazam&logoColor=white",
     "markdown": "![Shazam](https://img.shields.io/badge/shazam-1476FE?style=for-the-badge&logo=shazam&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "soundcloud",
     "name": "SoundCloud",
     "url": "https://img.shields.io/badge/soundcloud-FF5500?style=for-the-badge&logo=soundcloud&logoColor=white",
     "markdown": "![SoundCloud](https://img.shields.io/badge/soundcloud-FF5500?style=for-the-badge&logo=soundcloud&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "spotify",
     "name": "Spotify",
     "url": "https://img.shields.io/badge/Spotify-1ED760?style=for-the-badge&logo=spotify&logoColor=white",
     "markdown": "![Spotify](https://img.shields.io/badge/Spotify-1ED760?style=for-the-badge&logo=spotify&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "tidal",
     "name": "Tidal",
     "url": "https://img.shields.io/badge/tidal-00FFFF?style=for-the-badge&logo=tidal&logoColor=black",
     "markdown": "![Tidal](https://img.shields.io/badge/tidal-00FFFF?style=for-the-badge&logo=tidal&logoColor=black)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "youtube-music",
     "name": "YouTube Music",
     "url": "https://img.shields.io/badge/YouTube_Music-FF0000?style=for-the-badge&logo=youtube-music&logoColor=white",
     "markdown": "![YouTube Music](https://img.shields.io/badge/YouTube_Music-FF0000?style=for-the-badge&logo=youtube-music&logoColor=white)",
-    "category": "Music"
+    "categories": [
+      "Music"
+    ]
   },
   {
     "id": "google-sheets",
     "name": "Google Sheets",
     "url": "https://img.shields.io/badge/Google%20Sheets-%2334A853?style=for-the-badge&logo=googlesheets&logoColor=white",
     "markdown": "![Google Sheets](https://img.shields.io/badge/Google%20Sheets-%2334A853?style=for-the-badge&logo=googlesheets&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "libreoffice",
     "name": "LibreOffice",
     "url": "https://img.shields.io/badge/LibreOffice-%2318A303?style=for-the-badge&logo=LibreOffice&logoColor=white",
     "markdown": "![LibreOffice](https://img.shields.io/badge/LibreOffice-%2318A303?style=for-the-badge&logo=LibreOffice&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft",
     "name": "Microsoft",
     "url": "https://img.shields.io/badge/Microsoft-0078D4?style=for-the-badge&logo=microsoft&logoColor=white",
     "markdown": "![Microsoft](https://img.shields.io/badge/Microsoft-0078D4?style=for-the-badge&logo=microsoft&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-access",
     "name": "Microsoft Access",
     "url": "https://img.shields.io/badge/Microsoft_Access-A4373A?style=for-the-badge&logo=microsoft-access&logoColor=white",
     "markdown": "![Microsoft Access](https://img.shields.io/badge/Microsoft_Access-A4373A?style=for-the-badge&logo=microsoft-access&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-excel",
     "name": "Microsoft Excel",
     "url": "https://img.shields.io/badge/Microsoft_Excel-217346?style=for-the-badge&logo=microsoft-excel&logoColor=white",
     "markdown": "![Microsoft Excel](https://img.shields.io/badge/Microsoft_Excel-217346?style=for-the-badge&logo=microsoft-excel&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-office",
     "name": "Microsoft Office",
     "url": "https://img.shields.io/badge/Microsoft_Office-D83B01?style=for-the-badge&logo=microsoft-office&logoColor=white",
     "markdown": "![Microsoft Office](https://img.shields.io/badge/Microsoft_Office-D83B01?style=for-the-badge&logo=microsoft-office&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-powerpoint",
     "name": "Microsoft PowerPoint",
     "url": "https://img.shields.io/badge/Microsoft_PowerPoint-B7472A?style=for-the-badge&logo=microsoft-powerpoint&logoColor=white",
     "markdown": "![Microsoft PowerPoint](https://img.shields.io/badge/Microsoft_PowerPoint-B7472A?style=for-the-badge&logo=microsoft-powerpoint&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-sharepoint",
     "name": "Microsoft SharePoint",
     "url": "https://img.shields.io/badge/Microsoft_SharePoint-0078D4?style=for-the-badge&logo=microsoft-sharepoint&logoColor=white",
     "markdown": "![Microsoft SharePoint ](https://img.shields.io/badge/Microsoft_SharePoint-0078D4?style=for-the-badge&logo=microsoft-sharepoint&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-visio",
     "name": "Microsoft Visio",
     "url": "https://img.shields.io/badge/Microsoft_Visio-3955A3?style=for-the-badge&logo=microsoft-visio&logoColor=white",
     "markdown": "![Microsoft Visio ](https://img.shields.io/badge/Microsoft_Visio-3955A3?style=for-the-badge&logo=microsoft-visio&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "microsoft-word",
     "name": "Microsoft Word",
     "url": "https://img.shields.io/badge/Microsoft_Word-2B579A?style=for-the-badge&logo=microsoft-word&logoColor=white",
     "markdown": "![Microsoft Word](https://img.shields.io/badge/Microsoft_Word-2B579A?style=for-the-badge&logo=microsoft-word&logoColor=white)",
-    "category": "Office"
+    "categories": [
+      "Office"
+    ]
   },
   {
     "id": "alpine-linux",
     "name": "Alpine Linux",
     "url": "https://img.shields.io/badge/Alpine_Linux-%230D597F.svg?style=for-the-badge&logo=alpine-linux&logoColor=white",
     "markdown": "![Alpine Linux](https://img.shields.io/badge/Alpine_Linux-%230D597F.svg?style=for-the-badge&logo=alpine-linux&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "android",
     "name": "Android",
     "url": "https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white",
     "markdown": "![Android](https://img.shields.io/badge/Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "arch",
     "name": "Arch",
     "url": "https://img.shields.io/badge/Arch%20Linux-1793D1?logo=arch-linux&logoColor=fff&style=for-the-badge",
     "markdown": "![Arch](https://img.shields.io/badge/Arch%20Linux-1793D1?logo=arch-linux&logoColor=fff&style=for-the-badge)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "cent-os",
     "name": "Cent OS",
     "url": "https://img.shields.io/badge/cent%20os-002260?style=for-the-badge&logo=centos&logoColor=F0F0F0",
     "markdown": "![Cent OS](https://img.shields.io/badge/cent%20os-002260?style=for-the-badge&logo=centos&logoColor=F0F0F0)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "chrome-os",
     "name": "Chrome OS",
     "url": "https://img.shields.io/badge/chrome%20os-3d89fc?style=for-the-badge&logo=google%20chrome&logoColor=white",
     "markdown": "![Chrome OS](https://img.shields.io/badge/chrome%20os-3d89fc?style=for-the-badge&logo=google%20chrome&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "debian",
     "name": "Debian",
     "url": "https://img.shields.io/badge/Debian-D70A53?style=for-the-badge&logo=debian&logoColor=white",
     "markdown": "![Debian](https://img.shields.io/badge/Debian-D70A53?style=for-the-badge&logo=debian&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "deepin",
     "name": "Deepin",
     "url": "https://img.shields.io/badge/Deepin-007CFF?style=for-the-badge&logo=deepin&logoColor=white",
     "markdown": "![Deepin](https://img.shields.io/badge/Deepin-007CFF?style=for-the-badge&logo=deepin&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "elementary-os",
     "name": "Elementary OS",
     "url": "https://img.shields.io/badge/-elementary%20OS-black?style=for-the-badge&logo=elementary&logoColor=white",
     "markdown": "![Elementary OS](https://img.shields.io/badge/-elementary%20OS-black?style=for-the-badge&logo=elementary&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "fedora",
     "name": "Fedora",
     "url": "https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white",
     "markdown": "![Fedora](https://img.shields.io/badge/Fedora-294172?style=for-the-badge&logo=fedora&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "freebsd",
     "name": "FreeBSD",
     "url": "https://img.shields.io/badge/-FreeBSD-%23870000?style=for-the-badge&logo=freebsd&logoColor=white",
     "markdown": "![FreeBSD](https://img.shields.io/badge/-FreeBSD-%23870000?style=for-the-badge&logo=freebsd&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "gentoo",
     "name": "Gentoo",
     "url": "https://img.shields.io/badge/Gentoo-54487A?style=for-the-badge&logo=gentoo&logoColor=white",
     "markdown": "![Gentoo](https://img.shields.io/badge/Gentoo-54487A?style=for-the-badge&logo=gentoo&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "gnu",
     "name": "GNU",
     "url": "https://img.shields.io/badge/gnu-%23A42E2B.svg?style=for-the-badge&logo=gnu&logoColor=white",
     "markdown": "![gnu](https://img.shields.io/badge/gnu-%23A42E2B.svg?style=for-the-badge&logo=gnu&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "ios",
     "name": "iOS",
     "url": "https://img.shields.io/badge/iOS-000000?style=for-the-badge&logo=ios&logoColor=white",
     "markdown": "![iOS](https://img.shields.io/badge/iOS-000000?style=for-the-badge&logo=ios&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "kali",
     "name": "Kali",
     "url": "https://img.shields.io/badge/Kali-268BEE?style=for-the-badge&logo=kalilinux&logoColor=white",
     "markdown": "![Kali](https://img.shields.io/badge/Kali-268BEE?style=for-the-badge&logo=kalilinux&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "kubuntu",
     "name": "Kubuntu",
     "url": "https://img.shields.io/badge/-KUbuntu-%230079C1?style=for-the-badge&logo=kubuntu&logoColor=white",
     "markdown": "![Kubuntu](https://img.shields.io/badge/-KUbuntu-%230079C1?style=for-the-badge&logo=kubuntu&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "lineageos",
     "name": "Lineageos",
     "url": "https://img.shields.io/badge/lineageos-167C80?style=for-the-badge&logo=lineageos&logoColor=white",
     "markdown": "![Lineageos](https://img.shields.io/badge/lineageos-167C80?style=for-the-badge&logo=lineageos&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "linux",
     "name": "Linux",
     "url": "https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black",
     "markdown": "![Linux](https://img.shields.io/badge/Linux-FCC624?style=for-the-badge&logo=linux&logoColor=black)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "linux-mint",
     "name": "Linux Mint",
     "url": "https://img.shields.io/badge/Linux%20Mint-87CF3E?style=for-the-badge&logo=Linux%20Mint&logoColor=white",
     "markdown": "![Linux Mint](https://img.shields.io/badge/Linux%20Mint-87CF3E?style=for-the-badge&logo=Linux%20Mint&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "lubuntu",
     "name": "Lubuntu",
     "url": "https://img.shields.io/badge/-Lubuntu-%230065C2?style=for-the-badge&logo=lubuntu&logoColor=white",
     "markdown": "![Lubuntu](https://img.shields.io/badge/-Lubuntu-%230065C2?style=for-the-badge&logo=lubuntu&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "macos",
     "name": "macOS",
     "url": "https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0",
     "markdown": "![macOS](https://img.shields.io/badge/mac%20os-000000?style=for-the-badge&logo=macos&logoColor=F0F0F0)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "manjaro",
     "name": "Manjaro",
     "url": "https://img.shields.io/badge/Manjaro-35BF5C?style=for-the-badge&logo=Manjaro&logoColor=white",
     "markdown": "![Manjaro](https://img.shields.io/badge/Manjaro-35BF5C?style=for-the-badge&logo=Manjaro&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "mx-linux",
     "name": "MX Linux",
     "url": "https://img.shields.io/badge/-MX%20Linux-%23000000?style=for-the-badge&logo=MXlinux&logoColor=white",
     "markdown": "![MX Linux](https://img.shields.io/badge/-MX%20Linux-%23000000?style=for-the-badge&logo=MXlinux&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "nixos",
     "name": "NixOS",
     "url": "https://img.shields.io/badge/NIXOS-5277C3.svg?style=for-the-badge&logo=NixOS&logoColor=white",
     "markdown": "![NixOS](https://img.shields.io/badge/NIXOS-5277C3.svg?style=for-the-badge&logo=NixOS&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "openbsd",
     "name": "OpenBSD",
     "url": "https://img.shields.io/badge/-OpenBSD-%23FCC771?style=for-the-badge&logo=openbsd&logoColor=black",
     "markdown": "![OpenBSD](https://img.shields.io/badge/-OpenBSD-%23FCC771?style=for-the-badge&logo=openbsd&logoColor=black)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "opensuse",
     "name": "openSUSE",
     "url": "https://img.shields.io/badge/openSUSE-%2364B345?style=for-the-badge&logo=openSUSE&logoColor=white",
     "markdown": "![openSUSE](https://img.shields.io/badge/openSUSE-%2364B345?style=for-the-badge&logo=openSUSE&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "openwrt",
     "name": "OpenWRT",
     "url": "https://img.shields.io/badge/OpenWRT-00B5E2?style=for-the-badge&logo=OpenWrt&logoColor=white",
     "markdown": "![Openwrt](https://img.shields.io/badge/OpenWRT-00B5E2?style=for-the-badge&logo=OpenWrt&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "parrot-security",
     "name": "Parrot Security",
     "url": "https://img.shields.io/badge/parrot_security-%23000000.svg?style=for-the-badge&logo=parrotsecurity&logoColor=#15E0ED",
     "markdown": "![Parrot Security](https://img.shields.io/badge/parrot_security-%23000000.svg?style=for-the-badge&logo=parrotsecurity&logoColor=#15E0ED)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "pop!_os",
     "name": "Pop!_OS",
     "url": "https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white",
     "markdown": "![Pop!\\_OS](https://img.shields.io/badge/Pop!_OS-48B9C7?style=for-the-badge&logo=Pop!_OS&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "red-hat",
     "name": "Red Hat",
     "url": "https://img.shields.io/badge/Red%20Hat-EE0000?style=for-the-badge&logo=redhat&logoColor=white",
     "markdown": "![Red Hat](https://img.shields.io/badge/Red%20Hat-EE0000?style=for-the-badge&logo=redhat&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "rocky-linux",
     "name": "Rocky Linux",
     "url": "https://img.shields.io/badge/-Rocky%20Linux-%2310B981?style=for-the-badge&logo=rockylinux&logoColor=white",
     "markdown": "![Rocky Linux](https://img.shields.io/badge/-Rocky%20Linux-%2310B981?style=for-the-badge&logo=rockylinux&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "slackware",
     "name": "Slackware",
     "url": "https://img.shields.io/badge/-Slackware-%231357BD?style=for-the-badge&logo=slackware&logoColor=white",
     "markdown": "![Slackware](https://img.shields.io/badge/-Slackware-%231357BD?style=for-the-badge&logo=slackware&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "solus",
     "name": "Solus",
     "url": "https://img.shields.io/badge/Solus-%23f2f2f2.svg?style=for-the-badge&logo=solus&logoColor=5294E2",
     "markdown": "![Solus](https://img.shields.io/badge/Solus-%23f2f2f2.svg?style=for-the-badge&logo=solus&logoColor=5294E2)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "suse",
     "name": "SUSE",
     "url": "https://img.shields.io/badge/SUSE-0C322C?style=for-the-badge&logo=SUSE&logoColor=white",
     "markdown": "![Suse](https://img.shields.io/badge/SUSE-0C322C?style=for-the-badge&logo=SUSE&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "tails",
     "name": "Tails",
     "url": "https://img.shields.io/badge/Tails%20-56347C?&style=for-the-badge&logo=tails&logoColor=white",
     "markdown": "![Tails](https://img.shields.io/badge/Tails%20-56347C?&style=for-the-badge&logo=tails&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "ubuntu",
     "name": "Ubuntu",
     "url": "https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white",
     "markdown": "![Ubuntu](https://img.shields.io/badge/Ubuntu-E95420?style=for-the-badge&logo=ubuntu&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "ubuntu-mate",
     "name": "Ubuntu MATE",
     "url": "https://img.shields.io/badge/Ubuntu%20MATE-84A454.svg?style=for-the-badge&logo=Ubuntu-MATE&logoColor=white",
     "markdown": "![Ubuntu MATE](https://img.shields.io/badge/Ubuntu%20MATE-84A454.svg?style=for-the-badge&logo=Ubuntu-MATE&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "unraid",
     "name": "Unraid",
     "url": "https://img.shields.io/badge/unraid-%23F15A2C.svg?style=for-the-badge&logo=unraid&logoColor=white",
     "markdown": "![Unraid](https://img.shields.io/badge/unraid-%23F15A2C.svg?style=for-the-badge&logo=unraid&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "wear-os",
     "name": "Wear OS",
     "url": "https://img.shields.io/badge/-Wear%20OS-4285F4?style=for-the-badge&logo=wear-os&logoColor=white",
     "markdown": "![Wear OS](https://img.shields.io/badge/-Wear%20OS-4285F4?style=for-the-badge&logo=wear-os&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "windows",
     "name": "Windows",
     "url": "https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white",
     "markdown": "![Windows](https://img.shields.io/badge/Windows-0078D6?style=for-the-badge&logo=windows&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "windows-11",
     "name": "Windows 11",
     "url": "https://img.shields.io/badge/Windows%2011-%230079d5.svg?style=for-the-badge&logo=Windows%2011&logoColor=white",
     "markdown": "![Windows 11](https://img.shields.io/badge/Windows%2011-%230079d5.svg?style=for-the-badge&logo=Windows%2011&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "windows-95",
     "name": "Windows 95",
     "url": "https://img.shields.io/badge/Windows%2095-008484?style=for-the-badge&logo=windows95&logoColor=white",
     "markdown": "![Windows 95](https://img.shields.io/badge/Windows%2095-008484?style=for-the-badge&logo=windows95&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "windows-xp",
     "name": "Windows XP",
     "url": "https://img.shields.io/badge/Windows%20xp-003399?style=for-the-badge&logo=windowsxp&logoColor=white",
     "markdown": "![Windows XP](https://img.shields.io/badge/Windows%20xp-003399?style=for-the-badge&logo=windowsxp&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "zorin-os",
     "name": "Zorin OS",
     "url": "https://img.shields.io/badge/-Zorin%20OS-%2310AAEB?style=for-the-badge&logo=zorin&logoColor=white",
     "markdown": "![Zorin OS](https://img.shields.io/badge/-Zorin%20OS-%2310AAEB?style=for-the-badge&logo=zorin&logoColor=white)",
-    "category": "Operating System"
+    "categories": [
+      "Operating System"
+    ]
   },
   {
     "id": "doctrine",
     "name": "Doctrine",
     "url": "https://img.shields.io/badge/Doctrine-%23326CE5?style=for-the-badge&logo=doctrine&logoColor=white",
     "markdown": "![Doctrine](https://img.shields.io/badge/Doctrine-%23326CE5?style=for-the-badge&logo=doctrine&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "drizzle",
     "name": "Drizzle",
     "url": "https://img.shields.io/badge/Drizzle-%23000000?style=for-the-badge&logo=drizzle&logoColor=C5F74F",
     "markdown": "![Drizzle](https://img.shields.io/badge/Drizzle-%23000000?style=for-the-badge&logo=drizzle&logoColor=C5F74F)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "hibernate",
     "name": "Hibernate",
     "url": "https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white",
     "markdown": "![Hibernate](https://img.shields.io/badge/Hibernate-59666C?style=for-the-badge&logo=Hibernate&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "prisma",
     "name": "Prisma",
     "url": "https://img.shields.io/badge/Prisma-3982CE?style=for-the-badge&logo=Prisma&logoColor=white",
     "markdown": "![Prisma](https://img.shields.io/badge/Prisma-3982CE?style=for-the-badge&logo=Prisma&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "quill",
     "name": "Quill",
     "url": "https://img.shields.io/badge/Quill-52B0E7?style=for-the-badge&logo=apache&logoColor=white",
     "markdown": "![Quill](https://img.shields.io/badge/Quill-52B0E7?style=for-the-badge&logo=apache&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "sequelize",
     "name": "Sequelize",
     "url": "https://img.shields.io/badge/Sequelize-52B0E7?style=for-the-badge&logo=Sequelize&logoColor=white",
     "markdown": "![Sequelize](https://img.shields.io/badge/Sequelize-52B0E7?style=for-the-badge&logo=Sequelize&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "sqlalchemy",
     "name": "SQLAlchemy",
     "url": "https://img.shields.io/badge/sqlalchemy-%23D71F00.svg?style=for-the-badge&logo=sqlalchemy&logoColor=white",
     "markdown": "![SQLAlchemy](https://img.shields.io/badge/sqlalchemy-%23D71F00.svg?style=for-the-badge&logo=sqlalchemy&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "typeorm",
     "name": "TypeORM",
     "url": "https://img.shields.io/badge/TypeORM-FE0803.svg?style=for-the-badge&logo=typeorm&logoColor=white",
     "markdown": "![TypeORM](https://img.shields.io/badge/TypeORM-FE0803.svg?style=for-the-badge&logo=typeorm&logoColor=white)",
-    "category": "ORM"
+    "categories": [
+      "ORM"
+    ]
   },
   {
     "id": "accessibility",
     "name": "Accessibility",
     "url": "https://img.shields.io/badge/Accessibility-%230170EA.svg?style=for-the-badge&logo=Accessibility&logoColor=white",
     "markdown": "![Accessibility](https://img.shields.io/badge/Accessibility-%230170EA.svg?style=for-the-badge&logo=Accessibility&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "airbnb",
     "name": "Airbnb",
     "url": "https://img.shields.io/badge/Airbnb-%23ff5a5f.svg?style=for-the-badge&logo=Airbnb&logoColor=white",
     "markdown": "![Airbnb](https://img.shields.io/badge/Airbnb-%23ff5a5f.svg?style=for-the-badge&logo=Airbnb&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "alfred",
     "name": "Alfred",
     "url": "https://img.shields.io/badge/alfred-%235C1F87.svg?style=for-the-badge&logo=alfred",
     "markdown": "![Alfred](https://img.shields.io/badge/alfred-%235C1F87.svg?style=for-the-badge&logo=alfred)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "apex",
     "name": "Apex",
     "url": "https://img.shields.io/badge/Apex-blue?style=for-the-badge&logo=salesforce&logoColor=white",
     "markdown": "![Apex](https://img.shields.io/badge/Apex-blue?style=for-the-badge&logo=salesforce&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "codecov",
     "name": "CodeCov",
     "url": "https://img.shields.io/badge/codecov-%23ff0077.svg?style=for-the-badge&logo=codecov&logoColor=white",
     "markdown": "![CodeCov](https://img.shields.io/badge/codecov-%23ff0077.svg?style=for-the-badge&logo=codecov&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "crowdin",
     "name": "Crowdin",
     "url": "https://img.shields.io/badge/Crowdin-2E3340.svg?style=for-the-badge&logo=Crowdin&logoColor=white",
     "markdown": "![Crowdin](https://img.shields.io/badge/Crowdin-2E3340.svg?style=for-the-badge&logo=Crowdin&logoColor=white)",
-    "category": "Other"
-  },
-  {
-    "id": "elasticsearch-other",
-    "name": "ElasticSearch",
-    "url": "https://img.shields.io/badge/-ElasticSearch-005571?style=for-the-badge&logo=elasticsearch",
-    "markdown": "![ElasticSearch](https://img.shields.io/badge/-ElasticSearch-005571?style=for-the-badge&logo=elasticsearch)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "eslint",
     "name": "ESLint",
     "url": "https://img.shields.io/badge/ESLint-4B3263?style=for-the-badge&logo=eslint&logoColor=white",
     "markdown": "![ESLint](https://img.shields.io/badge/ESLint-4B3263?style=for-the-badge&logo=eslint&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "ffmpeg",
     "name": "FFmpeg",
     "url": "https://shields.io/badge/FFmpeg-%23171717.svg?logo=ffmpeg&style=for-the-badge&labelColor=171717&logoColor=5cb85c",
     "markdown": "![FFmpeg](https://shields.io/badge/FFmpeg-%23171717.svg?logo=ffmpeg&style=for-the-badge&labelColor=171717&logoColor=5cb85c)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "google-talkback",
     "name": "Google TalkBack",
     "url": "https://img.shields.io/badge/Google%20TalkBack-%236636B4.svg?style=for-the-badge&logo=GoogleTalkBack&logoColor=white",
     "markdown": "![Google TalkBack](https://img.shields.io/badge/Google%20TalkBack-%236636B4.svg?style=for-the-badge&logo=GoogleTalkBack&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "jaws",
     "name": "JAWS",
     "url": "https://img.shields.io/badge/JAWS-%231962AA.svg?style=for-the-badge&logo=JAWS&logoColor=white",
     "markdown": "![JAWS](https://img.shields.io/badge/JAWS-%231962AA.svg?style=for-the-badge&logo=JAWS&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "jellyfin",
     "name": "Jellyfin",
     "url": "https://img.shields.io/badge/jellyfin-%23000B25.svg?style=for-the-badge&logo=Jellyfin&logoColor=00A4DC",
     "markdown": "![Jellyfin](https://img.shields.io/badge/jellyfin-%23000B25.svg?style=for-the-badge&logo=Jellyfin&logoColor=00A4DC)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "meta",
     "name": "Meta",
     "url": "https://img.shields.io/badge/Meta-%230467DF.svg?style=for-the-badge&logo=Meta&logoColor=white",
     "markdown": "![Meta](https://img.shields.io/badge/Meta-%230467DF.svg?style=for-the-badge&logo=Meta&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "miro",
     "name": "Miro",
     "url": "https://img.shields.io/badge/Miro-%23F2CA02.svg?style=for-the-badge&logo=miro&logoColor=black",
     "markdown": "![Miro](https://img.shields.io/badge/Miro-%23F2CA02.svg?style=for-the-badge&logo=miro&logoColor=black)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "narrator",
     "name": "Narrator",
     "url": "https://img.shields.io/badge/Narrator-%230771D0.svg?style=for-the-badge&logo=Narrator&logoColor=white",
     "markdown": "![Narrator](https://img.shields.io/badge/Narrator-%230771D0.svg?style=for-the-badge&logo=Narrator&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "notion",
     "name": "Notion",
     "url": "https://img.shields.io/badge/Notion-%23000000.svg?style=for-the-badge&logo=notion&logoColor=white",
     "markdown": "![Notion](https://img.shields.io/badge/Notion-%23000000.svg?style=for-the-badge&logo=notion&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "nvda",
     "name": "NVDA",
     "url": "https://img.shields.io/badge/NVDA-%23630093.svg?style=for-the-badge&logo=NVDA&logoColor=white",
     "markdown": "![NVDA](https://img.shields.io/badge/NVDA-%23630093.svg?style=for-the-badge&logo=NVDA&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "openapi-specification",
     "name": "OpenAPI Specification",
     "url": "https://img.shields.io/badge/openapiinitiative-%23000000.svg?style=for-the-badge&logo=openapiinitiative&logoColor=white",
     "markdown": "![openapi initiative](https://img.shields.io/badge/openapiinitiative-%23000000.svg?style=for-the-badge&logo=openapiinitiative&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "plex",
     "name": "Plex",
     "url": "https://img.shields.io/badge/plex-%23E5A00D.svg?style=for-the-badge&logo=plex&logoColor=white",
     "markdown": "![Plex](https://img.shields.io/badge/plex-%23E5A00D.svg?style=for-the-badge&logo=plex&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "portfolio",
     "name": "Portfolio",
     "url": "https://img.shields.io/badge/Portfolio-%23000000.svg?style=for-the-badge&logo=firefox&logoColor=#FF7139",
     "markdown": "![Portfolio](https://img.shields.io/badge/Portfolio-%23000000.svg?style=for-the-badge&logo=firefox&logoColor=#FF7139)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "postman",
     "name": "Postman",
     "url": "https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white",
     "markdown": "![Postman](https://img.shields.io/badge/Postman-FF6C37?style=for-the-badge&logo=postman&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "power-bi",
     "name": "Power BI",
     "url": "https://img.shields.io/badge/power_bi-F2C811?style=for-the-badge&logo=powerbi&logoColor=black",
     "markdown": "![Power Bi](https://img.shields.io/badge/power_bi-F2C811?style=for-the-badge&logo=powerbi&logoColor=black)",
-    "category": "Other"
-  },
-  {
-    "id": "prettier-other",
-    "name": "Prettier",
-    "url": "https://img.shields.io/badge/prettier-%23F7B93E.svg?style=for-the-badge&logo=prettier&logoColor=black",
-    "markdown": "![Prettier](https://img.shields.io/badge/prettier-%23F7B93E.svg?style=for-the-badge&logo=prettier&logoColor=black)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "prezi",
     "name": "Prezi",
     "url": "https://img.shields.io/badge/Prezi-%23000000.svg?style=for-the-badge&logo=Prezi&logoColor=white",
     "markdown": "![Prezi](https://img.shields.io/badge/Prezi-%23000000.svg?style=for-the-badge&logo=Prezi&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "pypi",
     "name": "PyPi",
     "url": "https://img.shields.io/badge/pypi-%23ececec.svg?style=for-the-badge&logo=pypi&logoColor=1f73b7",
     "markdown": "![PyPi](https://img.shields.io/badge/pypi-%23ececec.svg?style=for-the-badge&logo=pypi&logoColor=1f73b7)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "salesforce",
     "name": "Salesforce",
     "url": "https://img.shields.io/badge/Salesforce-blue?style=for-the-badge&logo=salesforce&logoColor=white",
     "markdown": "![Salesforce](https://img.shields.io/badge/Salesforce-blue?style=for-the-badge&logo=salesforce&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "sonarlint",
     "name": "SonarLint",
     "url": "https://img.shields.io/badge/SonarLint-CB2029?style=for-the-badge&logo=SONARLINT&logoColor=white",
     "markdown": "![SonarLint](https://img.shields.io/badge/SonarLint-CB2029?style=for-the-badge&logo=SONARLINT&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "sonarqube",
     "name": "SonarQube",
     "url": "https://img.shields.io/badge/SonarQube-black?style=for-the-badge&logo=sonarqube&logoColor=4E9BCD",
     "markdown": "![SonarQube](https://img.shields.io/badge/SonarQube-black?style=for-the-badge&logo=sonarqube&logoColor=4E9BCD)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "tampermonkey",
     "name": "Tampermonkey",
     "url": "https://img.shields.io/badge/tampermonkey-%2300485B.svg?style=for-the-badge&logo=tampermonkey&logoColor=white",
     "markdown": "![Tampermonkey](https://img.shields.io/badge/tampermonkey-%2300485B.svg?style=for-the-badge&logo=tampermonkey&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "trello",
     "name": "Trello",
     "url": "https://img.shields.io/badge/Trello-%23026AA7.svg?style=for-the-badge&logo=Trello&logoColor=white",
     "markdown": "![Trello](https://img.shields.io/badge/Trello-%23026AA7.svg?style=for-the-badge&logo=Trello&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "twilio",
     "name": "Twilio",
     "url": "https://img.shields.io/badge/Twilio-F22F46?style=for-the-badge&logo=Twilio logoColor=white",
     "markdown": "![Twilio](https://img.shields.io/badge/Twilio-F22F46?style=for-the-badge&logo=Twilio logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "uber",
     "name": "Uber",
     "url": "https://img.shields.io/badge/Uber-%23000000.svg?style=for-the-badge&logo=Uber&logoColor=white",
     "markdown": "![Uber](https://img.shields.io/badge/Uber-%23000000.svg?style=for-the-badge&logo=Uber&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "virtualbox",
     "name": "VirtualBox",
     "url": "https://img.shields.io/badge/virtualbox-%23183A61.svg?style=for-the-badge&logo=virtualbox&logoColor=white",
     "markdown": "![VirtualBox](https://img.shields.io/badge/virtualbox-%23183A61.svg?style=for-the-badge&logo=virtualbox&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "voiceover",
     "name": "VoiceOver",
     "url": "https://img.shields.io/badge/VoiceOver-%23484848.svg?style=for-the-badge&logo=VoiceOver&logoColor=white",
     "markdown": "![VoiceOver](https://img.shields.io/badge/VoiceOver-%23484848.svg?style=for-the-badge&logo=VoiceOver&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "wcag",
     "name": "WCAG",
     "url": "https://img.shields.io/badge/WCAG-%23015A69.svg?style=for-the-badge&logo=WCAG&logoColor=white",
     "markdown": "![WCAG](https://img.shields.io/badge/WCAG-%23015A69.svg?style=for-the-badge&logo=WCAG&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "xfce",
     "name": "XFCE",
     "url": "https://img.shields.io/badge/XFCE-%232284F2.svg?style=for-the-badge&logo=xfce&logoColor=white",
     "markdown": "![XFCE](https://img.shields.io/badge/XFCE-%232284F2.svg?style=for-the-badge&logo=xfce&logoColor=white)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "xo",
     "name": "XO",
     "url": "https://img.shields.io/badge/XO-%235ED9C7.svg?style=for-the-badge&logo=xo&logoColor=black",
     "markdown": "![XO](https://img.shields.io/badge/XO-%235ED9C7.svg?style=for-the-badge&logo=xo&logoColor=black)",
-    "category": "Other"
+    "categories": [
+      "Other"
+    ]
   },
   {
     "id": "ansible",
     "name": "Ansible",
     "url": "https://img.shields.io/badge/ansible-%231A1918.svg?style=for-the-badge&logo=ansible&logoColor=white",
     "markdown": "![Ansible](https://img.shields.io/badge/ansible-%231A1918.svg?style=for-the-badge&logo=ansible&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "docker",
     "name": "Docker",
     "url": "https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white",
     "markdown": "![Docker](https://img.shields.io/badge/docker-%230db7ed.svg?style=for-the-badge&logo=docker&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "grafana",
     "name": "Grafana",
     "url": "https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white",
     "markdown": "![Grafana](https://img.shields.io/badge/grafana-%23F46800.svg?style=for-the-badge&logo=grafana&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "jira",
     "name": "Jira",
     "url": "https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white",
     "markdown": "![Jira](https://img.shields.io/badge/jira-%230A0FFF.svg?style=for-the-badge&logo=jira&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "kubernetes",
     "name": "Kubernetes",
     "url": "https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white",
     "markdown": "![Kubernetes](https://img.shields.io/badge/kubernetes-%23326ce5.svg?style=for-the-badge&logo=kubernetes&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "opentelemetry",
     "name": "OpenTelemetry",
     "url": "https://img.shields.io/badge/OpenTelemetry-FFFFFF?&style=for-the-badge&logo=opentelemetry&logoColor=black",
     "markdown": "![OpenTelemetry](https://img.shields.io/badge/OpenTelemetry-FFFFFF?&style=for-the-badge&logo=opentelemetry&logoColor=black)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "packer",
     "name": "Packer",
     "url": "https://img.shields.io/badge/packer-%23E7EEF0.svg?style=for-the-badge&logo=packer&logoColor=%2302A8EF",
     "markdown": "![Packer](https://img.shields.io/badge/packer-%23E7EEF0.svg?style=for-the-badge&logo=packer&logoColor=%2302A8EF)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "prometheus",
     "name": "Prometheus",
     "url": "https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white",
     "markdown": "![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "pulumi",
     "name": "Pulumi",
     "url": "https://img.shields.io/badge/Pulumi-%238A3391.svg?style=for-the-badge&logo=Pulumi&logoColor=%23f7bf2a",
     "markdown": "![Pulumi](https://img.shields.io/badge/Pulumi-%238A3391.svg?style=for-the-badge&logo=Pulumi&logoColor=%23f7bf2a)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "rancher",
     "name": "Rancher",
     "url": "https://img.shields.io/badge/rancher-%230075A8.svg?style=for-the-badge&logo=rancher&logoColor=white",
     "markdown": "![Rancher](https://img.shields.io/badge/rancher-%230075A8.svg?style=for-the-badge&logo=rancher&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "splunk",
     "name": "Splunk",
     "url": "https://img.shields.io/badge/splunk-%23000000.svg?style=for-the-badge&logo=splunk&logoColor=white",
     "markdown": "![Splunk](https://img.shields.io/badge/splunk-%23000000.svg?style=for-the-badge&logo=splunk&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "terraform",
     "name": "Terraform",
     "url": "https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white",
     "markdown": "![Terraform](https://img.shields.io/badge/terraform-%235835CC.svg?style=for-the-badge&logo=terraform&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "vagrant",
     "name": "Vagrant",
     "url": "https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white",
     "markdown": "![Vagrant](https://img.shields.io/badge/vagrant-%231563FF.svg?style=for-the-badge&logo=vagrant&logoColor=white)",
-    "category": "DevOps"
+    "categories": [
+      "DevOps"
+    ]
   },
   {
     "id": "babel",
     "name": "Babel",
     "url": "https://img.shields.io/badge/Babel-F9DC3e?style=for-the-badge&logo=babel&logoColor=black",
     "markdown": "![Babel](https://img.shields.io/badge/Babel-F9DC3e?style=for-the-badge&logo=babel&logoColor=black)",
-    "category": "Build Toolchains"
+    "categories": [
+      "Build Toolchains"
+    ]
   },
   {
     "id": "cmake",
     "name": "CMake",
     "url": "https://img.shields.io/badge/CMake-%23008FBA.svg?style=for-the-badge&logo=cmake&logoColor=white",
     "markdown": "![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?style=for-the-badge&logo=cmake&logoColor=white)",
-    "category": "Build Toolchains"
+    "categories": [
+      "Build Toolchains"
+    ]
   },
   {
     "id": "gradle",
     "name": "Gradle",
     "url": "https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white",
     "markdown": "![Gradle](https://img.shields.io/badge/Gradle-02303A.svg?style=for-the-badge&logo=Gradle&logoColor=white)",
-    "category": "Build Toolchains"
-  },
-  {
-    "id": "platformio-build-toolchains",
-    "name": "PlatformIO",
-    "url": "https://img.shields.io/badge/PlatformIO-%23222.svg?style=for-the-badge&logo=platformio&logoColor=%23f5822a",
-    "markdown": "![PlatformIO](https://img.shields.io/badge/PlatformIO-%23222.svg?style=for-the-badge&logo=platformio&logoColor=%23f5822a)",
-    "category": "Build Toolchains"
+    "categories": [
+      "Build Toolchains"
+    ]
   },
   {
     "id": "arduino",
     "name": "Arduino",
     "url": "https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white",
     "markdown": "![Arduino](https://img.shields.io/badge/-Arduino-00979D?style=for-the-badge&logo=Arduino&logoColor=white)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "espressif",
     "name": "Espressif",
     "url": "https://img.shields.io/badge/espressif-E7352C.svg?style=for-the-badge&logo=espressif&logoColor=white",
     "markdown": "![Espressif](https://img.shields.io/badge/espressif-E7352C.svg?style=for-the-badge&logo=espressif&logoColor=white)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "home-assistant",
     "name": "Home Assistant",
     "url": "https://img.shields.io/badge/home%20assistant-%2341BDF5.svg?style=for-the-badge&logo=home-assistant&logoColor=white",
     "markdown": "![Home Assistant](https://img.shields.io/badge/home%20assistant-%2341BDF5.svg?style=for-the-badge&logo=home-assistant&logoColor=white)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "homebridge",
     "name": "Homebridge",
     "url": "https://img.shields.io/badge/homebridge-%23491F59.svg?style=for-the-badge&logo=homebridge&logoColor=white",
     "markdown": "![Homebridge](https://img.shields.io/badge/homebridge-%23491F59.svg?style=for-the-badge&logo=homebridge&logoColor=white)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "mosquitto",
     "name": "Mosquitto",
     "url": "https://img.shields.io/badge/mosquitto-%233C5280.svg?style=for-the-badge&logo=eclipsemosquitto&logoColor=white",
     "markdown": "![Mosquitto](https://img.shields.io/badge/mosquitto-%233C5280.svg?style=for-the-badge&logo=eclipsemosquitto&logoColor=white)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "raspberry-pi",
     "name": "Raspberry Pi",
     "url": "https://img.shields.io/badge/-Raspberry_Pi-C51A4A?style=for-the-badge&logo=Raspberry-Pi",
     "markdown": "![Raspberry Pi](https://img.shields.io/badge/-Raspberry_Pi-C51A4A?style=for-the-badge&logo=Raspberry-Pi)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "zigbee",
     "name": "Zigbee",
     "url": "https://img.shields.io/badge/zigbee-%23EB0443.svg?style=for-the-badge&logo=zigbee&logoColor=white",
     "markdown": "![Zigbee](https://img.shields.io/badge/zigbee-%23EB0443.svg?style=for-the-badge&logo=zigbee&logoColor=white)",
-    "category": "Home Automation"
+    "categories": [
+      "Home Automation"
+    ]
   },
   {
     "id": "cisco",
     "name": "Cisco",
     "url": "https://img.shields.io/badge/cisco-%23049fd9.svg?style=for-the-badge&logo=cisco&logoColor=black",
     "markdown": "![Cisco](https://img.shields.io/badge/cisco-%23049fd9.svg?style=for-the-badge&logo=cisco&logoColor=black)",
-    "category": "Networking"
+    "categories": [
+      "Networking"
+    ]
   },
   {
     "id": "pi-hole",
     "name": "Pi-Hole",
     "url": "https://img.shields.io/badge/pihole-%2396060C.svg?style=for-the-badge&logo=pi-hole&logoColor=white",
     "markdown": "![Pi-Hole](https://img.shields.io/badge/pihole-%2396060C.svg?style=for-the-badge&logo=pi-hole&logoColor=white)",
-    "category": "Networking"
+    "categories": [
+      "Networking"
+    ]
   },
   {
     "id": "ubiquiti",
     "name": "Ubiquiti",
     "url": "https://img.shields.io/badge/ubiquiti-%230559C9.svg?style=for-the-badge&logo=ubiquiti&logoColor=white",
     "markdown": "![Ubiquiti](https://img.shields.io/badge/ubiquiti-%230559C9.svg?style=for-the-badge&logo=ubiquiti&logoColor=white)",
-    "category": "Networking"
+    "categories": [
+      "Networking"
+    ]
   },
   {
     "id": "wireguard",
     "name": "Wireguard",
     "url": "https://img.shields.io/badge/wireguard-%2388171A.svg?style=for-the-badge&logo=wireguard&logoColor=white",
     "markdown": "![Wireguard](https://img.shields.io/badge/wireguard-%2388171A.svg?style=for-the-badge&logo=wireguard&logoColor=white)",
-    "category": "Networking"
+    "categories": [
+      "Networking"
+    ]
   },
   {
     "id": "aqua-sec",
     "name": "Aqua Sec",
     "url": "https://img.shields.io/badge/aqua-%231904DA.svg?style=for-the-badge&logo=aqua&logoColor=#0018A8",
     "markdown": "![AquaSec](https://img.shields.io/badge/aqua-%231904DA.svg?style=for-the-badge&logo=aqua&logoColor=#0018A8)",
-    "category": "Security"
+    "categories": [
+      "Security"
+    ]
   },
   {
     "id": "bitwarden",
     "name": "Bitwarden",
     "url": "https://img.shields.io/badge/bitwarden-%23175DDC.svg?style=for-the-badge&logo=bitwarden&logoColor=white",
     "markdown": "![Bitwarden](https://img.shields.io/badge/bitwarden-%23175DDC.svg?style=for-the-badge&logo=bitwarden&logoColor=white)",
-    "category": "Security"
-  },
-  {
-    "id": "tor-security",
-    "name": "TOR",
-    "url": "https://img.shields.io/badge/tor-%237E4798.svg?style=for-the-badge&logo=tor-project&logoColor=white",
-    "markdown": "![TOR](https://img.shields.io/badge/tor-%237E4798.svg?style=for-the-badge&logo=tor-project&logoColor=white)",
-    "category": "Security"
+    "categories": [
+      "Security"
+    ]
   },
   {
     "id": "d-wave",
     "name": "D-Wave",
     "url": "https://img.shields.io/badge/dwave-%23008CD7.svg?style=for-the-badge&logo=dwavesystems&logoColor=white",
     "markdown": "![D-Wave](https://img.shields.io/badge/dwave-%23008CD7.svg?style=for-the-badge&logo=dwavesystems&logoColor=white)",
-    "category": "Quantum Programming"
+    "categories": [
+      "Quantum Programming"
+    ]
   },
   {
     "id": "qiskit",
     "name": "Qiskit",
     "url": "https://img.shields.io/badge/Qiskit-%236929C4.svg?style=for-the-badge&logo=Qiskit&logoColor=white",
     "markdown": "![Qiskit](https://img.shields.io/badge/Qiskit-%236929C4.svg?style=for-the-badge&logo=Qiskit&logoColor=white)",
-    "category": "Quantum Programming"
+    "categories": [
+      "Quantum Programming"
+    ]
   },
   {
     "id": "baidu",
     "name": "Baidu",
     "url": "https://img.shields.io/badge/Baidu-2932E1?style=for-the-badge&logo=Baidu&logoColor=white",
     "markdown": "![Baidu](https://img.shields.io/badge/Baidu-2932E1?style=for-the-badge&logo=Baidu&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "bing",
     "name": "Bing",
     "url": "https://img.shields.io/badge/Microsoft%20Bing-258FFA?style=for-the-badge&logo=Microsoft%20Bing&logoColor=white",
     "markdown": "![Bing](https://img.shields.io/badge/Microsoft%20Bing-258FFA?style=for-the-badge&logo=Microsoft%20Bing&logoColor=white)",
-    "category": "Search Engines"
-  },
-  {
-    "id": "brave-search-engines",
-    "name": "Brave",
-    "url": "https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white",
-    "markdown": "![Brave](https://img.shields.io/badge/Brave-FB542B?style=for-the-badge&logo=Brave&logoColor=white)",
-    "category": "Search Engines"
-  },
-  {
-    "id": "duckduckgo-search-engines",
-    "name": "DuckDuckGo",
-    "url": "https://img.shields.io/badge/DuckDuckGo-DE5833?style=for-the-badge&logo=DuckDuckGo&logoColor=white",
-    "markdown": "![DuckDuckGo](https://img.shields.io/badge/DuckDuckGo-DE5833?style=for-the-badge&logo=DuckDuckGo&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "ecosia",
     "name": "Ecosia",
     "url": "https://img.shields.io/badge/ecosia-%23008009.svg?style=for-the-badge&logo=ecosia&logoColor=white",
     "markdown": "![Ecosia](https://img.shields.io/badge/ecosia-%23008009.svg?style=for-the-badge&logo=ecosia&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "google",
     "name": "Google",
     "url": "https://img.shields.io/badge/google-4285F4?style=for-the-badge&logo=google&logoColor=white",
     "markdown": "![Google](https://img.shields.io/badge/google-4285F4?style=for-the-badge&logo=google&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "kagi",
     "name": "Kagi",
     "url": "https://img.shields.io/badge/kagi-%23FFB319.svg?style=for-the-badge&logo=kagi&logoColor=black",
     "markdown": "![Kagi](https://img.shields.io/badge/kagi-%23FFB319.svg?style=for-the-badge&logo=kagi&logoColor=black)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "mojeek",
     "name": "Mojeek",
     "url": "https://img.shields.io/badge/mojeek-%237AB93C.svg?style=for-the-badge&logo=mojeek&logoColor=white",
     "markdown": "![Mojeek](https://img.shields.io/badge/mojeek-%237AB93C.svg?style=for-the-badge&logo=mojeek&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "naver",
     "name": "Naver",
     "url": "https://img.shields.io/badge/naver-%2303C75A.svg?style=for-the-badge&logo=naver&logoColor=white",
     "markdown": "![Naver](https://img.shields.io/badge/naver-%2303C75A.svg?style=for-the-badge&logo=naver&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "qwant",
     "name": "Qwant",
     "url": "https://img.shields.io/badge/qwant-%23282B2F.svg?style=for-the-badge&logo=qwant&logoColor=white",
     "markdown": "![Qwant](https://img.shields.io/badge/qwant-%23282B2F.svg?style=for-the-badge&logo=qwant&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "searxng",
     "name": "Searxng",
     "url": "https://img.shields.io/badge/searxng-%233050FF.svg?style=for-the-badge&logo=searxng&logoColor=white",
     "markdown": "![Searxng](https://img.shields.io/badge/searxng-%233050FF.svg?style=for-the-badge&logo=searxng&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "startpage",
     "name": "Startpage",
     "url": "https://img.shields.io/badge/startpage-%236563FF.svg?style=for-the-badge&logo=startpage&logoColor=white",
     "markdown": "![Startpage](https://img.shields.io/badge/startpage-%236563FF.svg?style=for-the-badge&logo=startpage&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "yahoo!",
     "name": "Yahoo!",
     "url": "https://img.shields.io/badge/Yahoo!-6001D2?style=for-the-badge&logo=Yahoo!&logoColor=white",
     "markdown": "![Yahoo!](https://img.shields.io/badge/Yahoo!-6001D2?style=for-the-badge&logo=Yahoo!&logoColor=white)",
-    "category": "Search Engines"
+    "categories": [
+      "Search Engines"
+    ]
   },
   {
     "id": "apache",
     "name": "Apache",
     "url": "https://img.shields.io/badge/apache-%23D42029.svg?style=for-the-badge&logo=apache&logoColor=white",
     "markdown": "![Apache](https://img.shields.io/badge/apache-%23D42029.svg?style=for-the-badge&logo=apache&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "apache-airflow",
     "name": "Apache Airflow",
     "url": "https://img.shields.io/badge/Apache%20Airflow-017CEE?style=for-the-badge&logo=Apache%20Airflow&logoColor=white",
     "markdown": "![Apache Airflow](https://img.shields.io/badge/Apache%20Airflow-017CEE?style=for-the-badge&logo=Apache%20Airflow&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "apache-ant",
     "name": "Apache Ant",
     "url": "https://img.shields.io/badge/Apache%20Ant-A81C7D?style=for-the-badge&logo=Apache%20Ant&logoColor=white",
     "markdown": "![Apache Ant](https://img.shields.io/badge/Apache%20Ant-A81C7D?style=for-the-badge&logo=Apache%20Ant&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "apache-flink",
     "name": "Apache Flink",
     "url": "https://img.shields.io/badge/Apache%20Flink-E6526F?style=for-the-badge&logo=Apache%20Flink&logoColor=white",
     "markdown": "![Apache Flink](https://img.shields.io/badge/Apache%20Flink-E6526F?style=for-the-badge&logo=Apache%20Flink&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "apache-maven",
     "name": "Apache Maven",
     "url": "https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=Apache%20Maven&logoColor=white",
     "markdown": "![Apache Maven](https://img.shields.io/badge/Apache%20Maven-C71A36?style=for-the-badge&logo=Apache%20Maven&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "apache-tomcat",
     "name": "Apache Tomcat",
     "url": "https://img.shields.io/badge/apache%20tomcat-%23F8DC75.svg?style=for-the-badge&logo=apache-tomcat&logoColor=black",
     "markdown": "![Apache Tomcat](https://img.shields.io/badge/apache%20tomcat-%23F8DC75.svg?style=for-the-badge&logo=apache-tomcat&logoColor=black)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "gunicorn",
     "name": "Gunicorn",
     "url": "https://img.shields.io/badge/gunicorn-%298729.svg?style=for-the-badge&logo=gunicorn&logoColor=white",
     "markdown": "![Gunicorn](https://img.shields.io/badge/gunicorn-%298729.svg?style=for-the-badge&logo=gunicorn&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "jenkins",
     "name": "Jenkins",
     "url": "https://img.shields.io/badge/jenkins-%232C5263.svg?style=for-the-badge&logo=jenkins&logoColor=white",
     "markdown": "![Jenkins](https://img.shields.io/badge/jenkins-%232C5263.svg?style=for-the-badge&logo=jenkins&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "nginx",
     "name": "Nginx",
     "url": "https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white",
     "markdown": "![Nginx](https://img.shields.io/badge/nginx-%23009639.svg?style=for-the-badge&logo=nginx&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "nginx-proxy-manager",
     "name": "Nginx Proxy Manager",
     "url": "https://img.shields.io/badge/nginx_proxy_manager-%23F15833.svg?style=for-the-badge&logo=nginxproxymanager&logoColor=white",
     "markdown": "![Nginx Proxy Manager](https://img.shields.io/badge/nginx_proxy_manager-%23F15833.svg?style=for-the-badge&logo=nginxproxymanager&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "portainer",
     "name": "Portainer",
     "url": "https://img.shields.io/badge/portainer-%2313BEF9.svg?style=for-the-badge&logo=portainer&logoColor=white",
     "markdown": "![Portainer](https://img.shields.io/badge/portainer-%2313BEF9.svg?style=for-the-badge&logo=portainer&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "progress-kemp-virtual-loadmaster",
     "name": "Progress Kemp Virtual LoadMaster",
     "url": "https://img.shields.io/badge/Kemp%20VLM-%23fedd00.svg?style=for-the-badge&logo=progress&logoColor=%235ce500",
     "markdown": "![Kemp VLM](https://img.shields.io/badge/Kemp%20VLM-%23fedd00.svg?style=for-the-badge&logo=progress&logoColor=%235ce500)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "traefikproxy",
     "name": "TraefikProxy",
     "url": "https://img.shields.io/badge/Traefik-%252300314b.svg?style=for-the-badge&logo=traefikproxy&logoColor=white",
     "markdown": "![TraefikProxy](https://img.shields.io/badge/Traefik-%252300314b.svg?style=for-the-badge&logo=traefikproxy&logoColor=white)",
-    "category": "Servers"
+    "categories": [
+      "Servers"
+    ]
   },
   {
     "id": "airtable",
     "name": "Airtable",
     "url": "https://img.shields.io/badge/Airtable-18BFFF?style=for-the-badge&logo=Airtable&logoColor=white",
     "markdown": "![Airtable](https://img.shields.io/badge/Airtable-18BFFF?style=for-the-badge&logo=Airtable&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "bluesky",
     "name": "Bluesky",
     "url": "https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=Bluesky&logoColor=white",
     "markdown": "![Bluesky](https://img.shields.io/badge/Bluesky-0285FF?style=for-the-badge&logo=Bluesky&logoColor=white)",
-    "category": "Social"
-  },
-  {
-    "id": "buy-me-a-coffee-social",
-    "name": "Buy Me a Coffee",
-    "url": "https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black",
-    "markdown": "![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-ffdd00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=black)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "calendly",
     "name": "Calendly",
     "url": "https://img.shields.io/badge/Calendly-%23006BFF.svg?style=for-the-badge&logo=Calendly&logoColor=white",
     "markdown": "![Calendly](https://img.shields.io/badge/Calendly-%23006BFF.svg?style=for-the-badge&logo=Calendly&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "chess.com",
     "name": "Chess.com",
     "url": "https://img.shields.io/badge/Chess.com-81B64C?style=for-the-badge&logo=chessdotcom&logoColor=white",
     "markdown": "![Chess.com](https://img.shields.io/badge/Chess.com-81B64C?style=for-the-badge&logo=chessdotcom&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "discord",
     "name": "Discord",
     "url": "https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white",
     "markdown": "![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "element",
     "name": "Element",
     "url": "https://img.shields.io/badge/element-0DBD8B.svg?style=for-the-badge&logo=element&logoColor=white",
     "markdown": "![Element](https://img.shields.io/badge/element-0DBD8B.svg?style=for-the-badge&logo=element&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "facebook",
     "name": "Facebook",
     "url": "https://img.shields.io/badge/Facebook-%231877F2.svg?style=for-the-badge&logo=Facebook&logoColor=white",
     "markdown": "![Facebook](https://img.shields.io/badge/Facebook-%231877F2.svg?style=for-the-badge&logo=Facebook&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "gmail",
     "name": "Gmail",
     "url": "https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white",
     "markdown": "![Gmail](https://img.shields.io/badge/Gmail-D14836?style=for-the-badge&logo=gmail&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "goodreads",
     "name": "Goodreads",
     "url": "https://img.shields.io/badge/Goodreads-F3F1EA?style=for-the-badge&logo=goodreads&logoColor=372213",
     "markdown": "![Goodreads](https://img.shields.io/badge/Goodreads-F3F1EA?style=for-the-badge&logo=goodreads&logoColor=372213)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "google-meet",
     "name": "Google Meet",
     "url": "https://img.shields.io/badge/Google%20Meet-00897B?style=for-the-badge&logo=google-meet&logoColor=white",
     "markdown": "![Google Meet](https://img.shields.io/badge/Google%20Meet-00897B?style=for-the-badge&logo=google-meet&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "instagram",
     "name": "Instagram",
     "url": "https://img.shields.io/badge/Instagram-%23E4405F.svg?style=for-the-badge&logo=Instagram&logoColor=white",
     "markdown": "![Instagram](https://img.shields.io/badge/Instagram-%23E4405F.svg?style=for-the-badge&logo=Instagram&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "kakaotalk",
     "name": "KakaoTalk",
     "url": "https://img.shields.io/badge/kakaotalk-ffcd00.svg?style=for-the-badge&logo=kakaotalk&logoColor=000000",
     "markdown": "![KakaoTalk](https://img.shields.io/badge/kakaotalk-ffcd00.svg?style=for-the-badge&logo=kakaotalk&logoColor=000000)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "lichess",
     "name": "Lichess",
     "url": "https://img.shields.io/badge/Lichess-000000?style=for-the-badge&logo=lichess&logoColor=white",
     "markdown": "![Lichess](https://img.shields.io/badge/Lichess-000000?style=for-the-badge&logo=lichess&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "line",
     "name": "Line",
     "url": "https://img.shields.io/badge/Line-00C300?style=for-the-badge&logo=line&logoColor=white",
     "markdown": "![Line](https://img.shields.io/badge/Line-00C300?style=for-the-badge&logo=line&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "linkedin",
     "name": "LinkedIn",
     "url": "https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white",
     "markdown": "![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "linktree",
     "name": "Linktree",
     "url": "https://img.shields.io/badge/linktree-1de9b6?style=for-the-badge&logo=linktree&logoColor=white",
     "markdown": "![Linktree](https://img.shields.io/badge/linktree-1de9b6?style=for-the-badge&logo=linktree&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "mastodon",
     "name": "Mastodon",
     "url": "https://img.shields.io/badge/-MASTODON-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white",
     "markdown": "![Mastodon](https://img.shields.io/badge/-MASTODON-%232B90D9?style=for-the-badge&logo=mastodon&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "matrix",
     "name": "Matrix",
     "url": "https://img.shields.io/badge/matrix-%23000000?style=for-the-badge&logo=matrix&logoColor=white",
     "markdown": "![Matrix](https://img.shields.io/badge/matrix-%23000000?style=for-the-badge&logo=matrix&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "meetup",
     "name": "Meetup",
     "url": "https://img.shields.io/badge/Meetup-f64363?style=for-the-badge&logo=meetup&logoColor=white",
     "markdown": "![Meetup](https://img.shields.io/badge/Meetup-f64363?style=for-the-badge&logo=meetup&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "messenger",
     "name": "Messenger",
     "url": "https://img.shields.io/badge/Messenger-00B2FF?style=for-the-badge&logo=messenger&logoColor=white",
     "markdown": "![Messenger](https://img.shields.io/badge/Messenger-00B2FF?style=for-the-badge&logo=messenger&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "misskey",
     "name": "Misskey",
     "url": "https://img.shields.io/badge/Misskey-%232EC866.svg?style=for-the-badge&logo=misskey&logoColor=white",
     "markdown": "![Misskey](https://img.shields.io/badge/Misskey-%232EC866.svg?style=for-the-badge&logo=misskey&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "odysee",
     "name": "Odysee",
     "url": "https://img.shields.io/badge/odysee-EF1970?style=for-the-badge&logo=Odysee&logoColor=white",
     "markdown": "![Odysee](https://img.shields.io/badge/odysee-EF1970?style=for-the-badge&logo=Odysee&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "outlook",
     "name": "Outlook",
     "url": "https://img.shields.io/badge/Microsoft_Outlook-0078D4?style=for-the-badge&logo=microsoft-outlook&logoColor=white",
     "markdown": "![Outlook](https://img.shields.io/badge/Microsoft_Outlook-0078D4?style=for-the-badge&logo=microsoft-outlook&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "pinterest",
     "name": "Pinterest",
     "url": "https://img.shields.io/badge/Pinterest-%23E60023.svg?style=for-the-badge&logo=Pinterest&logoColor=white",
     "markdown": "![Pinterest](https://img.shields.io/badge/Pinterest-%23E60023.svg?style=for-the-badge&logo=Pinterest&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "polywork",
     "name": "Polywork",
     "url": "https://img.shields.io/badge/Polywork-543DE0?style=for-the-badge&logo=polywork&logoColor=black",
     "markdown": "![Polywork](https://img.shields.io/badge/Polywork-543DE0?style=for-the-badge&logo=polywork&logoColor=black)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "protonmail",
     "name": "Protonmail",
     "url": "https://img.shields.io/badge/ProtonMail-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white",
     "markdown": "![Protonmail](https://img.shields.io/badge/ProtonMail-8B89CC?style=for-the-badge&logo=protonmail&logoColor=white)",
-    "category": "Social"
-  },
-  {
-    "id": "reddit-social",
-    "name": "Reddit",
-    "url": "https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white",
-    "markdown": "![Reddit](https://img.shields.io/badge/Reddit-FF4500?style=for-the-badge&logo=reddit&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "session",
     "name": "Session",
     "url": "https://img.shields.io/badge/Session-%23000000.svg?style=for-the-badge&logo=Session&logoColor=02f780",
     "markdown": "![Session](https://img.shields.io/badge/Session-%23000000.svg?style=for-the-badge&logo=Session&logoColor=02f780)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "showwcase",
     "name": "Showwcase",
     "url": "https://img.shields.io/badge/showwcase-%230A0D14.svg?style=for-the-badge&logo=showwcase&logoColor=white",
     "markdown": "![Showwcase](https://img.shields.io/badge/showwcase-%230A0D14.svg?style=for-the-badge&logo=showwcase&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "signal",
     "name": "Signal",
     "url": "https://img.shields.io/badge/Signal-%23039BE5.svg?style=for-the-badge&logo=Signal&logoColor=white",
     "markdown": "![Signal](https://img.shields.io/badge/Signal-%23039BE5.svg?style=for-the-badge&logo=Signal&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "skype",
     "name": "Skype",
     "url": "https://img.shields.io/badge/Skype-%2300AFF0.svg?style=for-the-badge&logo=Skype&logoColor=white",
     "markdown": "![Skype](https://img.shields.io/badge/Skype-%2300AFF0.svg?style=for-the-badge&logo=Skype&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "slack",
     "name": "Slack",
     "url": "https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white",
     "markdown": "![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "snapchat",
     "name": "Snapchat",
     "url": "https://img.shields.io/badge/Snapchat-%23FFFC00.svg?style=for-the-badge&logo=Snapchat&logoColor=white",
     "markdown": "![Snapchat](https://img.shields.io/badge/Snapchat-%23FFFC00.svg?style=for-the-badge&logo=Snapchat&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "teamspeak",
     "name": "TeamSpeak",
     "url": "https://img.shields.io/badge/TeamSpeak-2580C3?style=for-the-badge&logo=teamspeak&logoColor=white",
     "markdown": "![TeamSpeak](https://img.shields.io/badge/TeamSpeak-2580C3?style=for-the-badge&logo=teamspeak&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "telegram",
     "name": "Telegram",
     "url": "https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white",
     "markdown": "![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "tencent-qq",
     "name": "Tencent QQ",
     "url": "https://img.shields.io/badge/Tencent_QQ-%2312B7F5?style=for-the-badge&logo=qq&logoColor=white",
     "markdown": "![Tencent QQ](https://img.shields.io/badge/Tencent_QQ-%2312B7F5?style=for-the-badge&logo=qq&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "threads",
     "name": "Threads",
     "url": "https://img.shields.io/badge/Threads-000000?style=for-the-badge&logo=Threads&logoColor=white",
     "markdown": "![Threads](https://img.shields.io/badge/Threads-000000?style=for-the-badge&logo=Threads&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "thunderbird",
     "name": "Thunderbird",
     "url": "https://img.shields.io/badge/Thunderbird-0A84FF.svg?style=for-the-badge&logo=Thunderbird&logoColor=white",
     "markdown": "![Thunderbird](https://img.shields.io/badge/Thunderbird-0A84FF.svg?style=for-the-badge&logo=Thunderbird&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "tiktok",
     "name": "TikTok",
     "url": "https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white",
     "markdown": "![TikTok](https://img.shields.io/badge/TikTok-%23000000.svg?style=for-the-badge&logo=TikTok&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "tumblr",
     "name": "Tumblr",
     "url": "https://img.shields.io/badge/Tumblr-%2336465D.svg?style=for-the-badge&logo=Tumblr&logoColor=white",
     "markdown": "![Tumblr](https://img.shields.io/badge/Tumblr-%2336465D.svg?style=for-the-badge&logo=Tumblr&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "tutanota",
     "name": "Tutanota",
     "url": "https://img.shields.io/badge/Tutanota-840010?style=for-the-badge&logo=Tutanota&logoColor=white",
     "markdown": "![Tutanota](https://img.shields.io/badge/Tutanota-840010?style=for-the-badge&logo=Tutanota&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "twitch",
     "name": "Twitch",
     "url": "https://img.shields.io/badge/Twitch-%239146FF.svg?style=for-the-badge&logo=Twitch&logoColor=white",
     "markdown": "![Twitch](https://img.shields.io/badge/Twitch-%239146FF.svg?style=for-the-badge&logo=Twitch&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social",
+      "Streaming"
+    ]
   },
   {
     "id": "viber",
     "name": "Viber",
     "url": "https://img.shields.io/badge/Viber-8B66A9?style=for-the-badge&logo=viber&logoColor=white",
     "markdown": "![Viber](https://img.shields.io/badge/Viber-8B66A9?style=for-the-badge&logo=viber&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "wechat",
     "name": "WeChat",
     "url": "https://img.shields.io/badge/WeChat-07C160?style=for-the-badge&logo=wechat&logoColor=white",
     "markdown": "![WeChat](https://img.shields.io/badge/WeChat-07C160?style=for-the-badge&logo=wechat&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "whatsapp",
     "name": "WhatsApp",
     "url": "https://img.shields.io/badge/WhatsApp-25D366?style=for-the-badge&logo=whatsapp&logoColor=white",
     "markdown": "![WhatsApp](https://img.shields.io/badge/WhatsApp-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "wire",
     "name": "Wire",
     "url": "https://img.shields.io/badge/Wire-B71C1C?style=for-the-badge&logo=wire&logoColor=white",
     "markdown": "![Wire](https://img.shields.io/badge/Wire-B71C1C?style=for-the-badge&logo=wire&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "x",
     "name": "X",
     "url": "https://img.shields.io/badge/X-%23000000.svg?style=for-the-badge&logo=X&logoColor=white",
     "markdown": "![X](https://img.shields.io/badge/X-%23000000.svg?style=for-the-badge&logo=X&logoColor=white)",
-    "category": "Social"
-  },
-  {
-    "id": "xbox-social",
-    "name": "Xbox",
-    "url": "https://img.shields.io/badge/Xbox-%23107C10.svg?style=for-the-badge&logo=Xbox&logoColor=white",
-    "markdown": "![Xbox](https://img.shields.io/badge/Xbox-%23107C10.svg?style=for-the-badge&logo=Xbox&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "xing",
     "name": "XING",
     "url": "https://img.shields.io/badge/xing-%23006567.svg?style=for-the-badge&logo=xing&logoColor=white",
     "markdown": "![XING](https://img.shields.io/badge/xing-%23006567.svg?style=for-the-badge&logo=xing&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "youtube",
     "name": "YouTube",
     "url": "https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white",
     "markdown": "![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "zoom",
     "name": "Zoom",
     "url": "https://img.shields.io/badge/Zoom-2D8CFF?style=for-the-badge&logo=zoom&logoColor=white",
     "markdown": "![Zoom](https://img.shields.io/badge/Zoom-2D8CFF?style=for-the-badge&logo=zoom&logoColor=white)",
-    "category": "Social"
+    "categories": [
+      "Social"
+    ]
   },
   {
     "id": "apple",
     "name": "Apple",
     "url": "https://img.shields.io/badge/Apple-%23000000.svg?style=for-the-badge&logo=apple&logoColor=white",
     "markdown": "![Apple](https://img.shields.io/badge/Apple-%23000000.svg?style=for-the-badge&logo=apple&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "asus",
     "name": "ASUS",
     "url": "https://img.shields.io/badge/asus-000080.svg?style=for-the-badge&logo=asus&logoColor=white",
     "markdown": "![ASUS](https://img.shields.io/badge/asus-000080.svg?style=for-the-badge&logo=asus&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "blackberry",
     "name": "BlackBerry",
     "url": "https://img.shields.io/badge/blackberry-808080.svg?style=for-the-badge&logo=blackberry&logoColor=white",
     "markdown": "![BlackBerry](https://img.shields.io/badge/blackberry-808080.svg?style=for-the-badge&logo=blackberry&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "huawei",
     "name": "Huawei",
     "url": "https://img.shields.io/badge/Huawei-%23FF0000.svg?style=for-the-badge&logo=huawei&logoColor=white",
     "markdown": "![Huawei](https://img.shields.io/badge/Huawei-%23FF0000.svg?style=for-the-badge&logo=huawei&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "lenovo",
     "name": "Lenovo",
     "url": "https://img.shields.io/badge/lenovo-E2231A?style=for-the-badge&logo=lenovo&logoColor=white",
     "markdown": "![Lenovo](https://img.shields.io/badge/lenovo-E2231A?style=for-the-badge&logo=lenovo&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "lg",
     "name": "LG",
     "url": "https://img.shields.io/badge/lg-a50034.svg?style=for-the-badge&logo=lg&logoColor=white",
     "markdown": "![LG](https://img.shields.io/badge/lg-a50034.svg?style=for-the-badge&logo=lg&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "motorola",
     "name": "Motorola",
     "url": "https://img.shields.io/badge/Motorola-%23E1140A.svg?style=for-the-badge&logo=motorola&logoColor=white",
     "markdown": "![Motorola](https://img.shields.io/badge/Motorola-%23E1140A.svg?style=for-the-badge&logo=motorola&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "nokia",
     "name": "Nokia",
     "url": "https://img.shields.io/badge/Nokia-%23124191.svg?style=for-the-badge&logo=nokia&logoColor=white",
     "markdown": "![Nokia](https://img.shields.io/badge/Nokia-%23124191.svg?style=for-the-badge&logo=nokia&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "oneplus",
     "name": "OnePlus",
     "url": "https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white",
     "markdown": "![OnePlus](https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "oppo",
     "name": "Oppo",
     "url": "https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white",
     "markdown": "![Oppo](https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "samsung",
     "name": "Samsung",
     "url": "https://img.shields.io/badge/Samsung-%231428A0.svg?style=for-the-badge&logo=samsung&logoColor=white",
     "markdown": "![Samsung](https://img.shields.io/badge/Samsung-%231428A0.svg?style=for-the-badge&logo=samsung&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "vivo",
     "name": "Vivo",
     "url": "https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black",
     "markdown": "![Vivo](https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "xiaomi",
     "name": "Xiaomi",
     "url": "https://img.shields.io/badge/Xiaomi-%23FF6900.svg?style=for-the-badge&logo=xiaomi&logoColor=white",
     "markdown": "![Xiaomi](https://img.shields.io/badge/Xiaomi-%23FF6900.svg?style=for-the-badge&logo=xiaomi&logoColor=white)",
-    "category": "Smartphone"
+    "categories": [
+      "Smartphone"
+    ]
   },
   {
     "id": "app-store",
     "name": "App Store",
     "url": "https://img.shields.io/badge/App_Store-0D96F6?style=for-the-badge&logo=app-store&logoColor=white",
     "markdown": "![App Store](https://img.shields.io/badge/App_Store-0D96F6?style=for-the-badge&logo=app-store&logoColor=white)",
-    "category": "Store"
+    "categories": [
+      "Store"
+    ]
   },
   {
     "id": "appgallery",
     "name": "AppGallery",
     "url": "https://img.shields.io/badge/AppGallery-C80A2D?style=for-the-badge&logo=huawei&logoColor=white",
     "markdown": "![AppGallery](https://img.shields.io/badge/AppGallery-C80A2D?style=for-the-badge&logo=huawei&logoColor=white)",
-    "category": "Store"
+    "categories": [
+      "Store"
+    ]
   },
   {
     "id": "f-droid",
     "name": "F-Droid",
     "url": "https://img.shields.io/badge/F_Droid-1976D2?style=for-the-badge&logo=f-droid&logoColor=white",
     "markdown": "![F Droid](https://img.shields.io/badge/F_Droid-1976D2?style=for-the-badge&logo=f-droid&logoColor=white)",
-    "category": "Store"
+    "categories": [
+      "Store"
+    ]
   },
   {
     "id": "shopify",
     "name": "Shopify",
     "url": "https://img.shields.io/badge/shopify-7AB55C.svg?style=for-the-badge&logo=shopify&logoColor=white",
     "markdown": "![Shopify](https://img.shields.io/badge/shopify-7AB55C.svg?style=for-the-badge&logo=shopify&logoColor=white)",
-    "category": "Store"
+    "categories": [
+      "Store"
+    ]
   },
   {
     "id": "amazon-prime",
     "name": "Amazon Prime",
     "url": "https://img.shields.io/badge/Amazon%20Prime-0F79AF?style=for-the-badge&logo=amazonprime&logoColor=white",
     "markdown": "![Amazon Prime](https://img.shields.io/badge/Amazon%20Prime-0F79AF?style=for-the-badge&logo=amazonprime&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "apple-tv",
     "name": "Apple TV",
     "url": "https://img.shields.io/badge/Apple%20TV-000000?style=for-the-badge&logo=Apple%20TV&logoColor=white",
     "markdown": "![Apple TV](https://img.shields.io/badge/Apple%20TV-000000?style=for-the-badge&logo=Apple%20TV&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "bilibili",
     "name": "Bilibili",
     "url": "https://img.shields.io/badge/bilibili-00A1D6.svg?style=for-the-badge&logo=bilibili&logoColor=white",
     "markdown": "![Bilibili](https://img.shields.io/badge/bilibili-00A1D6.svg?style=for-the-badge&logo=bilibili&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "crunchyroll",
     "name": "Crunchyroll",
     "url": "https://img.shields.io/badge/Crunchyroll-F47521?style=for-the-badge&logo=crunchyroll&logoColor=white",
     "markdown": "![Crunchyroll](https://img.shields.io/badge/Crunchyroll-F47521?style=for-the-badge&logo=crunchyroll&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "disney",
     "name": "Disney",
     "url": "https://img.shields.io/badge/Disney-%23006E99.svg?style=for-the-badge&logo=disney&logoColor=white",
     "markdown": "![Disney](https://img.shields.io/badge/Disney-%23006E99.svg?style=for-the-badge&logo=disney&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "facebook-gaming",
     "name": "Facebook Gaming",
     "url": "https://img.shields.io/badge/Facebook%20Gaming-015BE5?style=for-the-badge&logo=facebookgaming&logoColor=white",
     "markdown": "![Facebook Gaming](https://img.shields.io/badge/Facebook%20Gaming-015BE5?style=for-the-badge&logo=facebookgaming&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "facebook-live",
     "name": "Facebook Live",
     "url": "https://img.shields.io/badge/Facebook%20Live-ED4242?style=for-the-badge&logo=Facebook%20Live&logoColor=white",
     "markdown": "![Facebook Live](https://img.shields.io/badge/Facebook%20Live-ED4242?style=for-the-badge&logo=Facebook%20Live&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "fandango-at-home",
     "name": "Fandango At Home",
     "url": "https://img.shields.io/badge/Fandango%20At%20Home-3478C1?style=for-the-badge&logo=fandango&logoColor=white",
     "markdown": "![Fandango At Home](https://img.shields.io/badge/Fandango%20At%20Home-3478C1?style=for-the-badge&logo=fandango&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "fire-tv",
     "name": "Fire TV",
     "url": "https://img.shields.io/badge/fire%20tv-fc3b2d?style=for-the-badge&logo=amazon%20fire%20tv&logoColor=white",
     "markdown": "![Fire TV](https://img.shields.io/badge/fire%20tv-fc3b2d?style=for-the-badge&logo=amazon%20fire%20tv&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "fubo",
     "name": "Fubo",
     "url": "https://img.shields.io/badge/Fubo-E64526?style=for-the-badge&logo=fubo&logoColor=white",
     "markdown": "![Fubo](https://img.shields.io/badge/Fubo-E64526?style=for-the-badge&logo=fubo&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "hulu",
     "name": "Hulu",
     "url": "https://img.shields.io/badge/hulu-1CE783?style=for-the-badge&logo=hulu&logoColor=white",
     "markdown": "![Hulu](https://img.shields.io/badge/hulu-1CE783?style=for-the-badge&logo=hulu&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "kick",
     "name": "Kick",
     "url": "https://img.shields.io/badge/kick-53FC18?style=for-the-badge&logo=kick&logoColor=white",
     "markdown": "![Kick](https://img.shields.io/badge/kick-53FC18?style=for-the-badge&logo=kick&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "netflix",
     "name": "Netflix",
     "url": "https://img.shields.io/badge/Netflix-E50914?style=for-the-badge&logo=netflix&logoColor=white",
     "markdown": "![Netflix](https://img.shields.io/badge/Netflix-E50914?style=for-the-badge&logo=netflix&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "roku",
     "name": "Roku",
     "url": "https://img.shields.io/badge/roku-6f1ab1?style=for-the-badge&logo=roku&logoColor=white",
     "markdown": "![Roku](https://img.shields.io/badge/roku-6f1ab1?style=for-the-badge&logo=roku&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "tubi",
     "name": "Tubi",
     "url": "https://img.shields.io/badge/Tubi-6A18F5?style=for-the-badge&logo=tubi&logoColor=white",
     "markdown": "![Tubi](https://img.shields.io/badge/Tubi-6A18F5?style=for-the-badge&logo=tubi&logoColor=white)",
-    "category": "Streaming"
-  },
-  {
-    "id": "twitch-streaming",
-    "name": "Twitch",
-    "url": "https://img.shields.io/badge/Twitch-9347FF?style=for-the-badge&logo=twitch&logoColor=white",
-    "markdown": "![Twitch](https://img.shields.io/badge/Twitch-9347FF?style=for-the-badge&logo=twitch&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "youtube-gaming",
     "name": "Youtube Gaming",
     "url": "https://img.shields.io/badge/Youtube%20Gaming-FF0000?style=for-the-badge&logo=Youtubegaming&logoColor=white",
     "markdown": "![Youtube Gaming](https://img.shields.io/badge/Youtube%20Gaming-FF0000?style=for-the-badge&logo=Youtubegaming&logoColor=white)",
-    "category": "Streaming"
+    "categories": [
+      "Streaming"
+    ]
   },
   {
     "id": "alacritty",
     "name": "Alacritty",
     "url": "https://img.shields.io/badge/alacritty-%23F46D01?style=for-the-badge&logo=alacritty&logoColor=white",
     "markdown": "![Alacritty](https://img.shields.io/badge/alacritty-%23F46D01?style=for-the-badge&logo=alacritty&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "gnome-terminal",
     "name": "GNOME Terminal",
     "url": "https://img.shields.io/badge/gnometerminal-%23ffffff.svg?style=for-the-badge&logo=gnometerminal&logoColor=%23241F31",
     "markdown": "![GNOME Terminal](https://img.shields.io/badge/gnometerminal-%23ffffff.svg?style=for-the-badge&logo=gnometerminal&logoColor=%23241F31)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "hyper",
     "name": "Hyper",
     "url": "https://img.shields.io/badge/Hyper-%23000000?style=for-the-badge&logo=hyper&logoColor=white",
     "markdown": "![Hyper](https://img.shields.io/badge/Hyper-%23000000?style=for-the-badge&logo=hyper&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "iterm2",
     "name": "iTerm2",
     "url": "https://img.shields.io/badge/iTerm2-%23000000?style=for-the-badge&logo=iterm2&logoColor=white",
     "markdown": "![iTerm2](https://img.shields.io/badge/iTerm2-%23000000?style=for-the-badge&logo=iterm2&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "starship",
     "name": "Starship",
     "url": "https://img.shields.io/badge/starship-%23DD0B78?style=for-the-badge&logo=starship&logoColor=white",
     "markdown": "![Starship](https://img.shields.io/badge/starship-%23DD0B78?style=for-the-badge&logo=starship&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "termius",
     "name": "Termius",
     "url": "https://img.shields.io/badge/termius-%23000000?style=for-the-badge&logo=termius&logoColor=white",
     "markdown": "![Termius](https://img.shields.io/badge/termius-%23000000?style=for-the-badge&logo=termius&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "tmux",
     "name": "tmux",
     "url": "https://img.shields.io/badge/tmux-%23000000?style=for-the-badge&logo=tmux&logoColor=%231BB91F",
     "markdown": "![tmux](https://img.shields.io/badge/tmux-%23000000?style=for-the-badge&logo=tmux&logoColor=%231BB91F)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "warp",
     "name": "Warp",
     "url": "https://img.shields.io/badge/warp-%2301A4FF?style=for-the-badge&logo=warp&logoColor=white",
     "markdown": "![Warp](https://img.shields.io/badge/warp-%2301A4FF?style=for-the-badge&logo=warp&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "wezterm",
     "name": "WezTerm",
     "url": "https://img.shields.io/badge/WezTerm-%234E49EE?style=for-the-badge&logo=wezterm&logoColor=white",
     "markdown": "![WezTerm](https://img.shields.io/badge/WezTerm-%234E49EE?style=for-the-badge&logo=wezterm&logoColor=white)",
-    "category": "Terminals"
+    "categories": [
+      "Terminals"
+    ]
   },
   {
     "id": "apifox",
     "name": "Apifox",
     "url": "https://img.shields.io/badge/Apifox-%23FF6600.svg?style=for-the-badge&logo=apifox&logoColor=white",
     "markdown": "![Apifox](https://img.shields.io/badge/Apifox-%23FF6600.svg?style=for-the-badge&logo=apifox&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "cypress",
     "name": "Cypress",
     "url": "https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e",
     "markdown": "![cypress](https://img.shields.io/badge/-cypress-%23E5E5E5?style=for-the-badge&logo=cypress&logoColor=058a5e)",
-    "category": "Testing"
-  },
-  {
-    "id": "jasmine-testing",
-    "name": "Jasmine",
-    "url": "https://img.shields.io/badge/-Jasmine-%238A4182?style=for-the-badge&logo=Jasmine&logoColor=white",
-    "markdown": "![Jasmine](https://img.shields.io/badge/-Jasmine-%238A4182?style=for-the-badge&logo=Jasmine&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "jest",
     "name": "Jest",
     "url": "https://img.shields.io/badge/-jest-%23C21325?style=for-the-badge&logo=jest&logoColor=white",
     "markdown": "![Jest](https://img.shields.io/badge/-jest-%23C21325?style=for-the-badge&logo=jest&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "mocha",
     "name": "Mocha",
     "url": "https://img.shields.io/badge/-mocha-%238D6748?style=for-the-badge&logo=mocha&logoColor=white",
     "markdown": "![Mocha](https://img.shields.io/badge/-mocha-%238D6748?style=for-the-badge&logo=mocha&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "playwright",
     "name": "Playwright",
     "url": "https://img.shields.io/badge/-playwright-%232EAD33?style=for-the-badge&logo=playwright&logoColor=white",
     "markdown": "![Playwright](https://img.shields.io/badge/-playwright-%232EAD33?style=for-the-badge&logo=playwright&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "puppeteer",
     "name": "Puppeteer",
     "url": "https://img.shields.io/badge/Puppeteer-%2340B5A4.svg?style=for-the-badge&logo=Puppeteer&logoColor=black",
     "markdown": "![Puppeteer](https://img.shields.io/badge/Puppeteer-%2340B5A4.svg?style=for-the-badge&logo=Puppeteer&logoColor=black)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "pytest",
     "name": "Pytest",
     "url": "https://img.shields.io/badge/pytest-%23ffffff.svg?style=for-the-badge&logo=pytest&logoColor=2f9fe3",
     "markdown": "![Pytest](https://img.shields.io/badge/pytest-%23ffffff.svg?style=for-the-badge&logo=pytest&logoColor=2f9fe3)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "selenium",
     "name": "Selenium",
     "url": "https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white",
     "markdown": "![Selenium](https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "sentry",
     "name": "Sentry",
     "url": "https://img.shields.io/badge/sentry-%23362D59.svg?style=for-the-badge&logo=sentry&logoColor=white",
     "markdown": "![Sentry](https://img.shields.io/badge/sentry-%23362D59.svg?style=for-the-badge&logo=sentry&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "testing-library",
     "name": "Testing Library",
     "url": "https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white",
     "markdown": "![Testing-Library](https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "vitest",
     "name": "Vitest",
     "url": "https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B",
     "markdown": "![Vitest](https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B)",
-    "category": "Testing"
+    "categories": [
+      "Testing"
+    ]
   },
   {
     "id": "apache-subversion",
     "name": "Apache Subversion",
     "url": "https://img.shields.io/badge/subversion-%23809CC9.svg?style=for-the-badge&logo=subversion&logoColor=white",
     "markdown": "![Apache Subversion](https://img.shields.io/badge/subversion-%23809CC9.svg?style=for-the-badge&logo=subversion&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "bitbucket",
     "name": "Bitbucket",
     "url": "https://img.shields.io/badge/bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white",
     "markdown": "![Bitbucket](https://img.shields.io/badge/bitbucket-%230047B3.svg?style=for-the-badge&logo=bitbucket&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "forgejo",
     "name": "Forgejo",
     "url": "https://img.shields.io/badge/forgejo-%23FB923C.svg?style=for-the-badge&logo=forgejo&logoColor=white",
     "markdown": "![Forgejo](https://img.shields.io/badge/forgejo-%23FB923C.svg?style=for-the-badge&logo=forgejo&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "git",
     "name": "Git",
     "url": "https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white",
     "markdown": "![Git](https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "gitea",
     "name": "Gitea",
     "url": "https://img.shields.io/badge/Gitea-34495E?style=for-the-badge&logo=gitea&logoColor=5D9425",
     "markdown": "![Gitea](https://img.shields.io/badge/Gitea-34495E?style=for-the-badge&logo=gitea&logoColor=5D9425)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "gitee",
     "name": "Gitee",
     "url": "https://img.shields.io/badge/Gitee-C71D23?style=for-the-badge&logo=gitee&logoColor=white",
     "markdown": "![Gitee](https://img.shields.io/badge/Gitee-C71D23?style=for-the-badge&logo=gitee&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "github",
     "name": "GitHub",
     "url": "https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white",
     "markdown": "![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "gitlab",
     "name": "GitLab",
     "url": "https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white",
     "markdown": "![GitLab](https://img.shields.io/badge/gitlab-%23181717.svg?style=for-the-badge&logo=gitlab&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "gitpod",
     "name": "Gitpod",
     "url": "https://img.shields.io/badge/gitpod-f06611.svg?style=for-the-badge&logo=gitpod&logoColor=white",
     "markdown": "![Gitpod](https://img.shields.io/badge/gitpod-f06611.svg?style=for-the-badge&logo=gitpod&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "mercurial",
     "name": "Mercurial",
     "url": "https://img.shields.io/badge/mercurial-999999.svg?style=for-the-badge&logo=mercurial&logoColor=white",
     "markdown": "![Mercurial](https://img.shields.io/badge/mercurial-999999.svg?style=for-the-badge&logo=mercurial&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "perforce-helix",
     "name": "Perforce Helix",
     "url": "https://img.shields.io/badge/-PERFORCE%20HELIX-00AEEF?style=for-the-badge&logo=Perforce&logoColor=white",
     "markdown": "![Perforce Helix](https://img.shields.io/badge/-PERFORCE%20HELIX-00AEEF?style=for-the-badge&logo=Perforce&logoColor=white)",
-    "category": "Version Control"
+    "categories": [
+      "Version Control"
+    ]
   },
   {
     "id": "fitbit",
     "name": "Fitbit",
     "url": "https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white",
     "markdown": "![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)",
-    "category": "Wearables"
+    "categories": [
+      "Wearables"
+    ]
   },
   {
     "id": "angellist",
     "name": "AngelList",
     "url": "https://img.shields.io/badge/AngelList-%23D4D4D4.svg?style=for-the-badge&logo=AngelList&logoColor=black",
     "markdown": "![AngelList](https://img.shields.io/badge/AngelList-%23D4D4D4.svg?style=for-the-badge&logo=AngelList&logoColor=black)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   },
   {
     "id": "behance",
     "name": "Behance",
     "url": "https://img.shields.io/badge/Behance-1769ff?style=for-the-badge&logo=behance&logoColor=white",
     "markdown": "![Behance](https://img.shields.io/badge/Behance-1769ff?style=for-the-badge&logo=behance&logoColor=white)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   },
   {
     "id": "freelancer",
     "name": "Freelancer",
     "url": "https://img.shields.io/badge/Freelancer-29B2FE?style=for-the-badge&logo=Freelancer&logoColor=white",
     "markdown": "![Freelancer](https://img.shields.io/badge/Freelancer-29B2FE?style=for-the-badge&logo=Freelancer&logoColor=white)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   },
   {
     "id": "glassdoor",
     "name": "Glassdoor",
     "url": "https://img.shields.io/badge/Glassdoor-00A162?style=for-the-badge&logo=Glassdoor&logoColor=white",
     "markdown": "![Glassdoor](https://img.shields.io/badge/Glassdoor-00A162?style=for-the-badge&logo=Glassdoor&logoColor=white)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   },
   {
     "id": "hacker-earth",
     "name": "Hacker Earth",
     "url": "https://img.shields.io/badge/HackerEarth-%232C3454.svg?style=for-the-badge&logo=HackerEarth&logoColor=Blue",
     "markdown": "![HackerEarth](https://img.shields.io/badge/HackerEarth-%232C3454.svg?style=for-the-badge&logo=HackerEarth&logoColor=Blue)",
-    "category": "Jobs"
-  },
-  {
-    "id": "hackerrank-jobs",
-    "name": "HackerRank",
-    "url": "https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white",
-    "markdown": "![HackerRank](https://img.shields.io/badge/-Hackerrank-2EC866?style=for-the-badge&logo=HackerRank&logoColor=white)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   },
   {
     "id": "indeed",
     "name": "Indeed",
     "url": "https://img.shields.io/badge/indeed-003A9B?style=for-the-badge&logo=indeed&logoColor=white",
     "markdown": "![Indeed](https://img.shields.io/badge/indeed-003A9B?style=for-the-badge&logo=indeed&logoColor=white)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   },
   {
     "id": "upwork",
     "name": "Upwork",
     "url": "https://img.shields.io/badge/UpWork-6FDA44?style=for-the-badge&logo=Upwork&logoColor=white",
     "markdown": "![Upwork](https://img.shields.io/badge/UpWork-6FDA44?style=for-the-badge&logo=Upwork&logoColor=white)",
-    "category": "Jobs"
+    "categories": [
+      "Jobs"
+    ]
   }
 ]

--- a/scripts/generate-badges.js
+++ b/scripts/generate-badges.js
@@ -74,26 +74,40 @@ async function main() {
 
     // sanitizeId encodes # → %23, ? → %3F, \ → %5C so the ID is safe
     // to use as an Astro static route path segment.
-    let id = sanitizeId(nameToId(name));
+    const id = sanitizeId(nameToId(name));
 
-    // Resolve ID collisions by appending the category slug
-    if (seenIds.has(id)) {
-      const suffix = currentCategory.toLowerCase().replace(/[\s/]+/g, "-");
-      id = `${id}-${suffix}`;
-      console.warn(`  ⚠ Collision: renamed to "${id}"`);
+    // Same URL already exists → merge the new category into that entry.
+    const existingByUrl = badges.find((b) => b.url === url);
+    if (existingByUrl) {
+      if (!existingByUrl.categories.includes(currentCategory)) {
+        existingByUrl.categories.push(currentCategory);
+        console.warn(`  ℹ "${name}": merged category "${currentCategory}" (same URL)`);
+      }
+      continue;
     }
-    seenIds.add(id);
 
-    badges.push({ id, name, url, markdown, category: currentCategory });
+    // Same name/ID but different URL (e.g. Bitcoin in Blockchain vs Cryptocurrency
+    // with slightly different badge colours) → merge categories, keep first URL.
+    const existingById = badges.find((b) => b.id === id);
+    if (existingById) {
+      if (!existingById.categories.includes(currentCategory)) {
+        existingById.categories.push(currentCategory);
+        console.warn(`  ℹ "${name}": merged category "${currentCategory}" (same name, different URL)`);
+      }
+      continue;
+    }
+
+    seenIds.add(id);
+    badges.push({ id, name, url, markdown, categories: [currentCategory] });
   }
 
   // ── Summary ─────────────────────────────────────────────────────────────────
-  const categories = [...new Set(badges.map((b) => b.category))];
+  const categories = [...new Set(badges.flatMap((b) => b.categories))];
   console.log(
-    `\nExtracted ${badges.length} badges across ${categories.size ?? categories.length} categories:`,
+    `\nExtracted ${badges.length} badges across ${categories.length} categories:`,
   );
   for (const cat of categories) {
-    const count = badges.filter((b) => b.category === cat).length;
+    const count = badges.filter((b) => b.categories.includes(cat)).length;
     console.log(`  ${cat}: ${count}`);
   }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -104,8 +104,8 @@ export function parseTableRow(line) {
 export function validateBadge(badge) {
   const errors = [];
 
-  const requiredFields = ['id', 'name', 'url', 'markdown', 'category'];
-  for (const field of requiredFields) {
+  const requiredStringFields = ['id', 'name', 'url', 'markdown'];
+  for (const field of requiredStringFields) {
     if (!Object.hasOwn(badge, field)) {
       errors.push(`missing field: ${field}`);
       continue;
@@ -113,6 +113,14 @@ export function validateBadge(badge) {
     if (typeof badge[field] !== 'string' || badge[field].trim() === '') {
       errors.push(`empty or non-string field: ${field}`);
     }
+  }
+
+  if (!Object.hasOwn(badge, 'categories')) {
+    errors.push(`missing field: categories`);
+  } else if (!Array.isArray(badge.categories) || badge.categories.length === 0) {
+    errors.push(`categories must be a non-empty array`);
+  } else if (badge.categories.some((c) => typeof c !== 'string' || c.trim() === '')) {
+    errors.push(`categories array contains empty or non-string values`);
   }
 
   if (badge.id && badge.id !== badge.id.toLowerCase()) {
@@ -143,8 +151,12 @@ export function validateBadge(badge) {
     }
   }
 
-  if (badge.category && /\p{Extended_Pictographic}/u.test(badge.category)) {
-    errors.push(`category contains emoji: ${badge.category}`);
+  if (Array.isArray(badge.categories)) {
+    for (const cat of badge.categories) {
+      if (typeof cat === 'string' && /\p{Extended_Pictographic}/u.test(cat)) {
+        errors.push(`category contains emoji: ${cat}`);
+      }
+    }
   }
 
   return errors;

--- a/src/components/badges/badge-card.tsx
+++ b/src/components/badges/badge-card.tsx
@@ -1,3 +1,4 @@
+import { EllipsisIcon } from "lucide-react";
 import { memo, type MouseEvent } from "react";
 
 import { BadgeFavoriteButton } from "@/components/badges/badge-favorite-button";
@@ -5,6 +6,14 @@ import { useBadgeSidebar } from "@/components/badges/badge-sidebar";
 import { CopyClipboardButton } from "@/components/copy-clipboard-button";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Typography } from "@/components/ui/typography";
 import { useFavorites } from "@/context/favorites-context";
 import { cn } from "@/lib/utils";
@@ -14,6 +23,7 @@ type BadgeCardProps = {
   selectable?: boolean;
   isSelected?: boolean;
   onToggle?: (badge: Badge) => void;
+  activeCategory?: string | null;
 };
 
 export const BadgeCard = memo(function BadgeCard({
@@ -21,11 +31,19 @@ export const BadgeCard = memo(function BadgeCard({
   selectable = false,
   isSelected = false,
   onToggle,
+  activeCategory,
 }: BadgeCardProps) {
-  const { name, url, category } = badge;
+  const { name, url, categories } = badge;
 
   const { isFavorite } = useFavorites();
   const { open } = useBadgeSidebar();
+
+  const primaryCategory =
+    activeCategory && categories.includes(activeCategory)
+      ? activeCategory
+      : categories[0];
+
+  const extraCategories = categories.filter((cat) => cat !== primaryCategory);
 
   const handleClick = (e: MouseEvent<HTMLDivElement>) => {
     if (selectable && (e.ctrlKey || e.metaKey)) {
@@ -81,16 +99,58 @@ export const BadgeCard = memo(function BadgeCard({
         {name}
       </Typography>
 
-      <Button
-        asChild
-        variant="outline"
-        size="sm"
-        className="text-muted-foreground"
-      >
-        <a href={`/?category=${category}`} onClick={(e) => e.stopPropagation()}>
-          {category}
-        </a>
-      </Button>
+      <div className="flex flex-wrap justify-center gap-2">
+        <Button
+          asChild
+          variant="outline"
+          size="xs"
+          className="text-muted-foreground"
+        >
+          <a
+            href={`/?category=${primaryCategory}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {primaryCategory}
+          </a>
+        </Button>
+
+        {extraCategories.length > 0 && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <EllipsisIcon className="size-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start">
+              <PopoverHeader>
+                <PopoverTitle>More categories</PopoverTitle>
+                <PopoverDescription className="flex flex-col gap-2 mt-2">
+                  {extraCategories.map((cat) => (
+                    <Button
+                      key={cat}
+                      asChild
+                      variant="outline"
+                      size="sm"
+                      className="text-muted-foreground"
+                    >
+                      <a
+                        href={`/?category=${cat}`}
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {cat}
+                      </a>
+                    </Button>
+                  ))}
+                </PopoverDescription>
+              </PopoverHeader>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
 
       <div className="absolute top-0.5 right-0.5 transition duration-300 flex flex-col items-center gap-0.5">
         <CopyClipboardButton content={`![${name}](${url})`} />

--- a/src/components/badges/badge-sidebar.tsx
+++ b/src/components/badges/badge-sidebar.tsx
@@ -89,12 +89,22 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
     <BadgeSidebarContext.Provider value={{ open, close }}>
       {children}
       <Sheet open={isOpen} onOpenChange={close}>
-        <SheetContent>
+        <SheetContent className="z-1000">
           <SheetHeader className="border-b ">
-            <SheetTitle asChild>
+            <SheetTitle>
               <Typography size="h3">{badge?.name}</Typography>
             </SheetTitle>
-            <SheetDescription>{badge?.category}</SheetDescription>
+            <SheetDescription className="flex flex-wrap gap-1">
+              {badge?.categories.map((cat) => (
+                <a
+                  key={cat}
+                  href={`/?category=${cat}`}
+                  className="inline-flex items-center rounded-sm border px-2 py-0.5 text-xs text-muted-foreground hover:bg-primary/10 hover:border-primary/80 transition"
+                >
+                  {cat}
+                </a>
+              ))}
+            </SheetDescription>
           </SheetHeader>
           <div className="px-6 space-y-8">
             <section>

--- a/src/components/badges/badges-list.tsx
+++ b/src/components/badges/badges-list.tsx
@@ -5,9 +5,14 @@ import { useSelection } from "@/context/selection-context";
 type BadgesListProps = {
   badges: Badge[];
   selectable?: boolean;
+  activeCategory?: string | null;
 };
 
-export function BadgesList({ badges, selectable = false }: BadgesListProps) {
+export function BadgesList({
+  badges,
+  selectable = false,
+  activeCategory,
+}: BadgesListProps) {
   const { isSelected, toggle } = useSelection();
 
   return (
@@ -20,6 +25,7 @@ export function BadgesList({ badges, selectable = false }: BadgesListProps) {
             selectable={selectable}
             isSelected={selectable && isSelected(badge.id)}
             onToggle={toggle}
+            activeCategory={activeCategory}
           />
         ))}
       </div>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -280,7 +280,7 @@ function SearchContent({
 
       {results.length > 0 && (
         <div>
-          <BadgesList badges={results} selectable />
+          <BadgesList badges={results} selectable activeCategory={categoryQuery} />
 
           {results.length < filteredBadges.length && (
             <div className="flex justify-center items-center gap-4 mt-8">

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,7 +9,7 @@ const badges = defineCollection({
     name: z.string(),
     url: z.url(),
     markdown: z.string(),
-    category: z.string(),
+    categories: z.array(z.string()),
   }),
 });
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,7 +6,7 @@ interface Badge {
   name: string;
   url: string;
   markdown: string;
-  category: string;
+  categories: string[];
 }
 
 interface SimpleIcon {

--- a/src/lib/badges.ts
+++ b/src/lib/badges.ts
@@ -6,7 +6,7 @@ export function getBadgeSEOData(badge: Badge) {
     `${badge.name} github badge`,
     `${badge.name} badge for github readme`,
     `${badge.name} readme badge`,
-    `${badge.category} badge`,
+    ...badge.categories.map((cat) => `${cat} badge`),
     "markdown badges",
     "github readme badges",
     "github profile badges",

--- a/src/pages/badges/[...id].astro
+++ b/src/pages/badges/[...id].astro
@@ -43,9 +43,16 @@ const badgeSEO = getBadgeSEOData(badge);
           <Typography as="h1" size="h1" className="mb-2">
             {badge.name} Badge
           </Typography>
-          <Typography variant="muted">
-            {badge.category}
-          </Typography>
+          <div class="flex flex-wrap gap-2">
+            {badge.categories.map((cat) => (
+              <a
+                href={`/?category=${cat}`}
+                class="inline-flex items-center rounded-sm border px-2 py-0.5 text-sm text-muted-foreground hover:bg-primary/10 hover:border-primary/80 transition"
+              >
+                {cat}
+              </a>
+            ))}
+          </div>
         </header>
         <section class="mb-4">
           <Typography as="h2" size="h4" className="mb-2"> Markdown </Typography>

--- a/src/services/badges.ts
+++ b/src/services/badges.ts
@@ -16,7 +16,7 @@ const matchesQuery = (query?: string | null) => (badge: Badge) => {
 };
 
 const matchesCategory = (category?: string | null) => (badge: Badge) =>
-  !category || badge.category === category;
+  !category || badge.categories.includes(category);
 
 export function filterBadges(filters: BadgeFilters): Badge[] {
   const allBadges = getBadges();
@@ -33,13 +33,15 @@ export function getBadges(): Badge[] {
 }
 
 export function getBadgeCategories(): string[] {
-  return [...new Set(getBadges().map((badge) => badge.category))];
+  return [...new Set(getBadges().flatMap((badge) => badge.categories))];
 }
 
 export function getBadgeCountByCategory(): Record<string, number> {
   return getBadges().reduce(
     (acc, badge) => {
-      acc[badge.category] = (acc[badge.category] || 0) + 1;
+      badge.categories.forEach((cat) => {
+        acc[cat] = (acc[cat] || 0) + 1;
+      });
       return acc;
     },
     {} as Record<string, number>,
@@ -48,6 +50,10 @@ export function getBadgeCountByCategory(): Record<string, number> {
 
 export function getRelatedBadges(badge: Badge, maxBadges: number = 4): Badge[] {
   return getBadges()
-    .filter((b) => b.category === badge.category && b.id !== badge.id)
+    .filter(
+      (b) =>
+        b.id !== badge.id &&
+        b.categories.some((cat) => badge.categories.includes(cat)),
+    )
     .slice(0, maxBadges);
 }

--- a/test/generate-badges.test.ts
+++ b/test/generate-badges.test.ts
@@ -2,7 +2,7 @@
  * Test suite for generate-badges.js
  *
  * Covers three layers:
- *  1. Output validation  — the generated scripts/badges.json satisfies the schema
+ *  1. Output validation  — the generated data/badges.json satisfies the schema
  *  2. Negative cases     — validateBadge() correctly rejects malformed data
  *  3. Unit tests         — pure helpers (stripEmoji, nameToId, extractUrl, parseTableRow,
  *                          stripMarkdownEscapes, sanitizeId)
@@ -29,7 +29,7 @@ type Badge = {
   name: string;
   url: string;
   markdown: string;
-  category: string;
+  categories: string[];
 };
 
 const __dir = dirname(fileURLToPath(import.meta.url));
@@ -57,30 +57,43 @@ describe("badges.json — output validation", () => {
     });
 
     it("contains at least 800 badges", () => {
-      // sanity guard: upstream README currently has 880+
+      // sanity guard: upstream README currently has 850+
       expect(badges.length).toBeGreaterThanOrEqual(800);
     });
 
     it("spans at least 40 categories", () => {
-      const cats = new Set(badges.map((b) => b.category));
+      const cats = new Set(badges.flatMap((b) => b.categories));
       expect(cats.size).toBeGreaterThanOrEqual(40);
     });
   });
 
   describe("schema — required fields", () => {
-    it("every badge has id, name, url, markdown, category", () => {
+    it("every badge has id, name, url, markdown and a non-empty categories array", () => {
       for (const badge of badges) {
-        expect(badge, `badge: ${JSON.stringify(badge)}`).toMatchObject({
-          id: expect.any(String),
-          name: expect.any(String),
-          url: expect.any(String),
-          markdown: expect.any(String),
-          category: expect.any(String),
-        });
+        expect(
+          typeof badge.id === "string" && badge.id.length > 0,
+          `missing id in: ${JSON.stringify(badge)}`,
+        ).toBe(true);
+        expect(
+          typeof badge.name === "string" && badge.name.length > 0,
+          `missing name`,
+        ).toBe(true);
+        expect(
+          typeof badge.url === "string" && badge.url.length > 0,
+          `missing url in ${badge.name}`,
+        ).toBe(true);
+        expect(
+          typeof badge.markdown === "string" && badge.markdown.length > 0,
+          `missing markdown in ${badge.name}`,
+        ).toBe(true);
+        expect(
+          Array.isArray(badge.categories) && badge.categories.length > 0,
+          `categories must be a non-empty array in ${badge.name}`,
+        ).toBe(true);
       }
     });
 
-    it("no field is an empty string", () => {
+    it("no required field is empty or blank", () => {
       for (const badge of badges) {
         expect(badge.id.trim(), `empty id in ${badge.name}`).not.toBe("");
         expect(badge.name.trim(), `empty name`).not.toBe("");
@@ -89,10 +102,11 @@ describe("badges.json — output validation", () => {
           badge.markdown.trim(),
           `empty markdown in ${badge.name}`,
         ).not.toBe("");
-        expect(
-          badge.category.trim(),
-          `empty category in ${badge.name}`,
-        ).not.toBe("");
+        for (const cat of badge.categories) {
+          expect(cat.trim(), `blank category entry in ${badge.name}`).not.toBe(
+            "",
+          );
+        }
       }
     });
   });
@@ -166,24 +180,26 @@ describe("badges.json — output validation", () => {
   describe("category format", () => {
     it("no category contains emoji", () => {
       const withEmoji = badges.filter((b) =>
-        /\p{Extended_Pictographic}/u.test(b.category),
+        b.categories.some((cat) => /\p{Extended_Pictographic}/u.test(cat)),
       );
       expect(
-        withEmoji.map((b) => ({ name: b.name, category: b.category })),
+        withEmoji.map((b) => ({ name: b.name, categories: b.categories })),
       ).toEqual([]);
     });
 
     it("no category is whitespace-only", () => {
-      const blank = badges.filter((b) => b.category.trim() === "");
+      const blank = badges.filter((b) =>
+        b.categories.some((cat) => cat.trim() === ""),
+      );
       expect(blank.map((b) => b.name)).toEqual([]);
     });
   });
 
   describe("known badges — smoke tests", () => {
-    it("contains the Claude badge", () => {
+    it("contains the Claude badge in Artificial Intelligence", () => {
       const badge = badges.find((b) => b.id === "claude");
       expect(badge).toBeDefined();
-      expect(badge?.category).toBe("Artificial Intelligence");
+      expect(badge?.categories).toContain("Artificial Intelligence");
     });
 
     it('C++ → id "c++" (special chars preserved)', () => {
@@ -228,14 +244,78 @@ describe("badges.json — output validation", () => {
     });
 
     it("Wearables category has no emoji (regression: ⌚ U+231A)", () => {
-      const wearable = badges.find((b) => b.category === "Wearables");
+      const wearable = badges.find((b) => b.categories.includes("Wearables"));
       expect(wearable).toBeDefined();
       expect(/\p{Extended_Pictographic}/u.test("Wearables")).toBe(false);
     });
 
     it("Quantum Programming category is correctly mapped", () => {
-      const badge = badges.find((b) => b.category === "Quantum Programming");
+      const badge = badges.find((b) =>
+        b.categories.includes("Quantum Programming"),
+      );
       expect(badge).toBeDefined();
+    });
+  });
+
+  describe("multi-category badges — merge smoke tests", () => {
+    it("Bitcoin is a single entry covering Blockchain and Cryptocurrency", () => {
+      const allBitcoin = badges.filter((b) => b.name === "Bitcoin");
+      expect(allBitcoin).toHaveLength(1);
+      expect(allBitcoin[0].categories).toContain("Blockchain");
+      expect(allBitcoin[0].categories).toContain("Cryptocurrency");
+    });
+
+    it("Xbox is a single entry covering Gaming, Game Consoles and Social", () => {
+      const allXbox = badges.filter((b) => b.name === "Xbox");
+      expect(allXbox).toHaveLength(1);
+      expect(allXbox[0].categories).toContain("Gaming");
+      expect(allXbox[0].categories).toContain("Game Consoles");
+      expect(allXbox[0].categories).toContain("Social");
+    });
+
+    it("Twitch is a single entry covering its categories", () => {
+      const allTwitch = badges.filter((b) => b.name === "Twitch");
+      expect(allTwitch).toHaveLength(1);
+      expect(allTwitch[0].categories.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("DuckDuckGo is a single entry (URL casing difference → same badge)", () => {
+      const allDDG = badges.filter(
+        (b) => b.name.toLowerCase() === "duckduckgo",
+      );
+      expect(allDDG).toHaveLength(1);
+      expect(allDDG[0].categories).toContain("Browsers");
+      expect(allDDG[0].categories).toContain("Search Engines");
+    });
+
+    it("HackerRank is a single entry covering Forums and Jobs", () => {
+      const allHR = badges.filter((b) => b.name.toLowerCase() === "hackerrank");
+      expect(allHR).toHaveLength(1);
+      expect(allHR[0].categories).toContain("Forums");
+      expect(allHR[0].categories).toContain("Jobs");
+    });
+
+    it("every badge id matches its name-derived slug (no renamed/suffixed entries)", () => {
+      // If the script ever falls back to appending a category suffix
+      // (e.g. "bitcoin-cryptocurrency"), the stored id will diverge from
+      // sanitizeId(nameToId(badge.name)). All duplicates must be merged instead.
+      const mismatched = badges.filter(
+        (b) => b.id !== sanitizeId(nameToId(b.name)),
+      );
+      expect(
+        mismatched.map((b) => ({
+          id: b.id,
+          name: b.name,
+          expected: sanitizeId(nameToId(b.name)),
+        })),
+      ).toEqual([]);
+    });
+
+    it("categories array has no duplicates within a single badge", () => {
+      const withDuplicateCats = badges.filter(
+        (b) => new Set(b.categories).size !== b.categories.length,
+      );
+      expect(withDuplicateCats.map((b) => b.name)).toEqual([]);
     });
   });
 });
@@ -248,11 +328,17 @@ describe("validateBadge — negative cases", () => {
     name: "Test Badge",
     url: "https://img.shields.io/badge/test-badge-blue",
     markdown: "![Test Badge](https://img.shields.io/badge/test-badge-blue)",
-    category: "Testing",
+    categories: ["Testing"],
   };
 
   it("accepts a fully valid badge (zero errors)", () => {
     expect(validateBadge(VALID)).toEqual([]);
+  });
+
+  it("accepts a valid badge with multiple categories", () => {
+    expect(
+      validateBadge({ ...VALID, categories: ["Testing", "Frameworks"] }),
+    ).toEqual([]);
   });
 
   it("rejects a badge missing the id field", () => {
@@ -276,19 +362,34 @@ describe("validateBadge — negative cases", () => {
     expect(validateBadge(noMd).some((e) => e.includes("markdown"))).toBe(true);
   });
 
-  it("rejects a badge missing the category field", () => {
-    const { category, ...noCat } = VALID;
-    expect(validateBadge(noCat).some((e) => e.includes("category"))).toBe(true);
+  it("rejects a badge missing the categories field", () => {
+    const { categories, ...noCats } = VALID;
+    expect(validateBadge(noCats).some((e) => e.includes("categories"))).toBe(
+      true,
+    );
   });
 
   it("rejects a badge with an empty id", () => {
     expect(validateBadge({ ...VALID, id: "" }).length).toBeGreaterThan(0);
   });
 
-  it("rejects a badge with a whitespace-only category", () => {
-    expect(validateBadge({ ...VALID, category: "   " }).length).toBeGreaterThan(
-      0,
-    );
+  it("rejects a badge with an empty categories array", () => {
+    const errors = validateBadge({ ...VALID, categories: [] });
+    expect(errors.some((e) => e.includes("categories"))).toBe(true);
+  });
+
+  it("rejects a badge with a whitespace-only string in categories", () => {
+    expect(
+      validateBadge({ ...VALID, categories: ["   "] }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("rejects a badge with a non-array categories field", () => {
+    expect(
+      validateBadge({ ...VALID, categories: "Testing" }).some((e) =>
+        e.includes("categories"),
+      ),
+    ).toBe(true);
   });
 
   it("rejects a badge with an uppercase id", () => {
@@ -324,14 +425,22 @@ describe("validateBadge — negative cases", () => {
   });
 
   it("rejects a category that still contains emoji (⌚)", () => {
-    const errors = validateBadge({ ...VALID, category: "⌚ Wearables" });
+    const errors = validateBadge({ ...VALID, categories: ["⌚ Wearables"] });
     expect(errors.some((e) => e.includes("emoji"))).toBe(true);
   });
 
   it("rejects a category that still contains emoji (🤖)", () => {
     const errors = validateBadge({
       ...VALID,
-      category: "🤖 Artificial Intelligence",
+      categories: ["🤖 Artificial Intelligence"],
+    });
+    expect(errors.some((e) => e.includes("emoji"))).toBe(true);
+  });
+
+  it("rejects when any category in the array contains emoji", () => {
+    const errors = validateBadge({
+      ...VALID,
+      categories: ["Testing", "🤖 AI"],
     });
     expect(errors.some((e) => e.includes("emoji"))).toBe(true);
   });


### PR DESCRIPTION
## Overview

Replaces the single `category: string` field on every badge with `categories: string[]`, allowing a badge to belong to more than one category simultaneously. Duplicate entries that previously required ID-suffix collision resolution (e.g. Bitcoin appearing in both Blockchain and Cryptocurrency) are now merged into a single badge record with multiple categories.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 💥 Breaking change
- [ ] ♻️ Refactor
- [ ] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

### Data schema (`data/badges.json`, `src/env.d.ts`, `src/content.config.ts`)
- Renamed `category: string` → `categories: string[]` on all ~600+ badge records.
- Multi-category badges (e.g. Bitcoin, Ethereum) are now represented as a single entry with multiple items in the array instead of duplicated records with mangled IDs.

### Badge service (`src/services/badges.ts`)
- `matchesCategory` uses `Array.includes` instead of strict equality.
- `getBadgeCategories` uses `flatMap` to collect all unique categories across the new array field.
- `getBadgeCountByCategory` counts each category independently for multi-category badges.
- `getRelatedBadges` returns badges sharing *any* category with the target badge.

### UI — BadgeCard & BadgesList (`src/components/badges/badge-card.tsx`, `badges-list.tsx`, `search.tsx`)
- `BadgeCard` accepts a new `activeCategory` prop; when present and the badge belongs to that category, it is shown as the primary category link.
- Extra categories are exposed via an ellipsis (`…`) popover button built on the new `Popover` component.
- `BadgesList` forwards `activeCategory` to each card; `Search` passes the current `categoryQuery` as `activeCategory`.

### UI — Badge detail page & sidebar (`src/pages/badges/[...id].astro`, `src/components/badges/badge-sidebar.tsx`)
- Both views now render all categories as clickable pill links instead of a single plain-text label.

### New component (`src/components/ui/popover.tsx`)
- Radix UI-based `Popover` with `PopoverTrigger`, `PopoverContent`, `PopoverHeader`, `PopoverTitle`, and `PopoverDescription` sub-components, following the existing shadcn/ui pattern in this project.

### Badge generator & validation (`scripts/generate-badges.js`, `scripts/utils.js`)
- Generator merges duplicate entries (same URL or same name) by appending the new category to the existing record's `categories` array rather than creating a separate entry with a suffixed ID.
- `validateBadge` checks that `categories` is a non-empty array of non-empty strings and validates each entry for emoji content.

### SEO (`src/lib/badges.ts`)
- Badge detail page keywords now include a `"${cat} badge"` entry for every category, not just the first one.

### Tests (`test/generate-badges.test.ts`)
- All existing generator tests updated to use the `categories` array; new cases added to cover multi-category merging logic.

## How to test

1. `npm run dev` — browse to the home page and filter by any category; badges should appear as before.
2. Open a badge that belongs to multiple categories (e.g. *Bitcoin*) and confirm both category pills are visible and link correctly.
3. On the badge grid, verify that the primary category shown matches the active category filter when one is applied.
4. Click the `…` button on a multi-category badge card to confirm the popover lists the remaining categories as links.
5. Open the favorites sidebar for a multi-category badge and verify all category pills are displayed.
6. `npm run build` — should complete without type errors.

## Release notes

Badges can now belong to more than one category. The `category` string field has been replaced by a `categories` array in `data/badges.json` and all related TypeScript interfaces. Previously duplicated badge entries that existed solely to represent cross-category membership are consolidated into single records. The UI surfaces extra categories via a popover on the badge card and as clickable pills on detail pages and the sidebar.
