### PR TITLE
feat(api): allow unlimited badge retrieval with `limit=all`

### DIFF
--- a/src/pages/api/badges.ts
+++ b/src/pages/api/badges.ts
@@ -14,15 +14,19 @@ export const GET: APIRoute = ({ url }) => {
   const search = url.searchParams.get("search");
   const limitParam = url.searchParams.get("limit");
 
-  const parsed = limitParam !== null ? parseInt(limitParam, 10) : NaN;
-  const limit = Math.min(
-    Math.max(1, Number.isNaN(parsed) ? DEFAULT_LIMIT : parsed),
-    MAX_LIMIT,
-  );
+  const unlimited = limitParam?.toLowerCase() === "all";
+  const parsed =
+    !unlimited && limitParam !== null ? parseInt(limitParam, 10) : NaN;
+  const limit: number | null = unlimited
+    ? null
+    : Math.min(
+        Math.max(1, Number.isNaN(parsed) ? DEFAULT_LIMIT : parsed),
+        MAX_LIMIT,
+      );
 
   try {
     const badges = search ? filterBadges({ query: search }) : getBadges();
-    const data = badges.slice(0, limit);
+    const data = limit !== null ? badges.slice(0, limit) : badges;
 
     return Response.json(
       { total: badges.length, limit, count: data.length, data },

--- a/src/pages/docs/api.astro
+++ b/src/pages/docs/api.astro
@@ -16,7 +16,7 @@ const exampleResponse = `{
       "name": "React",
       "url": "https://reactjs.org/",
       "markdown": "![React](https://img.shields.io/badge/react-%2320232a.svg?style=for-the-badge&logo=react&logoColor=%2361DAFB)",
-      "category": "Frameworks"
+      "categories": ["Frameworks"]
     },
     ...
   ]
@@ -89,11 +89,15 @@ const exampleResponse = `{
               </tr>
               <tr>
                 <td class="px-4 py-3 font-mono text-fuchsia-300">limit</td>
-                <td class="px-4 py-3 text-muted-foreground">integer</td>
+                <td class="px-4 py-3 text-muted-foreground"
+                  >integer | <span class="font-mono">"all"</span></td
+                >
                 <td class="px-4 py-3 text-muted-foreground">No</td>
                 <td class="px-4 py-3 font-mono text-muted-foreground">20</td>
                 <td class="px-4 py-3 text-muted-foreground">
                   Maximum number of badges to return. Accepted range: 1–200.
+                  Pass <span class="font-mono text-fuchsia-300">all</span> to
+                  return every matching badge with no cap.
                 </td>
               </tr>
             </tbody>
@@ -122,9 +126,12 @@ const exampleResponse = `{
               </tr>
               <tr class="border-b border-white/10">
                 <td class="px-4 py-3 font-mono text-fuchsia-300">limit</td>
-                <td class="px-4 py-3 text-muted-foreground">integer</td>
+                <td class="px-4 py-3 text-muted-foreground">integer | null</td>
                 <td class="px-4 py-3 text-muted-foreground"
-                  >The effective limit applied to this response.</td
+                  >The effective limit applied to this response. <span
+                    class="font-mono text-fuchsia-300">null</span
+                  > when <span class="font-mono text-fuchsia-300">limit=all</span
+                  > was requested.</td
                 >
               </tr>
               <tr class="border-b border-white/10">
@@ -189,10 +196,10 @@ const exampleResponse = `{
                 >
               </tr>
               <tr>
-                <td class="px-4 py-3 font-mono text-fuchsia-300">category</td>
-                <td class="px-4 py-3 text-muted-foreground">string</td>
+                <td class="px-4 py-3 font-mono text-fuchsia-300">categories</td>
+                <td class="px-4 py-3 text-muted-foreground">string[]</td>
                 <td class="px-4 py-3 text-muted-foreground"
-                  >Category the badge belongs to (e.g. <span
+                  >One or more categories the badge belongs to (e.g. <span
                     class="font-mono text-fuchsia-300">Frameworks</span
                   >, <span class="font-mono text-fuchsia-300">Languages</span
                   >).</td
@@ -243,10 +250,11 @@ const exampleResponse = `{
         <li class="flex gap-3">
           <span class="text-fuchsia-300 mt-0.5 shrink-0">—</span>
           <Typography>
-            <strong class="text-white">Maximum response size:</strong> A single request
-            returns at most 200 badges (<span class="font-mono text-fuchsia-300"
-              >limit=200</span
-            >). Pagination is not supported beyond this cap.
+            <strong class="text-white">Default response size:</strong> Without an
+            explicit <span class="font-mono text-fuchsia-300">limit</span> the API
+            returns 20 badges. The cap is 200 for numeric values; use <span
+              class="font-mono text-fuchsia-300">limit=all</span
+            > to retrieve the full catalogue in a single request.
           </Typography>
         </li>
         <li class="flex gap-3">


### PR DESCRIPTION
## Overview

Adds support for `limit=all` on the `GET /api/badges` endpoint, allowing callers to retrieve the full badge catalogue in a single request without hitting the 200-badge numeric cap. Also corrects the API documentation to reflect the `categories` (array) field introduced in a prior schema change.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor
- [x] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

**API endpoint — `src/pages/api/badges.ts`**
- When `limit=all` (case-insensitive) is passed, the endpoint skips slicing and returns every badge that matches the query.
- `limit` in the JSON response is now `number | null`; it is `null` when `limit=all` was requested, preserving backward-compatibility for numeric values.
- Numeric `limit` behaviour is unchanged: defaults to 20, clamped to 1–200.

**API documentation — `src/pages/docs/api.astro`**
- Updated the `limit` parameter type to `integer | "all"` and added a description of the `all` value.
- Updated the `limit` response field type to `integer | null` and documented when it is `null`.
- Corrected the badge object field from `category: string` to `categories: string[]` to match the actual schema.
- Updated the "Maximum response size" note to reflect the new `limit=all` option.

## How to test

1. Start the dev server: `npm run dev`.
2. Hit `GET /api/badges?limit=all` — response should contain all ~600+ badges and `"limit": null`.
3. Hit `GET /api/badges?limit=all&search=react` — should return all matching badges without a cap.
4. Hit `GET /api/badges` — should still default to 20 badges with `"limit": 20`.
5. Hit `GET /api/badges?limit=250` — should be clamped to 200.
6. Visit `/docs/api` and verify the parameter table shows `integer | "all"` and the response table shows `integer | null` for `limit`, and `string[]` for `categories`.

## Release notes

The `/api/badges` endpoint now accepts `limit=all` to return the entire badge catalogue in one request. The `limit` field in the response will be `null` when this option is used. The `categories` field in each badge object is correctly documented as an array of strings.
