### PR TITLE
feat(tracking): Add Umami analytics tracking for badge interactions

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -124,4 +124,5 @@ const ogImage = image.startsWith("http")
   name="google-site-verification"
   content="bGA4Cm6PsD4Ug12ZPdf_xqLExFJaZDexlqZHsbL65SQ"
 />
+<script defer src="https://cloud.umami.is/script.js" data-website-id="b594d15d-991b-40c9-beb4-86954a1d4b16"></script>
 <SpeedInsights />

--- a/src/components/badges/badge-card.tsx
+++ b/src/components/badges/badge-card.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/popover";
 import { Typography } from "@/components/ui/typography";
 import { useFavorites } from "@/context/favorites-context";
+import { trackBadgeCopied } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { slugifyCategory } from "@/services/badges";
 
@@ -154,7 +155,10 @@ export const BadgeCard = memo(function BadgeCard({
       </div>
 
       <div className="absolute top-0.5 right-0.5 transition duration-300 flex flex-col items-center gap-0.5">
-        <CopyClipboardButton content={`![${name}](${url})`} />
+        <CopyClipboardButton
+          content={`![${name}](${url})`}
+          onCopy={() => trackBadgeCopied(name, primaryCategory)}
+        />
         <BadgeFavoriteButton
           badge={badge}
           className={cn(

--- a/src/components/badges/badge-sidebar.tsx
+++ b/src/components/badges/badge-sidebar.tsx
@@ -28,6 +28,7 @@ import {
 import { Typography } from "@/components/ui/typography";
 import { useFavorites } from "@/context/favorites-context";
 import { useCopyClipboard } from "@/hooks/use-copy-clipboard";
+import { trackBadgeCopied, trackBadgeSelected } from "@/lib/analytics";
 import { getRelatedBadges, slugifyCategory } from "@/services/badges";
 
 type BadgeSidebarContextType = {
@@ -56,6 +57,7 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
   const open = useCallback((badge: Badge) => {
     setBadge(badge);
     setIsOpen(true);
+    trackBadgeSelected(badge.name, badge.categories[0]);
   }, []);
 
   const close = useCallback(() => {
@@ -164,7 +166,13 @@ export function BadgeSidebarProvider({ children }: { children: ReactNode }) {
             )}
           </div>
           <SheetFooter>
-            <Button onClick={() => copy(badge?.markdown ?? "")}>
+            <Button
+              onClick={() => {
+                copy(badge?.markdown ?? "");
+                if (badge)
+                  trackBadgeCopied(badge.name, badge.categories[0]);
+              }}
+            >
               <ClipboardIcon className="mr-2" width={12} />
               Copy Markdown
             </Button>

--- a/src/components/copy-clipboard-button.tsx
+++ b/src/components/copy-clipboard-button.tsx
@@ -7,11 +7,13 @@ import { cn } from "@/lib/utils";
 type CopyClipboardButtonProps = {
   content: string;
   className?: string;
+  onCopy?: () => void;
 };
 
 export function CopyClipboardButton({
   content,
   className,
+  onCopy,
 }: CopyClipboardButtonProps) {
   const { isCopied, copy } = useCopyClipboard();
 
@@ -22,6 +24,7 @@ export function CopyClipboardButton({
       onClick={(e) => {
         e.stopPropagation();
         copy(content);
+        onCopy?.();
       }}
       className={cn(
         className,

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -31,6 +31,11 @@ import {
 import { Kbd } from "@/components/ui/kbd";
 import { Typography } from "@/components/ui/typography";
 import { SelectionProvider, useSelection } from "@/context/selection-context";
+import {
+  trackBadgeSearch,
+  trackSearchNoResults,
+  trackSelectionCleared,
+} from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { filterBadges } from "@/services/badges";
 
@@ -88,6 +93,13 @@ function SearchContent({
   useEffect(() => {
     setIsReady(true);
   }, []);
+
+  useEffect(() => {
+    if (!debouncedQuery) return;
+    const count = filteredBadges.length;
+    trackBadgeSearch(debouncedQuery.length, count, count > 0);
+    if (count === 0) trackSearchNoResults(debouncedQuery);
+  }, [debouncedQuery, filteredBadges]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -215,7 +227,14 @@ function SearchContent({
             <ClipboardIcon />
             Copy selected
           </Button>
-          <Button variant="ghost" size="sm" onClick={clearAll}>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              clearAll();
+              trackSelectionCleared();
+            }}
+          >
             <XIcon /> Clear selection
           </Button>
         </div>

--- a/src/context/favorites-context.tsx
+++ b/src/context/favorites-context.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 
 import { useCopyClipboard } from "@/hooks/use-copy-clipboard";
+import { trackFavoriteToggled } from "@/lib/analytics";
 
 type FavoritesContextType = {
   favorites: Badge[];
@@ -53,11 +54,17 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
   const toggle = useCallback((badge: Badge | null) => {
     if (!badge) return;
 
-    setFavorites((prev) =>
-      prev.some((b) => b.id === badge.id)
+    setFavorites((prev) => {
+      const isAlreadyFavorite = prev.some((b) => b.id === badge.id);
+      trackFavoriteToggled(
+        badge.name,
+        badge.categories[0],
+        isAlreadyFavorite ? "removed" : "added",
+      );
+      return isAlreadyFavorite
         ? prev.filter((b) => b.id !== badge.id)
-        : [...prev, badge],
-    );
+        : [...prev, badge];
+    });
   }, []);
 
   const copyAll = useCallback(() => {

--- a/src/context/selection-context.tsx
+++ b/src/context/selection-context.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import { toast } from "sonner";
 
+import { trackMultiCopy } from "@/lib/analytics";
+
 type SelectionContextType = {
   isSelected: (id: string) => boolean;
   toggle: (badge: Badge) => void;
@@ -57,6 +59,7 @@ export function SelectionProvider({ children }: { children: ReactNode }) {
     const markdown = badges.map((b) => b.markdown).join("\n");
     try {
       await navigator.clipboard.writeText(markdown);
+      trackMultiCopy(badges.length);
       clearAll();
       toast.success(
         `${badges.length} badge${badges.length > 1 ? "s" : ""} copied`,

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,107 @@
+declare global {
+  interface Window {
+    umami?: {
+      track: (eventName: string, eventData?: Record<string, unknown>) => void;
+    };
+  }
+}
+
+interface AnalyticsEvents {
+  badge_copied: {
+    badge_name: string;
+    category: string;
+  };
+
+  badge_selected: {
+    badge_name: string;
+    category: string;
+  };
+
+  badge_search: {
+    query_length: number;
+    results_count: number;
+    has_results: boolean;
+  };
+
+  search_no_results: {
+    query: string;
+  };
+
+  multi_copy: {
+    selected_count: number;
+  };
+
+  selection_cleared: undefined;
+
+  favorite_toggled: {
+    badge_name: string;
+    category: string;
+    action: "added" | "removed";
+  };
+}
+
+function trackEvent<K extends keyof AnalyticsEvents>(
+  event: K,
+  data?: AnalyticsEvents[K],
+) {
+  if (typeof window === "undefined") return;
+
+  window.umami?.track(
+    event,
+    data ? (data as Record<string, unknown>) : undefined,
+  );
+}
+
+export function trackBadgeCopied(badgeName: string, category: string): void {
+  trackEvent("badge_copied", {
+    badge_name: badgeName,
+    category,
+  });
+}
+
+export function trackBadgeSelected(badgeName: string, category: string): void {
+  trackEvent("badge_selected", {
+    badge_name: badgeName,
+    category,
+  });
+}
+
+export function trackBadgeSearch(
+  queryLength: number,
+  resultsCount: number,
+  hasResults: boolean,
+): void {
+  trackEvent("badge_search", {
+    query_length: queryLength,
+    results_count: resultsCount,
+    has_results: hasResults,
+  });
+}
+
+export function trackSearchNoResults(query: string): void {
+  trackEvent("search_no_results", {
+    query,
+  });
+}
+
+export function trackMultiCopy(selectedCount: number): void {
+  trackEvent("multi_copy", {
+    selected_count: selectedCount,
+  });
+}
+
+export function trackSelectionCleared(): void {
+  trackEvent("selection_cleared");
+}
+
+export function trackFavoriteToggled(
+  badgeName: string,
+  category: string,
+  action: "added" | "removed",
+): void {
+  trackEvent("favorite_toggled", {
+    badge_name: badgeName,
+    category,
+    action,
+  });
+}


### PR DESCRIPTION
## Summary

Integrates [Umami](https://umami.is/) analytics to track key user interactions across the badge browser. A typed analytics module is introduced and wired into every major user action, giving product visibility into how badges are discovered, copied, and favourited.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] ♻️ Refactor
- [ ] 📝 Docs update
- [ ] 🔧 CI / Config change

## Changes

### Analytics module (`src/lib/analytics.ts`)
- New file that declares a typed `AnalyticsEvents` interface and a generic `trackEvent` helper that calls `window.umami?.track`.
- Exports six public tracking functions: `trackBadgeCopied`, `trackBadgeSelected`, `trackBadgeSearch`, `trackSearchNoResults`, `trackMultiCopy`, `trackSelectionCleared`, `trackFavoriteToggled`.
- Guards against SSR by bailing early when `window` is undefined.

### Umami script injection (`src/components/SEO.astro`)
- Adds the Umami cloud `<script>` tag (deferred) with the project's `data-website-id`.

### `CopyClipboardButton` (`src/components/copy-clipboard-button.tsx`)
- Added optional `onCopy?: () => void` prop that fires after the clipboard write, allowing callers to attach tracking without the button knowing about analytics.

### Badge card tracking (`src/components/badges/badge-card.tsx`)
- Passes `onCopy` to `CopyClipboardButton` to fire `badge_copied` (with badge name + primary category) whenever a badge is copied from the grid.

### Badge sidebar tracking (`src/components/badges/badge-sidebar.tsx`)
- `open()` now calls `trackBadgeSelected` when a badge detail panel is opened.
- The "Copy Markdown" button in the sidebar footer calls `trackBadgeCopied`.

### Search tracking (`src/components/search.tsx`)
- A `useEffect` on the debounced query fires `trackBadgeSearch` (query length, result count, has-results flag) on every search.
- When results are zero, also fires `trackSearchNoResults` with the raw query string.
- "Clear selection" button calls `trackSelectionCleared` on click.

### Favorites tracking (`src/context/favorites-context.tsx`)
- `toggle()` calls `trackFavoriteToggled` with the badge name, primary category, and `"added"` / `"removed"` action before updating state.

### Multi-copy tracking (`src/context/selection-context.tsx`)
- After a successful multi-badge clipboard write, calls `trackMultiCopy` with the selected badge count.

## How to test

1. Run `npm run dev`.
2. Open the browser DevTools console and run `window.umami = { track: console.log }` to spy on events.
3. Type a search query — expect a `badge_search` event after the 450 ms debounce.
4. Type a query with no matches — expect an additional `search_no_results` event.
5. Click the copy icon on any badge card — expect a `badge_copied` event with the badge name and category.
6. Click a badge to open the sidebar — expect a `badge_selected` event.
7. Click "Copy Markdown" in the sidebar — expect a second `badge_copied` event.
8. Select multiple badges and click "Copy selected" — expect a `multi_copy` event with the correct count.
9. Click "Clear selection" — expect a `selection_cleared` event.
10. Toggle a badge as a favourite — expect a `favorite_toggled` event with action `"added"` or `"removed"`.

## Release notes

Umami analytics is now active on the site. The following events are tracked:

| Event | Payload |
|---|---|
| `badge_copied` | `badge_name`, `category` |
| `badge_selected` | `badge_name`, `category` |
| `badge_search` | `query_length`, `results_count`, `has_results` |
| `search_no_results` | `query` |
| `multi_copy` | `selected_count` |
| `selection_cleared` | — |
| `favorite_toggled` | `badge_name`, `category`, `action` |
