### PR TITLE
chore: pin pnpm version and configure allowed workspace builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,6 @@
     "shadcn": "^3.8.5",
     "tw-animate-css": "^1.4.0",
     "vitest": "^4.1.5"
-  }
+  },
+  "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: true
+  msw: false
+  sharp: false


### PR DESCRIPTION
## Summary
- Pin `packageManager` in `package.json` to `pnpm@11.1.1` for reproducible installs.
- Add `pnpm-workspace.yaml` to explicitly allow the `esbuild` build script while keeping `msw` and `sharp` disabled.

## Test plan
- [x] `pnpm install` runs cleanly with the pinned version and workspace build config