### PR TITLE
feat: add JSON-LD structured data and SEO metadata for home page

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -108,6 +108,23 @@ export function getBadgeJsonLd(badge: Badge, pageUrl: string): object {
   };
 }
 
+export function getHomePageJsonLd(badgeCount: number): object {
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": `${baseUrl}/`,
+    url: `${baseUrl}/`,
+    name: "Markdown Badges",
+    headline: `Browse ${badgeCount}+ GitHub README Badges`,
+    description:
+      "Markdown badges generator for GitHub README. Browse badges for languages, frameworks, tools and platforms and copy ready-to-use Markdown instantly.",
+    inLanguage: "en-US",
+    numberOfItems: badgeCount,
+    author: authorObject,
+    isPartOf: { "@id": baseUrl },
+  };
+}
+
 export function getBadgeCategoryJsonLd(
   categoryName: string,
   badgeCount: number,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,13 +2,23 @@
 import { Search } from "@/components/search";
 import { Typography } from "@/components/ui/typography";
 import Layout from "@/layouts/Layout.astro";
+import { getHomePageJsonLd } from "@/lib/seo";
+import { getBadges } from "@/services/badges";
 
 const query = Astro.url.searchParams.get("query") || null;
+const badgeCount = getBadges().length;
+
+const title = `Markdown Badges — Browse ${badgeCount}+ GitHub README Badges`;
 ---
 
-<Layout title="Markdown Badges">
+<Layout
+  title={title}
+  description={`Markdown badges generator for GitHub README. Browse ${badgeCount}+ badges for languages, frameworks, tools and platforms and copy ready-to-use Markdown instantly.`}
+  keywords="markdown badge, shield badges, readme badges, github profile badges, github badges, badge generator, developer tools, gfrancv"
+  jsonLd={getHomePageJsonLd(badgeCount)}
+>
   <Typography as="h1" size="h1" className="sr-only">
-    Markdown Badges
+    {title}
   </Typography>
   <Search client:load initialQuery={query} />
 </Layout>


### PR DESCRIPTION
## Summary

Adds structured data (JSON-LD) and richer SEO metadata to the home page using the live badge count, making the page more discoverable by search engines.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor
- [ ] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

### JSON-LD structured data for the home page (`src/lib/seo.ts`)

- Added `getHomePageJsonLd(badgeCount)` that emits a `schema.org/CollectionPage` object with `name`, `headline`, `description`, `numberOfItems`, and authorship metadata — consistent with the existing `getBadgeCategoryJsonLd` and `getBadgeJsonLd` helpers.

### Home page SEO enrichment (`src/pages/index.astro`)

- Passes `jsonLd` (the new JSON-LD block), `description`, and `keywords` props to `<Layout>`.
- Derives `badgeCount` at build time via `getBadges().length` so counts stay accurate without manual updates.
- Sets a dynamic `<title>` and `<h1>` that include the real badge count (e.g., _"Browse 600+ GitHub README Badges"_).

## How to test

1. `npm run dev` and open `http://localhost:4321/`.
2. Inspect the page source — a `<script type="application/ld+json">` block should appear with `@type: CollectionPage` and a populated `numberOfItems`.
3. Verify the `<title>` and `<meta name="description">` reflect the live badge count.
4. `npm run build` should pass without type errors.

## Release notes

The home page now includes Schema.org structured data and a keyword-rich title/description that reflects the actual badge count, improving search engine visibility.
