### PR TITLE
feat(ui): improve sidebar active states, accent colors, and SVG color handling

### DIFF
--- a/src/components/app-logo.tsx
+++ b/src/components/app-logo.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 export function AppLogo({ className }: { className?: string }) {
   return (
     <div className={cn(className, "flex gap-2 items-center")}>
-      <MarkdownDark className="size-9! stroke-2" />
+      <MarkdownDark className="size-9! stroke-2 text-primary" />
       <Typography as="span" size="h4">
         Markdown Badges
       </Typography>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -154,7 +154,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
                         <span>{cat}</span>
                       </a>
                     </SidebarMenuButton>
-                    <SidebarMenuBadge>
+                    <SidebarMenuBadge isActive={cat === activeCategory}>
                       {badgeCountByCategory[cat]}
                     </SidebarMenuBadge>
                   </SidebarMenuItem>
@@ -168,10 +168,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           {nav.navFooter.map((item) => (
             <SidebarMenuItem key={item.name}>
-              <SidebarMenuButton
-                asChild
-                isActive={pathname === item.url}
-              >
+              <SidebarMenuButton asChild isActive={pathname === item.url}>
                 <a href={item.url}>
                   <item.icon />
                   <span>{item.name}</span>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -493,7 +493,7 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm text-muted-foreground ring-sidebar-ring outline-hidden transition-[width,height,padding,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0",
+  "peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm text-muted-foreground ring-sidebar-ring outline-hidden transition-[width,height,padding,color] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 data-[active=true]:before:bg-primary data-[active=true]:before:w-0.5 data-[active=true]:before:h-4 data-[active=true]:before:rounded-lg data-[active=true]:before:left-0 data-[active=true]:before:absolute data-[active=true]:[&>svg]:text-primary",
   {
     variants: {
       variant: {
@@ -598,14 +598,17 @@ function SidebarMenuAction({
 
 function SidebarMenuBadge({
   className,
+  isActive = false,
   ...props
-}: React.ComponentProps<"div">) {
+}: React.ComponentProps<"div"> & { isActive?: boolean }) {
   return (
     <Badge
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
+      data-active={isActive}
       variant="outline"
       className={cn(
+        "data-[active=true]:text-primary  data-[active=true]:border-primary",
         "pointer-events-none absolute right-1 select-none tabular-nums z-100",
         "peer-data-[size=sm]/menu-button:top-1",
         "peer-data-[size=default]/menu-button:top-1.5",

--- a/src/components/ui/svgs/markdownDark.tsx
+++ b/src/components/ui/svgs/markdownDark.tsx
@@ -4,12 +4,12 @@ const MarkdownDark = (props: SVGProps<SVGSVGElement>) => (
   <svg {...props} viewBox="0 0 208 128" xmlSpace="preserve">
     <path
       fill="none"
-      stroke="#FFF"
+      stroke="currentColor"
       strokeWidth="10"
       d="M15 5h178a10 10 0 0 1 10 10v98a10 10 0 0 1-10 10H15a10 10 0 0 1-10-10V15A10 10 0 0 1 15 5z"
     />
     <path
-      fill="#FFF"
+      fill="currentColor"
       d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39H30zm125 0-30-33h20V30h20v35h20l-30 33z"
     />
   </svg>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,7 +58,7 @@
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.35 0 0);
   --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
+  --accent: oklch(0.74 0.11 342 / 12%);
   --accent-foreground: oklch(0.985 0 0);
   --success: oklch(0.7227 0.192 149.58);
   --destructive: oklch(0.704 0.191 22.216);
@@ -74,7 +74,7 @@
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.74 0.11 342);
   --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent: oklch(0.74 0.11 342 / 12%);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.74 0.11 342 / 40%);


### PR DESCRIPTION
## Overview

Improves the visual design of the sidebar by introducing theme-aware accent colors, an active indicator on menu items, active-state highlighting for category badges, and proper `currentColor` usage in the Markdown logo SVG. Also adds a CI workflow for PR checks and updates the PR template to a more structured format.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] ♻️ Refactor
- [ ] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

### Sidebar active state indicator
- Added a left-edge accent bar (via `before:` pseudo-element) to active `SidebarMenuButton` items in `src/components/ui/sidebar.tsx`
- Active SVG icons in the sidebar now inherit the primary color via `data-[active=true]:[&>svg]:text-primary`

### Category badge active highlighting
- `SidebarMenuBadge` in `src/components/ui/sidebar.tsx` now accepts an `isActive` prop; when active, the badge renders with primary-colored border and text
- `src/components/app-sidebar.tsx` passes `isActive={cat === activeCategory}` to `SidebarMenuBadge` for each category entry

### Accent color update (dark mode)
- `--accent` and `--sidebar-accent` CSS variables in `src/styles/global.css` changed from neutral grey (`oklch(0.269 0 0)`) to a translucent pink/rose tint (`oklch(0.74 0.11 342 / 12%)`) matching the primary sidebar color, giving hover and active backgrounds a subtle branded hue

### SVG `currentColor` support
- `src/components/ui/svgs/markdownDark.tsx`: replaced hardcoded `stroke="#FFF"` / `fill="#FFF"` with `currentColor` so the logo inherits its color from CSS context
- `src/components/app-logo.tsx`: added `text-primary` class to `<MarkdownDark>` so it renders in the theme's primary color

## How to test

1. Run `npm run dev` and open the app in a browser
2. Navigate through sidebar categories — the active category should show a left accent bar on the menu button and the badge count should render in the primary color
3. Hover over non-active items to confirm the subtle tinted background appears
4. Check the `AppLogo` in the nav — the Markdown icon should render in the primary color rather than white
5. Toggle dark/light mode and verify the logo and sidebar accent colors adapt correctly

## Release notes

- Sidebar active category now shows a left accent bar and colored badge count for clearer visual feedback
- Sidebar hover/active backgrounds use a brand-tinted color instead of plain grey in dark mode
- Markdown logo SVG now uses `currentColor` and renders in the theme's primary color