### PR TITLE
refactor(categories): migrate from query-param category filtering to dedicated URL routes

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -5,7 +5,7 @@ import {
   HomeIcon,
   InfoIcon,
 } from "lucide-react";
-import { type ComponentProps, useEffect, useRef, useState } from "react";
+import { type ComponentProps, useEffect, useRef } from "react";
 
 import {
   Sidebar,
@@ -21,7 +21,12 @@ import {
   SidebarMenuItem,
   useSidebar,
 } from "@/components/ui/sidebar";
-import { getBadgeCategories, getBadgeCountByCategory } from "@/services/badges";
+import {
+  getBadgeCategories,
+  getBadgeCountByCategory,
+  getCategoryBySlug,
+  slugifyCategory,
+} from "@/services/badges";
 import { AppLogo } from "./app-logo";
 import { ScrollArea } from "./ui/scroll-area";
 
@@ -62,36 +67,14 @@ const categories = getBadgeCategories();
 const badgeCountByCategory = getBadgeCountByCategory();
 
 export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
-  const { pathname, category: ssrCategory } = useSidebar();
+  const { pathname } = useSidebar();
   const activeCategoryRef = useRef<HTMLLIElement>(null);
 
-  // Initialized from the server-validated SSR prop — no hydration mismatch.
-  // Category is always valid here because Layout.astro filters invalid values before passing them down.
-  const [activeCategory, setActiveCategory] = useState<string | undefined>(
-    ssrCategory,
-  );
-
-  useEffect(() => {
-    const syncCategoryFromUrl = () => {
-      const cat =
-        new URLSearchParams(window.location.search).get("category") ||
-        undefined;
-      setActiveCategory(cat);
-    };
-
-    // popstate: browser back/forward navigation
-    window.addEventListener("popstate", syncCategoryFromUrl);
-    // locationchange: dispatched by search.tsx after every replaceState call
-    window.addEventListener("locationchange", syncCategoryFromUrl);
-
-    return () => {
-      window.removeEventListener("popstate", syncCategoryFromUrl);
-      window.removeEventListener("locationchange", syncCategoryFromUrl);
-    };
-  }, []);
-
-  const isValidCategory =
-    !!activeCategory && categories.includes(activeCategory);
+  const activeSlug = pathname?.startsWith("/categories/")
+    ? pathname.slice("/categories/".length)
+    : undefined;
+  const activeCategory = activeSlug ? getCategoryBySlug(activeSlug) : undefined;
+  const isValidCategory = !!activeCategory;
 
   useEffect(() => {
     if (isValidCategory && activeCategoryRef.current) {
@@ -150,7 +133,7 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
                       asChild
                       isActive={cat === activeCategory}
                     >
-                      <a href={`/?category=${cat}`}>
+                      <a href={`/categories/${slugifyCategory(cat)}`}>
                         <span>{cat}</span>
                       </a>
                     </SidebarMenuButton>

--- a/src/components/badges/badge-card.tsx
+++ b/src/components/badges/badge-card.tsx
@@ -17,6 +17,7 @@ import {
 import { Typography } from "@/components/ui/typography";
 import { useFavorites } from "@/context/favorites-context";
 import { cn } from "@/lib/utils";
+import { slugifyCategory } from "@/services/badges";
 
 type BadgeCardProps = {
   badge: Badge;
@@ -107,7 +108,7 @@ export const BadgeCard = memo(function BadgeCard({
           className="text-muted-foreground"
         >
           <a
-            href={`/?category=${primaryCategory}`}
+            href={`/categories/${slugifyCategory(primaryCategory)}`}
             onClick={(e) => e.stopPropagation()}
           >
             {primaryCategory}
@@ -138,7 +139,7 @@ export const BadgeCard = memo(function BadgeCard({
                       className="text-muted-foreground"
                     >
                       <a
-                        href={`/?category=${cat}`}
+                        href={`/categories/${slugifyCategory(cat)}`}
                         onClick={(e) => e.stopPropagation()}
                       >
                         {cat}

--- a/src/components/badges/badge-sidebar.tsx
+++ b/src/components/badges/badge-sidebar.tsx
@@ -28,7 +28,7 @@ import {
 import { Typography } from "@/components/ui/typography";
 import { useFavorites } from "@/context/favorites-context";
 import { useCopyClipboard } from "@/hooks/use-copy-clipboard";
-import { getRelatedBadges } from "@/services/badges";
+import { getRelatedBadges, slugifyCategory } from "@/services/badges";
 
 type BadgeSidebarContextType = {
   open: (badge: Badge) => void;
@@ -98,7 +98,7 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
               {badge?.categories.map((cat) => (
                 <a
                   key={cat}
-                  href={`/?category=${cat}`}
+                  href={`/categories/${slugifyCategory(cat)}`}
                   className="inline-flex items-center rounded-sm border px-2 py-0.5 text-xs text-muted-foreground hover:bg-primary/10 hover:border-primary/80 transition"
                 >
                   {cat}

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,5 +1,4 @@
 import {
-  ChevronDownIcon,
   ChevronsDownIcon,
   ClipboardIcon,
   CommandIcon,
@@ -14,16 +13,6 @@ import { useDebounce } from "use-debounce";
 
 import { BadgesList } from "@/components/badges/badges-list";
 import { Button } from "@/components/ui/button";
-import {
-  Combobox,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxTrigger,
-  ComboboxValue,
-} from "@/components/ui/combobox";
 import {
   Empty,
   EmptyContent,
@@ -43,7 +32,7 @@ import { Kbd } from "@/components/ui/kbd";
 import { Typography } from "@/components/ui/typography";
 import { SelectionProvider, useSelection } from "@/context/selection-context";
 import { cn } from "@/lib/utils";
-import { filterBadges, getBadgeCategories, getBadges } from "@/services/badges";
+import { filterBadges } from "@/services/badges";
 
 type SearchProps = {
   initialQuery?: string | null;
@@ -64,15 +53,9 @@ function SearchContent({
 }: SearchProps) {
   const { count, clearAll, copyAll, badges: selectedBadges } = useSelection();
 
-  const badges = useMemo(() => getBadges(), []);
-  const categories = useMemo(() => getBadgeCategories(), []);
-
   const searchInput = useRef<HTMLInputElement>(null);
 
   const [query, setQuery] = useState<string | null>(initialQuery);
-  const [categoryQuery, setCategoryQuery] = useState<string | null>(
-    initialCategory,
-  );
   const [resultsAmount, setResultsAmount] = useState(30);
   const [isReady, setIsReady] = useState(false);
 
@@ -81,9 +64,9 @@ function SearchContent({
   const filteredBadges = useMemo(() => {
     return filterBadges({
       query: isReady ? debouncedQuery : initialQuery,
-      category: categoryQuery,
+      category: initialCategory,
     });
-  }, [debouncedQuery, categoryQuery, isReady, initialQuery]);
+  }, [debouncedQuery, isReady, initialQuery, initialCategory]);
 
   const results = useMemo(() => {
     return filteredBadges.slice(0, resultsAmount);
@@ -98,17 +81,11 @@ function SearchContent({
       url.searchParams.set("query", debouncedQuery);
     else url.searchParams.delete("query");
 
-    if (categoryQuery) url.searchParams.set("category", categoryQuery);
-    else url.searchParams.delete("category");
-
     window.history.replaceState({}, "", url);
-    window.dispatchEvent(new Event("locationchange"));
     setResultsAmount(30);
-  }, [debouncedQuery, categoryQuery, isReady]);
+  }, [debouncedQuery, isReady]);
 
   useEffect(() => {
-    if (!categories.includes(initialCategory || "")) setCategoryQuery(null);
-
     setIsReady(true);
   }, []);
 
@@ -135,7 +112,7 @@ function SearchContent({
     setQuery("");
   };
 
-  const isFiltered = (query && query.length > 0) || !!categoryQuery;
+  const isFiltered = !!(query && query.length > 0);
 
   const isMac = navigator.userAgent.includes("Mac");
   return (
@@ -175,41 +152,6 @@ function SearchContent({
             </InputGroupAddon>
           </InputGroup>
         </Field>
-
-        <Combobox
-          items={categories}
-          value={categoryQuery}
-          onValueChange={setCategoryQuery}
-          defaultValue={null}
-        >
-          <ComboboxTrigger
-            render={
-              <Button
-                variant="outline"
-                className="w-50 justify-between text-muted-foreground"
-                aria-label="Select category"
-              >
-                <ComboboxValue placeholder="All Categories" />
-                <ChevronDownIcon className="size-4 opacity-50" />
-              </Button>
-            }
-          />
-          <ComboboxContent>
-            <ComboboxInput
-              showTrigger={false}
-              showClear
-              placeholder="Search category..."
-            />
-            <ComboboxEmpty>No category found.</ComboboxEmpty>
-            <ComboboxList>
-              {(item) => (
-                <ComboboxItem key={item} value={item}>
-                  {item}
-                </ComboboxItem>
-              )}
-            </ComboboxList>
-          </ComboboxContent>
-        </Combobox>
       </div>
 
       <div className="flex items-center justify-end gap-2 mb-3">
@@ -231,7 +173,7 @@ function SearchContent({
               variant="muted"
               className="flex items-center gap-1"
             >
-              <ShieldIcon /> {badges.length} badges
+              <ShieldIcon /> {filteredBadges.length} badges
             </Typography>
           )}
         </div>
@@ -280,7 +222,11 @@ function SearchContent({
 
       {results.length > 0 && (
         <div>
-          <BadgesList badges={results} selectable activeCategory={categoryQuery} />
+          <BadgesList
+            badges={results}
+            selectable
+            activeCategory={initialCategory}
+          />
 
           {results.length < filteredBadges.length && (
             <div className="flex justify-center items-center gap-4 mt-8">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ import SpeedInsights from "@vercel/speed-insights/astro";
 import { AppShell } from "@/components/app-shell";
 import SEO from "@/components/SEO.astro";
 import { Toaster } from "@/components/ui/sonner";
-import { getBadgeCategories } from "@/services/badges";
+import { getCategoryBySlug } from "@/services/badges";
 
 interface Props {
   title: string;
@@ -30,11 +30,10 @@ const {
 
 const pathname = Astro.url.pathname;
 
-const rawCategory = Astro.url.searchParams.get("category");
-const category =
-  rawCategory && getBadgeCategories().includes(rawCategory)
-    ? rawCategory
-    : undefined;
+const categorySlug = pathname.startsWith("/categories/")
+  ? pathname.slice("/categories/".length)
+  : undefined;
+const category = categorySlug ? getCategoryBySlug(categorySlug) : undefined;
 ---
 
 <!doctype html>

--- a/src/pages/badges/[...id].astro
+++ b/src/pages/badges/[...id].astro
@@ -3,7 +3,7 @@ import { CodeBlock } from "@/components/ui/code-block";
 import { Typography } from "@/components/ui/typography";
 import Layout from "@/layouts/Layout.astro";
 import { getBadgeSEOData } from "@/lib/badges";
-import { getBadges, getRelatedBadges } from "@/services/badges";
+import { getBadges, getRelatedBadges, slugifyCategory } from "@/services/badges";
 
 export const prerender = true;
 
@@ -46,7 +46,7 @@ const badgeSEO = getBadgeSEOData(badge);
           <div class="flex flex-wrap gap-2">
             {badge.categories.map((cat) => (
               <a
-                href={`/?category=${cat}`}
+                href={`/categories/${slugifyCategory(cat)}`}
                 class="inline-flex items-center rounded-sm border px-2 py-0.5 text-sm text-muted-foreground hover:bg-primary/10 hover:border-primary/80 transition"
               >
                 {cat}

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -1,0 +1,35 @@
+---
+import { Search } from "@/components/search";
+import { Typography } from "@/components/ui/typography";
+import Layout from "@/layouts/Layout.astro";
+import {
+  filterBadges,
+  getBadgeCategories,
+  slugifyCategory,
+} from "@/services/badges";
+
+export const prerender = true;
+
+export function getStaticPaths() {
+  return getBadgeCategories().map((category) => ({
+    params: { category: slugifyCategory(category) },
+    props: { category },
+  }));
+}
+
+const { category } = Astro.props;
+const query = Astro.url.searchParams.get("query") || null;
+
+const badgeCount = filterBadges({ category }).length;
+---
+
+<Layout
+  title={`${category} Badges | Markdown Badges`}
+  description={`Browse ${badgeCount} ${category} badges for GitHub README. Copy ready-to-use Markdown instantly.`}
+  keywords={`${category} badge, ${category} shield, readme badge, github badge, gfrancv`}
+>
+  <Typography as="h1" size="h1" className="mb-6">
+    {category}
+  </Typography>
+  <Search client:load initialQuery={query} initialCategory={category} />
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,6 @@ import { Typography } from "@/components/ui/typography";
 import Layout from "@/layouts/Layout.astro";
 
 const query = Astro.url.searchParams.get("query") || null;
-const category = Astro.url.searchParams.get("category") || null;
 
 const jsonLd = {
   "@context": "https://schema.org",
@@ -22,5 +21,5 @@ const jsonLd = {
   <Typography as="h1" size="h1" className="sr-only">
     Markdown Badges
   </Typography>
-  <Search client:load initialQuery={query} initialCategory={category} />
+  <Search client:load initialQuery={query} />
 </Layout>

--- a/src/services/badges.ts
+++ b/src/services/badges.ts
@@ -48,6 +48,17 @@ export function getBadgeCountByCategory(): Record<string, number> {
   );
 }
 
+export function slugifyCategory(category: string): string {
+  return category
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function getCategoryBySlug(slug: string): string | undefined {
+  return getBadgeCategories().find((cat) => slugifyCategory(cat) === slug);
+}
+
 export function getRelatedBadges(badge: Badge, maxBadges: number = 4): Badge[] {
   return getBadges()
     .filter(

--- a/test/badges.test.ts
+++ b/test/badges.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import badges from "~/data/badges.json";
+import {
+  filterBadges,
+  getBadgeCategories,
+  getCategoryBySlug,
+  slugifyCategory,
+} from "@/services/badges";
+
+// --- slugifyCategory ---
+
+describe("slugifyCategory", () => {
+  it("lowercases all characters", () => {
+    expect(slugifyCategory("CI")).toBe("ci");
+    expect(slugifyCategory("SaaS")).toBe("saas");
+    expect(slugifyCategory("IDEs")).toBe("ides");
+    expect(slugifyCategory("ORM")).toBe("orm");
+  });
+
+  it("converts spaces to hyphens", () => {
+    expect(slugifyCategory("Artificial Intelligence")).toBe(
+      "artificial-intelligence",
+    );
+    expect(slugifyCategory("Operating System")).toBe("operating-system");
+    expect(slugifyCategory("Home Automation")).toBe("home-automation");
+  });
+
+  it("converts slashes to hyphens", () => {
+    expect(slugifyCategory("ML/AI")).toBe("ml-ai");
+    expect(slugifyCategory("ML/DL")).toBe("ml-dl");
+  });
+
+  it("collapses consecutive separators into one hyphen", () => {
+    expect(slugifyCategory("A  B")).toBe("a-b");
+    expect(slugifyCategory("A / B")).toBe("a-b");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    expect(slugifyCategory(" Leading")).toBe("leading");
+    expect(slugifyCategory("Trailing ")).toBe("trailing");
+  });
+
+  it("produces URL-safe output (no spaces, slashes, or special chars)", () => {
+    const categories = getBadgeCategories();
+    for (const cat of categories) {
+      const slug = slugifyCategory(cat);
+      expect(slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+});
+
+// --- getCategoryBySlug ---
+
+describe("getCategoryBySlug", () => {
+  it("resolves known slugs back to their original category name", () => {
+    expect(getCategoryBySlug("artificial-intelligence")).toBe(
+      "Artificial Intelligence",
+    );
+    expect(getCategoryBySlug("ml-ai")).toBe("ML/AI");
+    expect(getCategoryBySlug("ml-dl")).toBe("ML/DL");
+    expect(getCategoryBySlug("operating-system")).toBe("Operating System");
+    expect(getCategoryBySlug("saas")).toBe("SaaS");
+    expect(getCategoryBySlug("ides")).toBe("IDEs");
+  });
+
+  it("returns undefined for an unknown slug", () => {
+    expect(getCategoryBySlug("not-a-category")).toBeUndefined();
+    expect(getCategoryBySlug("")).toBeUndefined();
+    expect(getCategoryBySlug("artificial_intelligence")).toBeUndefined();
+  });
+
+  it("round-trips every category: slug → name → slug stays identical", () => {
+    const categories = getBadgeCategories();
+    for (const cat of categories) {
+      const slug = slugifyCategory(cat);
+      const resolved = getCategoryBySlug(slug);
+      expect(resolved).toBe(cat);
+      expect(slugifyCategory(resolved!)).toBe(slug);
+    }
+  });
+});
+
+// --- getBadgeCategories ---
+
+describe("getBadgeCategories", () => {
+  it("returns a non-empty array", () => {
+    const categories = getBadgeCategories();
+    expect(categories.length).toBeGreaterThan(0);
+  });
+
+  it("contains no duplicate category names", () => {
+    const categories = getBadgeCategories();
+    expect(new Set(categories).size).toBe(categories.length);
+  });
+
+  it("all category slugs are unique — no route collisions", () => {
+    const categories = getBadgeCategories();
+    const slugs = categories.map(slugifyCategory);
+    const unique = new Set(slugs);
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  it("every badge category is included", () => {
+    const categories = new Set(getBadgeCategories());
+    for (const badge of badges as Badge[]) {
+      for (const cat of badge.categories) {
+        expect(categories.has(cat)).toBe(true);
+      }
+    }
+  });
+});
+
+// --- filterBadges ---
+
+describe("filterBadges", () => {
+  it("returns all badges when no filters are applied", () => {
+    const all = filterBadges({});
+    expect(all.length).toBe((badges as Badge[]).length);
+  });
+
+  it("filters by category — every result contains that category", () => {
+    const results = filterBadges({ category: "Artificial Intelligence" });
+    expect(results.length).toBeGreaterThan(0);
+    for (const badge of results) {
+      expect(badge.categories).toContain("Artificial Intelligence");
+    }
+  });
+
+  it("returns an empty array for a category that does not exist", () => {
+    expect(filterBadges({ category: "NonExistentXYZ" })).toHaveLength(0);
+  });
+
+  it("filters by text query", () => {
+    const results = filterBadges({ query: "github" });
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it("applies both query and category together", () => {
+    const categories = getBadgeCategories();
+    const firstCategory = categories[0];
+    const allInCategory = filterBadges({ category: firstCategory });
+    const filtered = filterBadges({
+      query: allInCategory[0].name,
+      category: firstCategory,
+    });
+    expect(filtered.length).toBeGreaterThan(0);
+    for (const badge of filtered) {
+      expect(badge.categories).toContain(firstCategory);
+    }
+  });
+});


### PR DESCRIPTION
## Overview

Replaces the `/?category=X` query-param approach with dedicated `/categories/<slug>` routes for browsing badges by category. Each category now has a pre-rendered static page with its own URL, SEO metadata, and slug-based routing. The category combobox is removed from the search component, and all category links across the app are updated to point to the new paths.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] ♻️ Refactor
- [ ] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

### New category pages (`src/pages/categories/[category].astro`)
- Added a statically pre-rendered Astro page at `/categories/[category]` that renders the `Search` component with `initialCategory` set from the route.
- Page title, description, and keywords are generated dynamically per category.

### Slug utilities (`src/services/badges.ts`)
- Added `slugifyCategory(category)` — normalises a category name to a URL-safe slug (lowercased, non-alphanumeric runs collapsed to hyphens).
- Added `getCategoryBySlug(slug)` — reverse-lookup: finds the original category name from its slug.

### Sidebar simplification (`src/components/app-sidebar.tsx`)
- Removed the `useState`/`useEffect` event-listener logic that synced category state from `?category=` query params and custom `locationchange` events.
- Active category is now derived directly from the current `pathname` (`/categories/<slug>`), eliminating the hydration-mismatch guard and the SSR `category` prop.
- All category `<a>` links updated to `/categories/<slug>`.

### Layout cleanup (`src/layouts/Layout.astro`)
- Replaced `Astro.url.searchParams.get("category")` + `getBadgeCategories()` validation with `getCategoryBySlug` derived from the pathname.

### Search component simplification (`src/components/search.tsx`)
- Removed the category combobox (Combobox, ComboboxContent, ComboboxList, etc.) and the associated `categoryQuery` state and `locationchange` dispatch.
- `initialCategory` is now a read-only prop injected by the page; category filtering no longer lives inside the search component.
- Badge count now reflects the filtered result set rather than the total badge count.

### Category link updates
- `src/components/badges/badge-card.tsx` — primary and secondary category links updated to `/categories/<slug>`.
- `src/components/badges/badge-sidebar.tsx` — category tag links updated to `/categories/<slug>`.
- `src/pages/badges/[...id].astro` — category links on badge detail pages updated to `/categories/<slug>`.
- `src/pages/index.astro` — `initialCategory` prop removed (homepage no longer handles category filtering directly).

### Tests (`test/badges.test.ts`)
- Added comprehensive test suite covering `slugifyCategory`, `getCategoryBySlug`, `getBadgeCategories`, and `filterBadges`.
- Includes round-trip tests (`slug → name → slug`) and a uniqueness check to guard against route collisions.

## How to test

1. `npm run dev`
2. Click any category link in the sidebar or on a badge card — the URL should change to `/categories/<slug>` (e.g. `/categories/artificial-intelligence`).
3. The page title should reflect the category name and the badge list should be pre-filtered.
4. Navigating back and forward should retain the correct active category highlight in the sidebar.
5. Visiting `/` should show all badges with no category filter and no category combobox.
6. Visiting a badge detail page (e.g. `/badges/github`) and clicking a category tag should navigate to the correct `/categories/<slug>` page.
7. Run `npx vitest run test/badges.test.ts` to execute the new test suite.

## Release notes

Category browsing now uses dedicated URL routes (`/categories/<slug>`) instead of query parameters, enabling shareable, bookmarkable, and SEO-friendly category pages with pre-rendered static HTML.
