### PR TITLE
feat: improve layout, search UX, and OG image component

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -16,8 +16,9 @@ export function AppShell({
   return (
     <SidebarProvider pathname={pathname} category={category}>
       <AppSidebar />
-      <SidebarInset>
+      <SidebarInset className="overflow-hidden">
         <AppHeader />
+        <div className="-top-80 -right-80 w-190 h-190 absolute pointer-events-none bg-radial to-transparent to-65% from-primary/12" />
         <div className="p-6">{children}</div>
       </SidebarInset>
     </SidebarProvider>

--- a/src/components/og/badge-og.tsx
+++ b/src/components/og/badge-og.tsx
@@ -1,3 +1,5 @@
+import { MarkdownDark } from "../ui/svgs/markdownDark";
+
 const PRIMARY = "#d47898";
 const BG = "#0f0f0f";
 const SURFACE = "#181818";
@@ -10,23 +12,6 @@ type BadgeOgProps = {
   badgeImage: string | null;
   badgeDims: { width: number; height: number } | null;
 };
-
-function MarkdownLogoSvg() {
-  return (
-    <svg viewBox="0 0 208 128" width="38" height="24" style={{ flexShrink: 0 }}>
-      <path
-        stroke={TEXT}
-        strokeWidth="10"
-        fill="none"
-        d="M15 5h178a10 10 0 0 1 10 10v98a10 10 0 0 1-10 10H15a10 10 0 0 1-10-10V15A10 10 0 0 1 15 5z"
-      />
-      <path
-        fill={TEXT}
-        d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39H30zm125 0-30-33h20V30h20v35h20l-30 33z"
-      />
-    </svg>
-  );
-}
 
 export function BadgeOg({ badge, badgeImage, badgeDims }: BadgeOgProps) {
   const { name, categories, markdown } = badge;
@@ -72,7 +57,7 @@ export function BadgeOg({ badge, badgeImage, badgeDims }: BadgeOgProps) {
           tw="flex items-center justify-between"
         >
           <div style={{ gap: 10 }} tw="flex items-center">
-            <MarkdownLogoSvg />
+            <MarkdownDark width="38" height="24" />
             <span
               style={{
                 fontSize: 20,
@@ -81,7 +66,7 @@ export function BadgeOg({ badge, badgeImage, badgeDims }: BadgeOgProps) {
                 letterSpacing: "-0.3px",
               }}
             >
-              Markdown Badges
+              Markdown Badgesa
             </span>
           </div>
           <span style={{ color: MUTED, fontSize: 16 }}>

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -94,6 +94,7 @@ function SearchContent({
       if (event.ctrlKey && event.key === "k") {
         event.preventDefault();
         searchInput.current?.focus();
+        searchInput.current?.select();
       }
     };
 

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -24,15 +24,27 @@ const query = Astro.url.searchParams.get("query") || null;
 const badgeCount = filterBadges({ category }).length;
 
 const badgeCategoryJsonLd = getBadgeCategoryJsonLd(category, badgeCount);
+const description = `Browse ${badgeCount} ${category} badges for GitHub README. Copy ready-to-use Markdown instantly.`;
 ---
 
 <Layout
   title={`${category} Badges | Markdown Badges`}
-  description={`Browse ${badgeCount} ${category} badges for GitHub README. Copy ready-to-use Markdown instantly.`}
+  description={description}
   jsonLd={badgeCategoryJsonLd}
 >
-  <Typography as="h1" size="h1" className="mb-6">
-    {category} Badges
-  </Typography>
+  <header class="pb-6 mb-6 border-b">
+    <Typography as="div" size="h3" variant="muted" className="mb-2">
+      Category
+    </Typography>
+    <Typography as="h1" size="h1" className="mb-4">
+      {category}
+      <Typography as="span" variant="muted" size="h4" className="ml-2">
+        {badgeCount}
+      </Typography>
+    </Typography>
+    <Typography variant="muted">
+      {description}
+    </Typography>
+  </header>
   <Search client:load initialQuery={query} initialCategory={category} />
 </Layout>

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -33,14 +33,11 @@ const description = `Browse ${badgeCount} ${category} badges for GitHub README. 
   jsonLd={badgeCategoryJsonLd}
 >
   <header class="pb-6 mb-6 border-b">
-    <Typography as="div" size="h3" variant="muted" className="mb-2">
+    <Typography as="div" size="h3" variant="muted" className="mb-2 font-normal">
       Category
     </Typography>
     <Typography as="h1" size="h1" className="mb-4">
       {category}
-      <Typography as="span" variant="muted" size="h4" className="ml-2">
-        {badgeCount}
-      </Typography>
     </Typography>
     <Typography variant="muted">
       {description}

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -33,7 +33,12 @@ const description = `Browse ${badgeCount} ${category} badges for GitHub README. 
   jsonLd={badgeCategoryJsonLd}
 >
   <header class="pb-6 mb-6 border-b">
-    <Typography as="div" size="h3" variant="muted" className="mb-2 font-normal">
+    <Typography
+      as="div"
+      size="h4"
+      variant="muted"
+      className="mb-2 font-normal uppercase"
+    >
       Category
     </Typography>
     <Typography as="h1" size="h1" className="mb-4">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,14 +1,27 @@
 ---
+import { getCollection } from "astro:content";
+
 import { Search } from "@/components/search";
 import { Typography } from "@/components/ui/typography";
 import Layout from "@/layouts/Layout.astro";
 
 const query = Astro.url.searchParams.get("query") || null;
+const badges = await getCollection("badges");
 ---
 
 <Layout title="Markdown Badges">
-  <Typography as="h1" size="h1" className="sr-only">
-    Markdown Badges
-  </Typography>
+  <header class="pb-6 mb-6 border-b">
+    <Typography as="h1" size="h1" className="mb-4">
+      Markdown Badges
+      <Typography as="span" variant="muted" size="h4" className="ml-2">
+        {badges.length}
+      </Typography>
+    </Typography>
+    <Typography variant="muted">
+      Markdown badges generator for GitHub README. Browse 600+ badges for
+      languages, frameworks, tools and platforms and copy ready-to-use Markdown
+      instantly.
+    </Typography>
+  </header>
   <Search client:load initialQuery={query} />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,9 +22,6 @@ const description = `Markdown badges generator for GitHub README. Browse ${badge
   <header class="pb-6 mb-6 border-b">
     <Typography as="h1" size="h1" className="mb-4">
       Markdown Badges
-      <Typography as="span" variant="muted" size="h4" className="ml-2">
-        {badgeCount}
-      </Typography>
     </Typography>
     <Typography variant="muted">
       {description}


### PR DESCRIPTION
## Summary

Multiple UX improvements across the app: structured page headers with descriptions on the home and category pages, search input text selection on Ctrl+K, a decorative radial gradient in the app shell, and consolidation of the Markdown logo into a shared SVG component for OG images.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [x] ♻️ Refactor
- [ ] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

### Page headers — index and category pages
- `src/pages/index.astro`: Replaced visually-hidden `sr-only` h1 with a visible `<header>` block containing the h1 title and a descriptive subtitle. Also switched `badgeCount` from `getBadges()` to `getCollection("badges")` for consistency with Astro content collections.
- `src/pages/categories/[category].astro`: Replaced the bare h1 with a structured header that includes a muted uppercase "Category" label, the category h1, and a description line. The description string is now stored in a variable and reused for both the `<meta>` tag and the visible subtitle.

### Search UX — Ctrl+K selects existing text
- `src/components/search.tsx`: Added `searchInput.current?.select()` after `focus()` in the Ctrl+K handler so any text already in the input is highlighted. Users can now start typing immediately to replace a previous query rather than manually clearing it.

### App shell — decorative background and layout fix
- `src/components/app-shell.tsx`: Added `overflow-hidden` to `SidebarInset` (prevents content bleed) and a decorative radial gradient `<div>` positioned in the top-right corner of the content area for visual depth.

### OG image — shared SVG component
- `src/components/og/badge-og.tsx`: Removed the inline `MarkdownLogoSvg` function and replaced it with the imported `MarkdownDark` SVG component, keeping the logo rendering consistent with the rest of the app.

> **Note:** Line 69 of `badge-og.tsx` contains a potential typo: `"Markdown Badgesa"` — verify this was intentional before merging.

## How to test

1. **Home page header** — visit `/`; confirm the "Markdown Badges" h1 and descriptive subtitle are visible above the search bar.
2. **Category page header** — visit any category (e.g. `/categories/Languages`); confirm the muted "Category" label, bold h1, and description line render correctly.
3. **Ctrl+K selection** — with text in the search input, press Ctrl+K; confirm the existing text is selected so typing replaces it immediately.
4. **Radial gradient** — check that a subtle pink glow appears in the top-right of the main content area on any page.
5. **OG image** — visit `/api/og/badge/<any-id>` and confirm the Markdown logo still renders correctly.

## Release notes

- Home and category pages now show a structured header with a visible title and description, improving both readability and SEO context.
- Ctrl+K search shortcut now selects existing input text for faster query replacement.
- No breaking changes; layout and data-fetching changes are internal.
